### PR TITLE
Add test description to dashboard

### DIFF
--- a/campaign_info.toml
+++ b/campaign_info.toml
@@ -4,6 +4,7 @@
 
 # A Campaign with global settings
 [desktop]
+description="3 step form vs 4 step form"
 campaign_tracking = "00-ba-230202"
 preview_link = "/wiki/Wikipedia:Hauptseite?devbanner={{banner}}&banner=B22_WMDE_local_prototype"
 preview_url = 'https://de.wikipedia.org/wiki/Wikipedia:Hauptseite?banner={{banner}}'
@@ -23,7 +24,7 @@ tracking = "org-00-230202-var"
 
 # English Campaign
 [english]
-# name = "C22_WMDE_Test_EN_00"
+description="VAR has the already donated modal"
 campaign_tracking = "en00-ba-230421"
 preview_link = "/wiki/Main_Page?devbanner={{banner}}&banner=B22_WMDE_local_prototype&devMode"
 preview_url = 'https://en.wikipedia.org/wiki/Main_Page?banner={{banner}}'
@@ -41,6 +42,7 @@ pagename = "B23_WMDE_Test_EN_00_var"
 tracking = "org-en00-230421-var"
 
 [mobile]
+description="2 step form vs 3 step form"
 campaign_tracking = "00-ba-230202"
 preview_link = "/mobile/wiki/Wikipedia:Hauptseite?devbanner={{banner}}&banner=B22_WMDE_local_prototype&useskin=minerva"
 preview_url = 'https://de.m.wikipedia.org/wiki/Wikipedia:Hauptseite?banner={{banner}}'
@@ -60,6 +62,7 @@ tracking = "org-00-230202-var"
 
 # Mobile English Campaign
 [mobile_english]
+description="Tab button VS interior button on mini banners"
 campaign_tracking = "mob_en00-ba-230425"
 preview_link = "/en-mobile/wiki/Main_Page?devbanner={{banner}}&useskin=minerva&banner=B22_WMDE_local_prototype&devMode"
 preview_url = 'https://en.m.wikipedia.org/wiki/Main_Page?banner={{banner}}'
@@ -78,6 +81,7 @@ tracking = "org-mob_en00-230425-var"
 # desktop banners on wikipedia.de
 [wikipediade]
 name = "C23_WPDE_00"
+description="Nothing to see here"
 campaign_tracking = "wpde-00-230202"
 preview_link = "/wikipedia.de?devbanner={{banner}}&banner=dev-mode-wpde"
 wrapper_template = "wikipedia_de"
@@ -92,6 +96,7 @@ tracking = "wpde-00-230202-ctrl"
 # iPad campaign
 [pad]
 name = "iPad Test 00"
+description="VAR has a header text above the slider"
 campaign_tracking = "pad00-ba-230426"
 preview_link = "/wiki/Wikipedia:Hauptseite?devbanner={{banner}}&banner=B22_WMDE_local_prototype&devMode"
 preview_url = 'https://de.wikipedia.org/wiki/Wikipedia:Hauptseite?banner={{PLACEHOLDER}}'

--- a/dashboard/components/DevDashboard.vue
+++ b/dashboard/components/DevDashboard.vue
@@ -24,6 +24,9 @@
 				>
 					<div class="campaign-title">
 						<span :title="campaign.name">{{ campaign.name }}</span>
+						<span :data-tooltip="campaign.description" class="link-icon link-icon-large">
+							<IconInfo/>
+						</span>
 						<a
 							v-if="!campaign.banners.ctrl.pageName.includes('WPDE')"
 							target="_blank"
@@ -89,6 +92,7 @@ import IconCog from './IconCog.vue';
 import IconCommand from './IconCommand.vue';
 import { CompileInfo, parseCompileInfo } from '../util';
 import { computed, onMounted, ref } from 'vue';
+import IconInfo from './IconInfo.vue';
 
 const props = defineProps<{ campaigns: CampaignConfig, gitBranch: string }>();
 let branchName = ref<string>( props.gitBranch );

--- a/dashboard/components/IconInfo.vue
+++ b/dashboard/components/IconInfo.vue
@@ -1,0 +1,32 @@
+<template>
+	<svg width="100%" height="100%" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg"
+		xml:space="preserve" style="fill-rule: evenodd;clip-rule: evenodd;stroke-linejoin: round;stroke-miterlimit: 2;">
+    <g transform="matrix(1,0,0,1,-883,-68)">
+        <g transform="matrix(1,0,0,1,0,492)">
+            <g id="Info" transform="matrix(1.10345,0,0,1.10345,179,-518.897)">
+                <circle cx="652.5" cy="100.5" r="14.5" style="fill: rgba( 231, 107, 0, 1 );"/>
+				<clipPath id="_clip1">
+                    <circle cx="652.5" cy="100.5" r="14.5"/>
+                </clipPath>
+				<g clip-path="url(#_clip1)">
+                    <g transform="matrix(0.90625,0,0,0.90625,-128.283,31.4578)">
+                        <path d="M857.748,73.658L862.846,73.658L862.846,81.524L866.045,81.524L866.045,83.501L857.063,
+                        83.501L857.063,81.524L860.271,81.524L860.271,75.635L857.748,75.635L857.748,73.658ZM860.271,
+                        68.868L862.846,68.868L862.846,71.873L860.271,71.873L860.271,68.868Z" style="fill-rule: nonzero;"/>
+                    </g>
+                </g>
+				<path d="M652.5,86C660.503,86 667,92.497 667,100.5C667,108.503 660.503,115 652.5,115C644.497,115 638,
+				108.503 638,100.5C638,92.497 644.497,86 652.5,86ZM652.5,87.813C645.498,87.813 639.813,93.498 639.813,
+				100.5C639.813,107.502 645.498,113.188 652.5,113.188C659.502,113.188 665.188,107.502 665.188,100.5C665.188,
+				93.498 659.502,87.813 652.5,87.813Z"/>
+            </g>
+        </g>
+    </g>
+</svg>
+</template>
+
+<script lang="ts">
+export default {
+	name: 'IconInfo'
+};
+</script>

--- a/webpack/campaign_config_types.ts
+++ b/webpack/campaign_config_types.ts
@@ -6,6 +6,7 @@ export interface Banner {
 
 export interface Campaign {
 	name: string,
+	description: string,
 	tracking: string,
 	previewUrlDev: string,
 	previewUrlProd: string,

--- a/webpack/convert_info_to_type.js
+++ b/webpack/convert_info_to_type.js
@@ -6,6 +6,7 @@ const BannerConfigMap = {
 
 const CamapignConfigMap = {
 	name: 'name',
+	description: 'description',
 	tracking: 'campaign_tracking',
 	previewUrlDev: 'preview_link',
 	previewUrlProd: 'preview_url',


### PR DESCRIPTION
This adds a description field to the campaign config file that will be visible in the tooltip of a new info icon on the dashboard. The purpose of this is to allow the developers to view a small summary of what a current test is doing.