### PR TITLE
Prepare code for new tracking schema

### DIFF
--- a/banners/desktop/banner_ctrl.ts
+++ b/banners/desktop/banner_ctrl.ts
@@ -14,7 +14,7 @@ import TranslationPlugin from '@src/TranslationPlugin';
 import { Translator } from '@src/Translator';
 import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
-import { TrackerWPORG } from '@src/tracking/TrackerWPORG';
+import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 
 // Locale-specific imports
@@ -34,7 +34,7 @@ const mediaWiki = new WindowMediaWiki();
 const page = new PageWPORG( mediaWiki, ( new SkinFactory( mediaWiki ) ).getSkin(), new WindowSizeIssueChecker() );
 
 const impressionCount = new LocalImpressionCount( page.getTracking().keyword );
-const tracker = new TrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
+const tracker = new LegacyTrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
 
 const app = createVueApp( BannerConductor, {
 	page,

--- a/banners/desktop/banner_var.ts
+++ b/banners/desktop/banner_var.ts
@@ -14,7 +14,7 @@ import TranslationPlugin from '@src/TranslationPlugin';
 import { Translator } from '@src/Translator';
 import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
-import { TrackerWPORG } from '@src/tracking/TrackerWPORG';
+import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 
 // Locale-specific imports
@@ -34,7 +34,7 @@ const mediaWiki = new WindowMediaWiki();
 const page = new PageWPORG( mediaWiki, ( new SkinFactory( mediaWiki ) ).getSkin(), new WindowSizeIssueChecker() );
 
 const impressionCount = new LocalImpressionCount( page.getTracking().keyword );
-const tracker = new TrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
+const tracker = new LegacyTrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
 
 const app = createVueApp( BannerConductor, {
 	page,

--- a/banners/desktop/components/BannerCtrl.vue
+++ b/banners/desktop/components/BannerCtrl.vue
@@ -122,7 +122,7 @@ const contentState = ref<ContentStates>( ContentStates.Main );
 const formModel = useFormModel();
 const stepControllers = [
 	createSubmittableMainDonationForm( formModel, FormStepNames.UpgradeToYearlyFormStep ),
-	createSubmittableUpgradeToYearly( formModel, FormStepNames.CustomAmountFormStep, FormStepNames.MainDonationFormStep, ( interval: string ) => new SubmitEvent( interval === Intervals.YEARLY.value ? 'recurring' : 'non-recurring' ) ),
+	createSubmittableUpgradeToYearly( formModel, FormStepNames.CustomAmountFormStep, FormStepNames.MainDonationFormStep ),
 	createSubmittableCustomAmount( formModel, FormStepNames.UpgradeToYearlyFormStep )
 ];
 

--- a/banners/desktop/event_map.ts
+++ b/banners/desktop/event_map.ts
@@ -1,7 +1,6 @@
-import { EventDataConverterFactory } from '@src/tracking/TrackerWPORG';
+import { EventDataConverterFactory } from '@src/tracking/LegacyTrackerWPORG';
 import { CloseSources } from '@src/tracking/CloseSources';
-import { CloseEvent } from '@src/tracking/events/CloseEvent';
-import { WMDEBannerEvent } from '@src/tracking/WPORG/WMDEBannerEvent';
+import { WMDELegacyBannerEvent } from '@src/tracking/WPORG/WMDELegacyBannerEvent';
 import { BannerNotShownReasons } from '@src/page/BannerNotShownReasons';
 import { NotShownEvent } from '@src/tracking/events/NotShownEvent';
 import { WMDESizeIssueEvent } from '@src/tracking/WPORG/WMDEBannerSizeIssue';
@@ -12,22 +11,22 @@ import { FormStepShownEvent } from '@src/tracking/events/FormStepShownEvent';
 import { mapFormStepShownEvent } from '@src/tracking/LegacyEventTracking/mapFormStepShownEvent';
 
 export default new Map<string, EventDataConverterFactory>( [
-	[ CloseSources.MainBanner, ( e: CloseEvent ): WMDEBannerEvent => new WMDEBannerEvent( 'banner-closed', e.trackingRate ) ],
-	[ CloseSources.AlreadyDonatedGoAway, ( e: CloseEvent ): WMDEBannerEvent => new WMDEBannerEvent( 'banner-closed', e.trackingRate ) ],
+	[ CloseSources.MainBanner, (): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( 'banner-closed', 0.1 ) ],
+	[ CloseSources.AlreadyDonatedGoAway, (): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( 'banner-closed', 0.1 ) ],
 	[ FormStepShownEvent.EVENT_NAME, mapFormStepShownEvent ],
 	[ IncreaseCustomAmountEvent.EVENT_NAME,
-		( e: IncreaseCustomAmountEvent ): WMDEBannerEvent => new WMDEBannerEvent( e.eventName, e.trackingRate ) ],
+		( e: IncreaseCustomAmountEvent ): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( e.eventName, 1 ) ],
 	[ DecreaseCustomAmountEvent.EVENT_NAME,
-		( e: DecreaseCustomAmountEvent ): WMDEBannerEvent => new WMDEBannerEvent( e.eventName, e.trackingRate ) ],
-	[ BannerNotShownReasons.SizeIssue, ( e: NotShownEvent ): WMDESizeIssueEvent => new WMDESizeIssueEvent( '', e.bannerSize, 1 ) ],
+		( e: DecreaseCustomAmountEvent ): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( e.eventName, 1 ) ],
+	[ BannerNotShownReasons.SizeIssue, ( e: NotShownEvent ): WMDESizeIssueEvent => new WMDESizeIssueEvent( '', Number( e.customData.bannerSize ), 1 ) ],
 	[ BannerSubmitEvent.EVENT_NAME, ( e: BannerSubmitEvent ): WMDESizeIssueEvent => {
-		switch ( e.eventFeature ) {
+		switch ( e.feature ) {
 			case 'UpgradeToYearlyForm':
-				return new WMDESizeIssueEvent( `submit-${e.customData.optionSelected}`, 0, 0.1 );
+				return new WMDESizeIssueEvent( `submit-${e.customData.optionSelected}`, 0, 1 );
 			case 'CustomAmount':
-				return new WMDESizeIssueEvent( `submit-different-amount`, 0, 0.1 );
+				return new WMDESizeIssueEvent( `submit-different-amount`, 0, 1 );
 			default:
-				return new WMDESizeIssueEvent( `submit`, 0, 0.1 );
+				return new WMDESizeIssueEvent( `submit`, 0, 1 );
 		}
 	} ]
 	// TODO add more events

--- a/banners/desktop/event_map_var.ts
+++ b/banners/desktop/event_map_var.ts
@@ -2,18 +2,18 @@ import CtrlEventMap from './event_map';
 import { BannerSubmitEvent } from '@src/tracking/events/BannerSubmitEvent';
 import { WMDESizeIssueEvent } from '@src/tracking/WPORG/WMDEBannerSizeIssue';
 import { UpgradeToYearlyEvent } from '@src/tracking/events/UpgradeToYearlyEvent';
-import { WMDEBannerEvent } from '@src/tracking/WPORG/WMDEBannerEvent';
+import { WMDELegacyBannerEvent } from '@src/tracking/WPORG/WMDELegacyBannerEvent';
 
-// We "extend" the event map here because the original one is still in flux and we want to avoid duplication
+// We "extend" the event map here because the original one is still in flux, and we want to avoid duplication
 // At the next reset of this test, you should either throw away this map or combine the two maps in one file
 CtrlEventMap.set( BannerSubmitEvent.EVENT_NAME,
-	( e: BannerSubmitEvent ): WMDESizeIssueEvent => {
-		return new WMDESizeIssueEvent( `submit`, 0, 0.1 );
+	(): WMDESizeIssueEvent => {
+		return new WMDESizeIssueEvent( `submit`, 0, 1 );
 	}
 );
 CtrlEventMap.set( UpgradeToYearlyEvent.EVENT_NAME,
-	( e: BannerSubmitEvent ): WMDEBannerEvent => {
-		return new WMDEBannerEvent( e.customData.optionSelected, 0.1 );
+	( e: BannerSubmitEvent ): WMDELegacyBannerEvent => {
+		return new WMDELegacyBannerEvent( e.customData.optionSelected, 1 );
 	}
 );
 

--- a/banners/english/banner_ctrl.ts
+++ b/banners/english/banner_ctrl.ts
@@ -14,7 +14,7 @@ import TranslationPlugin from '@src/TranslationPlugin';
 import { Translator } from '@src/Translator';
 import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
-import { TrackerWPORG } from '@src/tracking/TrackerWPORG';
+import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 
 // Locale-specific imports
@@ -34,7 +34,7 @@ const mediaWiki = new WindowMediaWiki();
 const page = new PageWPORG( mediaWiki, ( new SkinFactory( mediaWiki ) ).getSkin(), new WindowSizeIssueChecker() );
 
 const impressionCount = new LocalImpressionCount( page.getTracking().keyword );
-const tracker = new TrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
+const tracker = new LegacyTrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
 
 const app = createVueApp( BannerConductor, {
 	page,

--- a/banners/english/banner_var.ts
+++ b/banners/english/banner_var.ts
@@ -14,7 +14,7 @@ import TranslationPlugin from '@src/TranslationPlugin';
 import { Translator } from '@src/Translator';
 import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
-import { TrackerWPORG } from '@src/tracking/TrackerWPORG';
+import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map_var';
 
 // Locale-specific imports
@@ -34,7 +34,7 @@ const mediaWiki = new WindowMediaWiki();
 const page = new PageWPORG( mediaWiki, ( new SkinFactory( mediaWiki ) ).getSkin(), new WindowSizeIssueChecker() );
 
 const impressionCount = new LocalImpressionCount( page.getTracking().keyword );
-const tracker = new TrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
+const tracker = new LegacyTrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
 
 const app = createVueApp( BannerConductor, {
 	page,

--- a/banners/english/event_map.ts
+++ b/banners/english/event_map.ts
@@ -1,7 +1,6 @@
-import { EventDataConverterFactory } from '@src/tracking/TrackerWPORG';
+import { EventDataConverterFactory } from '@src/tracking/LegacyTrackerWPORG';
 import { CloseSources } from '@src/tracking/CloseSources';
-import { CloseEvent } from '@src/tracking/events/CloseEvent';
-import { WMDEBannerEvent } from '@src/tracking/WPORG/WMDEBannerEvent';
+import { WMDELegacyBannerEvent } from '@src/tracking/WPORG/WMDELegacyBannerEvent';
 import { BannerNotShownReasons } from '@src/page/BannerNotShownReasons';
 import { NotShownEvent } from '@src/tracking/events/NotShownEvent';
 import { WMDESizeIssueEvent } from '@src/tracking/WPORG/WMDEBannerSizeIssue';
@@ -11,14 +10,14 @@ import { FormStepShownEvent } from '@src/tracking/events/FormStepShownEvent';
 import { mapFormStepShownEvent } from '@src/tracking/LegacyEventTracking/mapFormStepShownEvent';
 
 export default new Map<string, EventDataConverterFactory>( [
-	[ CloseSources.MainBanner, ( e: CloseEvent ): WMDEBannerEvent => new WMDEBannerEvent( 'banner-closed', e.trackingRate ) ],
-	[ CloseSources.AlreadyDonatedGoAway, ( e: CloseEvent ): WMDEBannerEvent => new WMDEBannerEvent( 'banner-closed', e.trackingRate ) ],
+	[ CloseSources.MainBanner, (): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( 'banner-closed', 0.1 ) ],
+	[ CloseSources.AlreadyDonatedGoAway, (): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( 'banner-closed', 0.1 ) ],
 	[ FormStepShownEvent.EVENT_NAME, mapFormStepShownEvent ],
 	[ IncreaseCustomAmountEvent.EVENT_NAME,
-		( e: IncreaseCustomAmountEvent ): WMDEBannerEvent => new WMDEBannerEvent( e.eventName, e.trackingRate ) ],
+		( e: IncreaseCustomAmountEvent ): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( e.eventName, 1 ) ],
 	[ DecreaseCustomAmountEvent.EVENT_NAME,
-		( e: DecreaseCustomAmountEvent ): WMDEBannerEvent => new WMDEBannerEvent( e.eventName, e.trackingRate ) ],
+		( e: DecreaseCustomAmountEvent ): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( e.eventName, 1 ) ],
 
-	[ BannerNotShownReasons.SizeIssue, ( e: NotShownEvent ): WMDESizeIssueEvent => new WMDESizeIssueEvent( '', e.bannerSize, 1 ) ]
+	[ BannerNotShownReasons.SizeIssue, ( e: NotShownEvent ): WMDESizeIssueEvent => new WMDESizeIssueEvent( '', Number( e.customData.bannerSize ), 1 ) ]
 	// TODO add more events
 ] );

--- a/banners/english/event_map_var.ts
+++ b/banners/english/event_map_var.ts
@@ -1,9 +1,9 @@
 import CtrlEventMap from './event_map';
 import { ClickAlreadyDonatedEvent } from '@src/tracking/events/ClickAlreadyDonatedEvent';
-import { WMDEBannerEvent } from '@src/tracking/WPORG/WMDEBannerEvent';
+import { WMDELegacyBannerEvent } from '@src/tracking/WPORG/WMDELegacyBannerEvent';
 
-// We "extend" the event map here because the original one is still in flux and we want to avoid duplication
+// We "extend" the event map here because the original one is still in flux, and we want to avoid duplication
 // At the next reset of this test, you should either throw away this map or combine the two maps in one file
-CtrlEventMap.set( ClickAlreadyDonatedEvent.EVENT_NAME, ( e: ClickAlreadyDonatedEvent ): WMDEBannerEvent => new WMDEBannerEvent( e.eventName, e.trackingRate ) );
+CtrlEventMap.set( ClickAlreadyDonatedEvent.EVENT_NAME, ( e: ClickAlreadyDonatedEvent ): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( e.eventName, 1 ) );
 
 export default CtrlEventMap;

--- a/banners/mobile/banner_ctrl.ts
+++ b/banners/mobile/banner_ctrl.ts
@@ -15,7 +15,7 @@ import { Translator } from '@src/Translator';
 import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { WindowPageScroller } from '@src/utils/PageScroller/WindowPageScroller';
-import { TrackerWPORG } from '@src/tracking/TrackerWPORG';
+import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 
 // Locale-specific imports
@@ -36,7 +36,7 @@ const mediaWiki = new WindowMediaWiki();
 const page = new PageWPORG( mediaWiki, ( new SkinFactory( mediaWiki ) ).getSkin(), new WindowSizeIssueChecker() );
 
 const impressionCount = new LocalImpressionCount( page.getTracking().keyword );
-const tracker = new TrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
+const tracker = new LegacyTrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
 
 const pageScroller = new WindowPageScroller();
 

--- a/banners/mobile/banner_var.ts
+++ b/banners/mobile/banner_var.ts
@@ -15,7 +15,7 @@ import { Translator } from '@src/Translator';
 import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { WindowPageScroller } from '@src/utils/PageScroller/WindowPageScroller';
-import { TrackerWPORG } from '@src/tracking/TrackerWPORG';
+import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 
 // Locale-specific imports
@@ -34,7 +34,7 @@ const translator = new Translator( messages );
 // This is channel specific and must be changed for wp.de banners
 const mediaWiki = new WindowMediaWiki();
 const page = new PageWPORG( mediaWiki, ( new SkinFactory( mediaWiki ) ).getSkin(), new WindowSizeIssueChecker() );
-const tracker = new TrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
+const tracker = new LegacyTrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
 
 const impressionCount = new LocalImpressionCount( page.getTracking().keyword );
 

--- a/banners/mobile/event_map.ts
+++ b/banners/mobile/event_map.ts
@@ -1,7 +1,6 @@
-import { EventDataConverterFactory } from '@src/tracking/TrackerWPORG';
+import { EventDataConverterFactory } from '@src/tracking/LegacyTrackerWPORG';
 import { CloseSources } from '@src/tracking/CloseSources';
-import { CloseEvent } from '@src/tracking/events/CloseEvent';
-import { WMDEBannerEvent } from '@src/tracking/WPORG/WMDEBannerEvent';
+import { WMDELegacyBannerEvent } from '@src/tracking/WPORG/WMDELegacyBannerEvent';
 import { BannerNotShownReasons } from '@src/page/BannerNotShownReasons';
 import { NotShownEvent } from '@src/tracking/events/NotShownEvent';
 import { WMDESizeIssueEvent } from '@src/tracking/WPORG/WMDEBannerSizeIssue';
@@ -10,14 +9,14 @@ import { FormStepShownEvent } from '@src/tracking/events/FormStepShownEvent';
 import { mapFormStepShownEvent } from '@src/tracking/LegacyEventTracking/mapFormStepShownEvent';
 
 export default new Map<string, EventDataConverterFactory>( [
-	[ CloseSources.MainBanner, ( e: CloseEvent ): WMDEBannerEvent => new WMDEBannerEvent( 'banner-closed', e.trackingRate ) ],
-	[ CloseSources.AlreadyDonatedGoAway, ( e: CloseEvent ): WMDEBannerEvent => new WMDEBannerEvent( 'banner-closed', e.trackingRate ) ],
+	[ CloseSources.MainBanner, (): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( 'banner-closed', 0.1 ) ],
+	[ CloseSources.AlreadyDonatedGoAway, (): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( 'banner-closed', 0.1 ) ],
 
 	[ MobileMiniBannerExpandedEvent.EVENT_NAME,
-		( e: MobileMiniBannerExpandedEvent ): WMDEBannerEvent => new WMDEBannerEvent( e.eventName, e.trackingRate ) ],
+		( e: MobileMiniBannerExpandedEvent ): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( e.eventName, 1 ) ],
 
 	[ FormStepShownEvent.EVENT_NAME, mapFormStepShownEvent ],
 
-	[ BannerNotShownReasons.SizeIssue, ( e: NotShownEvent ): WMDESizeIssueEvent => new WMDESizeIssueEvent( '', e.bannerSize, 1 ) ]
+	[ BannerNotShownReasons.SizeIssue, ( e: NotShownEvent ): WMDESizeIssueEvent => new WMDESizeIssueEvent( '', Number( e.customData.bannerSize ), 1 ) ]
 	// TODO add more events
 ] );

--- a/banners/mobile_english/banner_ctrl.ts
+++ b/banners/mobile_english/banner_ctrl.ts
@@ -11,7 +11,7 @@ import { WindowMediaWiki } from '@src/page/MediaWiki/WindowMediaWiki';
 import { SkinFactory } from '@src/page/skin/SkinFactory';
 import { WindowSizeIssueChecker } from '@src/utils/SizeIssueChecker/WindowSizeIssueChecker';
 import TranslationPlugin from '@src/TranslationPlugin';
-import { TrackerWPORG } from '@src/tracking/TrackerWPORG';
+import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 
 // Channel specific form setup
@@ -37,7 +37,7 @@ const translator = new Translator( messages );
 // This is channel specific and must be changed for wp.de banners
 const mediaWiki = new WindowMediaWiki();
 const page = new PageWPORG( mediaWiki, ( new SkinFactory( mediaWiki ) ).getSkin(), new WindowSizeIssueChecker() );
-const tracker = new TrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
+const tracker = new LegacyTrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
 
 // This is language-specific and must be changed for EN banners
 const currencyFormatter = new CurrencyEn();

--- a/banners/mobile_english/banner_var.ts
+++ b/banners/mobile_english/banner_var.ts
@@ -11,7 +11,7 @@ import { WindowMediaWiki } from '@src/page/MediaWiki/WindowMediaWiki';
 import { SkinFactory } from '@src/page/skin/SkinFactory';
 import { WindowSizeIssueChecker } from '@src/utils/SizeIssueChecker/WindowSizeIssueChecker';
 import TranslationPlugin from '@src/TranslationPlugin';
-import { TrackerWPORG } from '@src/tracking/TrackerWPORG';
+import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 
 // Channel specific form setup
@@ -37,7 +37,7 @@ const translator = new Translator( messages );
 // This is channel specific and must be changed for wp.de banners
 const mediaWiki = new WindowMediaWiki();
 const page = new PageWPORG( mediaWiki, ( new SkinFactory( mediaWiki ) ).getSkin(), new WindowSizeIssueChecker() );
-const tracker = new TrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
+const tracker = new LegacyTrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
 
 // This is language-specific and must be changed for EN banners
 const currencyFormatter = new CurrencyEn();

--- a/banners/mobile_english/components/BannerCtrl.vue
+++ b/banners/mobile_english/components/BannerCtrl.vue
@@ -87,7 +87,9 @@ import ChevronLeftIcon from '@src/components/Icons/ChevronLeftIcon.vue';
 import ChevronRightIcon from '@src/components/Icons/ChevronRightIcon.vue';
 import { Tracker } from '@src/tracking/Tracker';
 import { MobileMiniBannerExpandedEvent } from '@src/tracking/events/MobileMiniBannerExpandedEvent';
-import { createSubmittableSinglePage } from '@src/components/DonationForm/StepControllers/SubmittableSinglePage';
+import {
+	createSubmittableMainDonationFormSinglePage
+} from '@src/components/DonationForm/StepControllers/SubmittableMainDonationFormSinglePage';
 
 enum ContentStates {
 	Mini = 'wmde-banner-wrapper--mini',
@@ -109,7 +111,7 @@ const isFundsModalVisible = ref<boolean>( false );
 const slideShowStopped = ref<boolean>( false );
 const slideshowShouldPlay = computed( () => props.bannerState === BannerStates.Visible && !slideShowStopped.value );
 const contentState = ref<ContentStates>( ContentStates.Mini );
-const stepControllers = [ createSubmittableSinglePage() ];
+const stepControllers = [ createSubmittableMainDonationFormSinglePage() ];
 
 watch( contentState, async () => {
 	emit( 'bannerContentChanged' );

--- a/banners/mobile_english/components/BannerVar.vue
+++ b/banners/mobile_english/components/BannerVar.vue
@@ -87,7 +87,9 @@ import ChevronLeftIcon from '@src/components/Icons/ChevronLeftIcon.vue';
 import ChevronRightIcon from '@src/components/Icons/ChevronRightIcon.vue';
 import { Tracker } from '@src/tracking/Tracker';
 import { MobileMiniBannerExpandedEvent } from '@src/tracking/events/MobileMiniBannerExpandedEvent';
-import { createSubmittableSinglePage } from '@src/components/DonationForm/StepControllers/SubmittableSinglePage';
+import {
+	createSubmittableMainDonationFormSinglePage
+} from '@src/components/DonationForm/StepControllers/SubmittableMainDonationFormSinglePage';
 
 enum ContentStates {
 	Mini = 'wmde-banner-wrapper--mini',
@@ -110,7 +112,7 @@ const isFundsModalVisible = ref<boolean>( false );
 const slideShowStopped = ref<boolean>( false );
 const slideshowShouldPlay = computed( () => props.bannerState === BannerStates.Visible && !slideShowStopped.value );
 const contentState = ref<ContentStates>( ContentStates.Mini );
-const stepControllers = [ createSubmittableSinglePage() ];
+const stepControllers = [ createSubmittableMainDonationFormSinglePage() ];
 
 watch( contentState, async () => {
 	emit( 'bannerContentChanged' );

--- a/banners/mobile_english/event_map.ts
+++ b/banners/mobile_english/event_map.ts
@@ -1,17 +1,16 @@
-import { EventDataConverterFactory } from '@src/tracking/TrackerWPORG';
+import { EventDataConverterFactory } from '@src/tracking/LegacyTrackerWPORG';
 import { CloseSources } from '@src/tracking/CloseSources';
-import { CloseEvent } from '@src/tracking/events/CloseEvent';
-import { WMDEBannerEvent } from '@src/tracking/WPORG/WMDEBannerEvent';
+import { WMDELegacyBannerEvent } from '@src/tracking/WPORG/WMDELegacyBannerEvent';
 import { BannerNotShownReasons } from '@src/page/BannerNotShownReasons';
 import { NotShownEvent } from '@src/tracking/events/NotShownEvent';
 import { WMDESizeIssueEvent } from '@src/tracking/WPORG/WMDEBannerSizeIssue';
 import { MobileMiniBannerExpandedEvent } from '@src/tracking/events/MobileMiniBannerExpandedEvent';
 
 export default new Map<string, EventDataConverterFactory>( [
-	[ CloseSources.MainBanner, ( e: CloseEvent ): WMDEBannerEvent => new WMDEBannerEvent( 'banner-closed', e.trackingRate ) ],
-	[ CloseSources.AlreadyDonatedGoAway, ( e: CloseEvent ): WMDEBannerEvent => new WMDEBannerEvent( 'banner-closed', e.trackingRate ) ],
-	[ BannerNotShownReasons.SizeIssue, ( e: NotShownEvent ): WMDESizeIssueEvent => new WMDESizeIssueEvent( '', e.bannerSize, 1 ) ],
+	[ CloseSources.MainBanner, (): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( 'banner-closed', 0.1 ) ],
+	[ CloseSources.AlreadyDonatedGoAway, (): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( 'banner-closed', 0.1 ) ],
+	[ BannerNotShownReasons.SizeIssue, ( e: NotShownEvent ): WMDESizeIssueEvent => new WMDESizeIssueEvent( '', Number( e.customData.bannerSize ), 1 ) ],
 	[ MobileMiniBannerExpandedEvent.EVENT_NAME,
-		( e: MobileMiniBannerExpandedEvent ): WMDEBannerEvent => new WMDEBannerEvent( e.eventName, e.trackingRate ) ]
+		( e: MobileMiniBannerExpandedEvent ): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( e.eventName, 1 ) ]
 	// TODO add more events
 ] );

--- a/banners/pad/banner_ctrl.ts
+++ b/banners/pad/banner_ctrl.ts
@@ -11,7 +11,7 @@ import { WindowMediaWiki } from '@src/page/MediaWiki/WindowMediaWiki';
 import { SkinFactory } from '@src/page/skin/SkinFactory';
 import { WindowSizeIssueChecker } from '@src/utils/SizeIssueChecker/WindowSizeIssueChecker';
 import TranslationPlugin from '@src/TranslationPlugin';
-import { TrackerWPORG } from '@src/tracking/TrackerWPORG';
+import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 
 // Channel specific form setup
@@ -32,7 +32,7 @@ const translator = new Translator( messages );
 // This is channel specific and must be changed for wp.de banners
 const mediaWiki = new WindowMediaWiki();
 const page = new PageWPORG( mediaWiki, ( new SkinFactory( mediaWiki ) ).getSkin(), new WindowSizeIssueChecker() );
-const tracker = new TrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
+const tracker = new LegacyTrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
 
 const impressionCount = new LocalImpressionCount( page.getTracking().keyword );
 

--- a/banners/pad/banner_var.ts
+++ b/banners/pad/banner_var.ts
@@ -11,7 +11,7 @@ import { WindowMediaWiki } from '@src/page/MediaWiki/WindowMediaWiki';
 import { SkinFactory } from '@src/page/skin/SkinFactory';
 import { WindowSizeIssueChecker } from '@src/utils/SizeIssueChecker/WindowSizeIssueChecker';
 import TranslationPlugin from '@src/TranslationPlugin';
-import { TrackerWPORG } from '@src/tracking/TrackerWPORG';
+import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 
 // Channel specific form setup
@@ -32,7 +32,7 @@ const translator = new Translator( messages );
 // This is channel specific and must be changed for wp.de banners
 const mediaWiki = new WindowMediaWiki();
 const page = new PageWPORG( mediaWiki, ( new SkinFactory( mediaWiki ) ).getSkin(), new WindowSizeIssueChecker() );
-const tracker = new TrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
+const tracker = new LegacyTrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
 
 // This is language-specific and must be changed for EN banners
 

--- a/banners/pad/event_map.ts
+++ b/banners/pad/event_map.ts
@@ -1,7 +1,6 @@
-import { EventDataConverterFactory } from '@src/tracking/TrackerWPORG';
+import { EventDataConverterFactory } from '@src/tracking/LegacyTrackerWPORG';
 import { CloseSources } from '@src/tracking/CloseSources';
-import { CloseEvent } from '@src/tracking/events/CloseEvent';
-import { WMDEBannerEvent } from '@src/tracking/WPORG/WMDEBannerEvent';
+import { WMDELegacyBannerEvent } from '@src/tracking/WPORG/WMDELegacyBannerEvent';
 import { BannerNotShownReasons } from '@src/page/BannerNotShownReasons';
 import { NotShownEvent } from '@src/tracking/events/NotShownEvent';
 import { WMDESizeIssueEvent } from '@src/tracking/WPORG/WMDEBannerSizeIssue';
@@ -10,10 +9,10 @@ import { FormStepShownEvent } from '@src/tracking/events/FormStepShownEvent';
 import { mapFormStepShownEvent } from '@src/tracking/LegacyEventTracking/mapFormStepShownEvent';
 
 export default new Map<string, EventDataConverterFactory>( [
-	[ CloseSources.MainBanner, ( e: CloseEvent ): WMDEBannerEvent => new WMDEBannerEvent( 'banner-closed', e.trackingRate ) ],
-	[ CloseSources.AlreadyDonatedGoAway, ( e: CloseEvent ): WMDEBannerEvent => new WMDEBannerEvent( 'banner-closed', e.trackingRate ) ],
-	[ ClickAlreadyDonatedEvent.EVENT_NAME, ( e: ClickAlreadyDonatedEvent ): WMDEBannerEvent => new WMDEBannerEvent( e.eventName, e.trackingRate ) ],
+	[ CloseSources.MainBanner, (): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( 'banner-closed', 0.1 ) ],
+	[ CloseSources.AlreadyDonatedGoAway, (): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( 'banner-closed', 0.1 ) ],
+	[ ClickAlreadyDonatedEvent.EVENT_NAME, ( e: ClickAlreadyDonatedEvent ): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( e.eventName, 1 ) ],
 	[ FormStepShownEvent.EVENT_NAME, mapFormStepShownEvent ],
-	[ BannerNotShownReasons.SizeIssue, ( e: NotShownEvent ): WMDESizeIssueEvent => new WMDESizeIssueEvent( '', e.bannerSize, 1 ) ]
+	[ BannerNotShownReasons.SizeIssue, ( e: NotShownEvent ): WMDESizeIssueEvent => new WMDESizeIssueEvent( '', Number( e.customData.bannerSize ), 1 ) ]
 	// TODO add more events
 ] );

--- a/banners/pad_english/banner_ctrl.ts
+++ b/banners/pad_english/banner_ctrl.ts
@@ -15,7 +15,7 @@ import { Translator } from '@src/Translator';
 import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import eventMappings from './event_map';
-import { TrackerWPORG } from '@src/tracking/TrackerWPORG';
+import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 
 // Locale-specific imports
 import messages from './messages';
@@ -37,7 +37,7 @@ const page = new PageWPORG(
 	( new SkinFactory( mediaWiki ) ).getSkin(),
 	new WindowSizeIssueChecker()
 );
-const tracker = new TrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
+const tracker = new LegacyTrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
 
 const impressionCount = new LocalImpressionCount( page.getTracking().keyword );
 

--- a/banners/pad_english/banner_var.ts
+++ b/banners/pad_english/banner_var.ts
@@ -15,7 +15,7 @@ import { Translator } from '@src/Translator';
 import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import eventMappings from './event_map';
-import { TrackerWPORG } from '@src/tracking/TrackerWPORG';
+import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 
 // Locale-specific imports
 import messages from './messages';
@@ -37,7 +37,7 @@ const page = new PageWPORG(
 	( new SkinFactory( mediaWiki ) ).getSkin(),
 	new WindowSizeIssueChecker()
 );
-const tracker = new TrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
+const tracker = new LegacyTrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings );
 
 const impressionCount = new LocalImpressionCount( page.getTracking().keyword );
 

--- a/banners/pad_english/event_map.ts
+++ b/banners/pad_english/event_map.ts
@@ -1,7 +1,6 @@
-import { EventDataConverterFactory } from '@src/tracking/TrackerWPORG';
+import { EventDataConverterFactory } from '@src/tracking/LegacyTrackerWPORG';
 import { CloseSources } from '@src/tracking/CloseSources';
-import { CloseEvent } from '@src/tracking/events/CloseEvent';
-import { WMDEBannerEvent } from '@src/tracking/WPORG/WMDEBannerEvent';
+import { WMDELegacyBannerEvent } from '@src/tracking/WPORG/WMDELegacyBannerEvent';
 import { BannerNotShownReasons } from '@src/page/BannerNotShownReasons';
 import { NotShownEvent } from '@src/tracking/events/NotShownEvent';
 import { WMDESizeIssueEvent } from '@src/tracking/WPORG/WMDEBannerSizeIssue';
@@ -11,12 +10,12 @@ import { FormStepShownEvent } from '@src/tracking/events/FormStepShownEvent';
 import { mapFormStepShownEvent } from '@src/tracking/LegacyEventTracking/mapFormStepShownEvent';
 
 export default new Map<string, EventDataConverterFactory>( [
-	[ CloseSources.MainBanner, ( e: CloseEvent ): WMDEBannerEvent => new WMDEBannerEvent( 'banner-closed', e.trackingRate ) ],
-	[ CloseSources.AlreadyDonatedGoAway, ( e: CloseEvent ): WMDEBannerEvent => new WMDEBannerEvent( 'banner-closed', e.trackingRate ) ],
-	[ BannerNotShownReasons.SizeIssue, ( e: NotShownEvent ): WMDESizeIssueEvent => new WMDESizeIssueEvent( '', e.bannerSize, 1 ) ],
+	[ CloseSources.MainBanner, (): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( 'banner-closed', 0.1 ) ],
+	[ CloseSources.AlreadyDonatedGoAway, (): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( 'banner-closed', 0.1 ) ],
+	[ BannerNotShownReasons.SizeIssue, ( e: NotShownEvent ): WMDESizeIssueEvent => new WMDESizeIssueEvent( '', Number( e.customData.bannerSize ), 1 ) ],
 	[ FormStepShownEvent.EVENT_NAME, mapFormStepShownEvent ],
 	[ IncreaseCustomAmountEvent.EVENT_NAME,
-		( e: IncreaseCustomAmountEvent ): WMDEBannerEvent => new WMDEBannerEvent( e.eventName, e.trackingRate ) ],
+		( e: IncreaseCustomAmountEvent ): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( e.eventName, 1 ) ],
 	[ DecreaseCustomAmountEvent.EVENT_NAME,
-		( e: DecreaseCustomAmountEvent ): WMDEBannerEvent => new WMDEBannerEvent( e.eventName, e.trackingRate ) ]
+		( e: DecreaseCustomAmountEvent ): WMDELegacyBannerEvent => new WMDELegacyBannerEvent( e.eventName, 1 ) ]
 ] );

--- a/src/components/DonationForm/StepControllers/SubmittableAddressType.ts
+++ b/src/components/DonationForm/StepControllers/SubmittableAddressType.ts
@@ -2,11 +2,12 @@ import { FormModel } from '@src/utils/FormModel/FormModel';
 import { StepController } from '@src/components/DonationForm/StepController';
 import { StepAction } from '@src/components/DonationForm/StepNavigation';
 import { Validity } from '@src/utils/FormModel/Validity';
+import { BannerSubmitEvent } from '@src/tracking/events/BannerSubmitEvent';
 
 export function createSubmittableAddressType( formModel: FormModel, pageIndexForPrevious: string ): StepController {
 	return {
 		async submit( navigation: StepAction ): Promise<void> {
-			await navigation.submit( 'submit' );
+			await navigation.submit( new BannerSubmitEvent( 'AddressTypeForm' ) );
 		},
 		async previous( navigation: StepAction ): Promise<void> {
 			formModel.addressType.value = '';

--- a/src/components/DonationForm/StepControllers/SubmittableCustomAmount.ts
+++ b/src/components/DonationForm/StepControllers/SubmittableCustomAmount.ts
@@ -2,13 +2,14 @@ import { FormModel } from '@src/utils/FormModel/FormModel';
 import { StepController } from '@src/components/DonationForm/StepController';
 import { StepAction } from '@src/components/DonationForm/StepNavigation';
 import { Intervals } from '@src/utils/FormItemsBuilder/fields/Intervals';
+import { BannerSubmitEvent } from '@src/tracking/events/BannerSubmitEvent';
 
 export function createSubmittableCustomAmount( formModel: FormModel, stepNamePrevious: string ): StepController {
 	return {
 		async submit( navigation: StepAction, submitData: Record<string, string> ): Promise<void> {
 			formModel.interval.value = Intervals.YEARLY.value;
 			formModel.customAmount.value = submitData.newCustomAmount;
-			await navigation.submit( 'submit-different-amount' );
+			await navigation.submit( new BannerSubmitEvent( 'CustomAmountForm' ) );
 		},
 		async previous( navigation: StepAction ): Promise<void> {
 			await navigation.goToStep( stepNamePrevious );

--- a/src/components/DonationForm/StepControllers/SubmittableMainDonationForm.ts
+++ b/src/components/DonationForm/StepControllers/SubmittableMainDonationForm.ts
@@ -3,12 +3,13 @@ import { Intervals } from '@src/utils/FormItemsBuilder/fields/Intervals';
 import { PaymentMethods } from '@src/utils/FormItemsBuilder/fields/PaymentMethods';
 import { StepController } from '@src/components/DonationForm/StepController';
 import { StepAction } from '@src/components/DonationForm/StepNavigation';
+import { BannerSubmitEvent } from '@src/tracking/events/BannerSubmitEvent';
 
 export function createSubmittableMainDonationForm( formModel: FormModel, stepNameOfUpgradeToYearly: string ): StepController {
 	return {
 		async submit( navigation: StepAction ): Promise<void> {
 			if ( formModel.interval.value !== Intervals.ONCE.value || formModel.paymentMethod.value === PaymentMethods.SOFORT.value ) {
-				await navigation.submit( 'submit' );
+				await navigation.submit( new BannerSubmitEvent( 'MainDonationForm' ) );
 				return;
 			}
 			await navigation.goToStep( stepNameOfUpgradeToYearly );

--- a/src/components/DonationForm/StepControllers/SubmittableMainDonationFormSinglePage.ts
+++ b/src/components/DonationForm/StepControllers/SubmittableMainDonationFormSinglePage.ts
@@ -1,10 +1,11 @@
 import { StepController } from '@src/components/DonationForm/StepController';
 import { StepAction } from '@src/components/DonationForm/StepNavigation';
+import { BannerSubmitEvent } from '@src/tracking/events/BannerSubmitEvent';
 
-export function createSubmittableSinglePage(): StepController {
+export function createSubmittableMainDonationFormSinglePage(): StepController {
 	return {
 		async submit( navigation: StepAction ): Promise<void> {
-			await navigation.submit( 'submit' );
+			await navigation.submit( new BannerSubmitEvent( 'MainDonationForm' ) );
 		},
 		async previous(): Promise<void> {
 			return Promise.reject( 'Single page forms cannot go to previous. This should never happen.' );

--- a/src/domain/BannerType.ts
+++ b/src/domain/BannerType.ts
@@ -1,0 +1,4 @@
+export enum BannerType {
+	CTRL = 'CTRL',
+	VAR = 'VAR',
+}

--- a/src/page/MediaWiki/BannerEvent.ts
+++ b/src/page/MediaWiki/BannerEvent.ts
@@ -1,7 +1,14 @@
+import { BannerType } from '@src/domain/BannerType';
+
 export interface BannerEvent {
-	bannerName: string;
-	bannerAction: string;
-	eventRate: number;
-	slidesShown: number;
-	finalSlide: number;
+	action: string;
+	platform: string;
+	language: string;
+	test_number: number;
+	banner: BannerType;
+	campaign_name: string;
+	banner_name: string;
+	feature: string;
+	event_rate: number;
+	custom_data: Record<string, string|number>;
 }

--- a/src/page/MediaWiki/LegacyBannerEvent.ts
+++ b/src/page/MediaWiki/LegacyBannerEvent.ts
@@ -1,0 +1,11 @@
+/**
+ * @deprecated LegacyBannerEvent is for an old tracking schema
+ *             Will be removed when the new tracking schema is implemented
+ */
+export interface LegacyBannerEvent {
+	bannerName: string;
+	bannerAction: string;
+	eventRate: number;
+	slidesShown: number;
+	finalSlide: number;
+}

--- a/src/page/MediaWiki/MediaWiki.ts
+++ b/src/page/MediaWiki/MediaWiki.ts
@@ -1,4 +1,4 @@
-import { BannerEvent } from '@src/page/MediaWiki/BannerEvent';
+import { LegacyBannerEvent } from '@src/page/MediaWiki/LegacyBannerEvent';
 import { SizeIssue } from '@src/page/MediaWiki/SizeIssue';
 
 export interface MediaWiki {
@@ -6,7 +6,7 @@ export interface MediaWiki {
 	isShowingContentPage: () => boolean;
 	isContentHiddenByLightbox: () => boolean;
 	isInArticleNamespace: () => boolean;
-	track: ( name: string, trackingData: BannerEvent|SizeIssue ) => void;
+	track: ( name: string, trackingData: LegacyBannerEvent|SizeIssue ) => void;
 	preventBannerDisplayForPeriod: () => void;
 	preventBannerDisplayUntilEndOfCampaign: () => void;
 	setBannerLoadedButHidden: () => void;

--- a/src/page/MediaWiki/SizeIssue.ts
+++ b/src/page/MediaWiki/SizeIssue.ts
@@ -1,3 +1,7 @@
+/**
+ * @deprecated SizeIssue is for an old tracking schema
+ *             Will be removed when the new tracking schema is implemented
+ */
 export interface SizeIssue {
 	bannerName: string;
 	viewportWidth: number;

--- a/src/page/MediaWiki/WindowMediaWiki.ts
+++ b/src/page/MediaWiki/WindowMediaWiki.ts
@@ -1,10 +1,10 @@
 import { MediaWiki } from '@src/page/MediaWiki/MediaWiki';
-import { BannerEvent } from '@src/page/MediaWiki/BannerEvent';
+import { LegacyBannerEvent } from '@src/page/MediaWiki/LegacyBannerEvent';
 import { SizeIssue } from '@src/page/MediaWiki/SizeIssue';
 
 interface MediaWikiTools {
 	config: { get: ( item: string ) => any };
-	track: ( name: string, trackingData: BannerEvent|SizeIssue ) => void;
+	track: ( name: string, trackingData: LegacyBannerEvent|SizeIssue ) => void;
 	centralNotice: any;
 }
 
@@ -43,7 +43,7 @@ export class WindowMediaWiki implements MediaWiki {
 		return this.getConfigItem( 'wgAction' ) === 'view';
 	}
 
-	public track( name: string, trackingData: BannerEvent | SizeIssue ): void {
+	public track( name: string, trackingData: LegacyBannerEvent | SizeIssue ): void {
 		window.mw.track( name, trackingData );
 	}
 

--- a/src/tracking/EventData.ts
+++ b/src/tracking/EventData.ts
@@ -1,4 +1,5 @@
 export interface EventData {
-	eventName: string,
-	trackingRate: number,
+	eventName: string;
+	feature: string;
+	customData: Record<string, string|number>;
 }

--- a/src/tracking/LegacyEventTracking/mapFormStepShownEvent.ts
+++ b/src/tracking/LegacyEventTracking/mapFormStepShownEvent.ts
@@ -1,11 +1,14 @@
 import { FormStepShownEvent } from '@src/tracking/events/FormStepShownEvent';
-import { WMDEBannerEvent } from '@src/tracking/WPORG/WMDEBannerEvent';
+import { WMDELegacyBannerEvent } from '@src/tracking/WPORG/WMDELegacyBannerEvent';
 
-export function mapFormStepShownEvent( e: FormStepShownEvent ): WMDEBannerEvent {
+/**
+ * @deprecated Will be removed when the new tracking schema is implemented
+ */
+export function mapFormStepShownEvent( e: FormStepShownEvent ): WMDELegacyBannerEvent {
 	const stepNameToEventLookup: Record<string, string> = {
 		UpgradeToYearlyForm: 'upgrade-to-yearly-form-page-shown',
 		CustomAmountForm: 'custom-amount-form-page-shown',
 		AddressTypeForm: 'address-type-form-page-shown'
 	};
-	return new WMDEBannerEvent( stepNameToEventLookup[ e.feature ] );
+	return new WMDELegacyBannerEvent( stepNameToEventLookup[ e.feature ] );
 }

--- a/src/tracking/LegacyTrackerWPORG.ts
+++ b/src/tracking/LegacyTrackerWPORG.ts
@@ -2,13 +2,17 @@ import { Tracker } from '@src/tracking/Tracker';
 import { EventData } from '@src/tracking/EventData';
 import { MediaWiki } from '@src/page/MediaWiki/MediaWiki';
 import { WMDESizeIssueEvent } from '@src/tracking/WPORG/WMDEBannerSizeIssue';
-import { WMDEBannerEvent } from '@src/tracking/WPORG/WMDEBannerEvent';
+import { WMDELegacyBannerEvent } from '@src/tracking/WPORG/WMDELegacyBannerEvent';
 
-export type EventDataConverterFactory = ( event: EventData ) => WMDEBannerEvent|WMDESizeIssueEvent;
+export type EventDataConverterFactory = ( event: EventData ) => WMDELegacyBannerEvent|WMDESizeIssueEvent;
 
 type EventNameMap = Map<string, EventDataConverterFactory>;
 
-export class TrackerWPORG implements Tracker {
+/**
+ * @deprecated LegacyTrackerWPORG is for old tracking schemas
+ *             It will be deleted when the new schema is implemented
+ */
+export class LegacyTrackerWPORG implements Tracker {
 	private readonly _mediaWiki: MediaWiki;
 	private readonly _bannerName: string;
 	private readonly _supportedTrackingEvents: EventNameMap;
@@ -24,8 +28,9 @@ export class TrackerWPORG implements Tracker {
 			return;
 		}
 		const wpOrgEvent = this._supportedTrackingEvents.get( event.eventName )( event );
-		if ( this.isDevMode() || Math.random() > event.trackingRate ) {
-			this._mediaWiki.track( wpOrgEvent.eventType, wpOrgEvent.getEventData( this._bannerName ) );
+		const eventData = wpOrgEvent.getEventData( this._bannerName );
+		if ( this.isDevMode() || Math.random() > eventData.eventRate ) {
+			this._mediaWiki.track( wpOrgEvent.eventType, eventData );
 		}
 	}
 

--- a/src/tracking/TrackerWPDE.ts
+++ b/src/tracking/TrackerWPDE.ts
@@ -24,7 +24,8 @@ export class TrackerWPDE implements Tracker {
 		if ( !this._supportedTrackingEvents.has( event.eventName ) ) {
 			return;
 		}
-		if ( this.isDevMode() || Math.random() > event.trackingRate ) {
+		// TODO: Import event tracking rate from new map
+		if ( this.isDevMode() || Math.random() > 1 ) {
 			this.trackOrStore( event.eventName );
 		}
 	}

--- a/src/tracking/WPORG/WMDEBannerSizeIssue.ts
+++ b/src/tracking/WPORG/WMDEBannerSizeIssue.ts
@@ -1,11 +1,8 @@
-interface WMDESizeIssueEventData {
-	bannerName: string;
-	viewportWidth: number;
-	viewportHeight: number;
-	bannerHeight: number;
-	eventRate: number;
-}
+import { SizeIssue } from '@src/page/MediaWiki/SizeIssue';
 
+/**
+ * @deprecated WMDESizeIssueEvent is for an old tracking schema
+ */
 export class WMDESizeIssueEvent {
 
 	private readonly _eventName: string;
@@ -19,7 +16,7 @@ export class WMDESizeIssueEvent {
 		this._trackingRate = trackingRate;
 	}
 
-	public getEventData( bannerName: string ): WMDESizeIssueEventData {
+	public getEventData( bannerName: string ): SizeIssue {
 		return {
 			bannerName: this._eventName + '-' + bannerName,
 			viewportWidth: window.innerWidth,

--- a/src/tracking/WPORG/WMDELegacyBannerEvent.ts
+++ b/src/tracking/WPORG/WMDELegacyBannerEvent.ts
@@ -1,12 +1,9 @@
-interface WMDEBannerEventData {
-	bannerName: string;
-	bannerAction: string;
-	eventRate: number;
-	finalSlide: number;
-	slidesShown: number;
-}
+import { LegacyBannerEvent } from '@src/page/MediaWiki/LegacyBannerEvent';
 
-export class WMDEBannerEvent {
+/**
+ * @deprecated WMDELegacyBannerEvent is for an old tracking schema
+ */
+export class WMDELegacyBannerEvent {
 
 	private readonly _eventName: string;
 	private readonly _trackingRate: number;
@@ -19,7 +16,7 @@ export class WMDEBannerEvent {
 		this._trackingRate = trackingRate;
 	}
 
-	public getEventData( bannerName: string ): WMDEBannerEventData {
+	public getEventData( bannerName: string ): LegacyBannerEvent {
 		return {
 			bannerName: bannerName,
 			bannerAction: this._eventName + '-' + bannerName,

--- a/src/tracking/events/BannerSubmitEvent.ts
+++ b/src/tracking/events/BannerSubmitEvent.ts
@@ -4,13 +4,11 @@ export class BannerSubmitEvent implements EventData {
 	public static readonly EVENT_NAME = 'submit';
 
 	public readonly eventName = BannerSubmitEvent.EVENT_NAME;
-	public readonly trackingRate = 0.01;
-
-	public readonly eventFeature;
+	public readonly feature: string;
 	public readonly customData: Record<string, string>;
 
-	public constructor( eventFeature: string, customData: Record<string, string> = {} ) {
-		this.eventFeature = eventFeature;
+	public constructor( feature: string, customData: Record<string, string> = {} ) {
+		this.feature = feature;
 		this.customData = customData;
 	}
 }

--- a/src/tracking/events/ClickAlreadyDonatedEvent.ts
+++ b/src/tracking/events/ClickAlreadyDonatedEvent.ts
@@ -4,5 +4,6 @@ export class ClickAlreadyDonatedEvent implements EventData {
 	public static readonly EVENT_NAME = 'clicked-already-donated';
 
 	public readonly eventName = ClickAlreadyDonatedEvent.EVENT_NAME;
-	public readonly trackingRate = 0.01;
+	public readonly customData: Record<string, string> = {};
+	public readonly feature: string = 'AlreadyDonatedModal';
 }

--- a/src/tracking/events/CloseEvent.ts
+++ b/src/tracking/events/CloseEvent.ts
@@ -2,12 +2,11 @@ import { EventData } from '@src/tracking/EventData';
 import { CloseSources } from '@src/tracking/CloseSources';
 
 export class CloseEvent implements EventData {
-	// TODO: Make these private and add getters
-	public eventName: string;
-	public trackingRate: number;
+	public readonly eventName: string;
+	public readonly customData: Record<string, string> = {};
+	public readonly feature: string = '';
 
-	public constructor( source: CloseSources, trackingRate = 0.01 ) {
+	public constructor( source: CloseSources ) {
 		this.eventName = source;
-		this.trackingRate = trackingRate;
 	}
 }

--- a/src/tracking/events/CustomAmountChangedEvent.ts
+++ b/src/tracking/events/CustomAmountChangedEvent.ts
@@ -1,0 +1,13 @@
+import { EventData } from '@src/tracking/EventData';
+
+export class CustomAmountChangedEvent implements EventData {
+	public static readonly EVENT_NAME = 'custom-amount-changed';
+
+	public readonly eventName = CustomAmountChangedEvent.EVENT_NAME;
+	public readonly customData: Record<string, string> = {};
+	public readonly feature: string = 'CustomAmountForm';
+
+	public constructor( amountChange: 'increased' | 'decreased' ) {
+		this.customData = { amountChange };
+	}
+}

--- a/src/tracking/events/DecreaseCustomAmountEvent.ts
+++ b/src/tracking/events/DecreaseCustomAmountEvent.ts
@@ -1,10 +1,9 @@
 import { EventData } from '@src/tracking/EventData';
 
 export class DecreaseCustomAmountEvent implements EventData {
-
 	public static readonly EVENT_NAME = 'decreased-amount';
 
 	public readonly eventName = DecreaseCustomAmountEvent.EVENT_NAME;
-
-	public readonly trackingRate: number = 0.01;
+	public readonly customData: Record<string, string> = {};
+	public readonly feature: string = 'CustomAmountForm';
 }

--- a/src/tracking/events/FormStepShownEvent.ts
+++ b/src/tracking/events/FormStepShownEvent.ts
@@ -3,12 +3,12 @@ import { EventData } from '@src/tracking/EventData';
 export class FormStepShownEvent implements EventData {
 	public static readonly EVENT_NAME = 'decreased-amount';
 
-	public readonly feature: string;
 	public readonly eventName = FormStepShownEvent.EVENT_NAME;
+	public readonly feature: string;
+	public readonly customData: Record<string, string> = {};
 
 	public constructor( feature: string ) {
 		this.feature = feature;
 	}
 
-	public readonly trackingRate: number = 0.01;
 }

--- a/src/tracking/events/IncreaseCustomAmountEvent.ts
+++ b/src/tracking/events/IncreaseCustomAmountEvent.ts
@@ -5,6 +5,6 @@ export class IncreaseCustomAmountEvent implements EventData {
 	public static readonly EVENT_NAME = 'increased-amount';
 
 	public readonly eventName = IncreaseCustomAmountEvent.EVENT_NAME;
-
-	public readonly trackingRate: number = 0.01;
+	public readonly customData: Record<string, string> = {};
+	public readonly feature: string = 'CustomAmountForm';
 }

--- a/src/tracking/events/MobileMiniBannerExpandedEvent.ts
+++ b/src/tracking/events/MobileMiniBannerExpandedEvent.ts
@@ -5,6 +5,6 @@ export class MobileMiniBannerExpandedEvent implements EventData {
 	public static readonly EVENT_NAME = 'mobile-mini-banner-expanded';
 
 	public readonly eventName = MobileMiniBannerExpandedEvent.EVENT_NAME;
-
-	public readonly trackingRate: number = 0.01;
+	public readonly customData: Record<string, string> = {};
+	public readonly feature: string = 'MiniBanner';
 }

--- a/src/tracking/events/NotShownEvent.ts
+++ b/src/tracking/events/NotShownEvent.ts
@@ -2,14 +2,12 @@ import { EventData } from '@src/tracking/EventData';
 import { BannerNotShownReasons } from '@src/page/BannerNotShownReasons';
 
 export class NotShownEvent implements EventData {
-	// TODO: Make these private and add getters
-	public eventName: string;
-	public trackingRate: number;
-	public bannerSize: number;
+	public readonly eventName: string;
+	public readonly customData: Record<string, string|number>;
+	public readonly feature: string = 'BannerConductor';
 
-	public constructor( reason: BannerNotShownReasons, bannerSize: number, trackingRate: number = 1 ) {
+	public constructor( reason: BannerNotShownReasons, bannerSize: number ) {
 		this.eventName = reason;
-		this.bannerSize = bannerSize;
-		this.trackingRate = trackingRate;
+		this.customData = { bannerSize };
 	}
 }

--- a/src/tracking/events/UpgradeToYearlyEvent.ts
+++ b/src/tracking/events/UpgradeToYearlyEvent.ts
@@ -3,12 +3,11 @@ import { EventData } from '@src/tracking/EventData';
 export class UpgradeToYearlyEvent implements EventData {
 	public static readonly EVENT_NAME = 'upgrade-to-yearly';
 
+	public readonly eventName = UpgradeToYearlyEvent.EVENT_NAME;
 	public readonly customData: Record<string, string>;
+	public readonly feature: string = 'UpgradeToYearlyForm';
 
 	public constructor( optionSelected: 'upgraded-to-yearly'|'not-upgraded-to-yearly' ) {
 		this.customData = { optionSelected };
 	}
-
-	public readonly eventName = UpgradeToYearlyEvent.EVENT_NAME;
-	public readonly trackingRate = 0.01;
 }

--- a/test/components/DonationForm/Forms/CustomAmountForm.spec.ts
+++ b/test/components/DonationForm/Forms/CustomAmountForm.spec.ts
@@ -8,6 +8,7 @@ import { FormStepShownEvent } from '@src/tracking/events/FormStepShownEvent';
 import { TrackerSpy } from '@test/fixtures/TrackerSpy';
 import { resetFormModel } from '@test/resetFormModel';
 import { useFormModel } from '@src/components/composables/useFormModel';
+import { CustomAmountChangedEvent } from '@src/tracking/events/CustomAmountChangedEvent';
 
 const formModel = useFormModel();
 
@@ -129,13 +130,13 @@ describe( 'CustomAmountForm.vue', () => {
 		expect( wrapper.find( '.wmde-banner-select-group-container--with-error' ).exists() ).toBe( true );
 	} );
 
-	describe( 'tracking events ', function () {
+	describe.todo( 'tracking events ', function () {
 
 		it( 'should track "increased amount"', async function () {
 			const wrapper = getWrapper();
 			// TODO insert higher custom amount setup
 
-			expect( tracker.hasTrackedEvent( CustomAmountChanged.EVENT_NAME ) ).toBe( true );
+			expect( tracker.hasTrackedEvent( CustomAmountChangedEvent.EVENT_NAME ) ).toBe( true );
 			expect( tracker.getTrackedEvent( UpgradeToYearlyEvent.EVENT_NAME ) ).toEqual( new UpgradeToYearlyEvent( 'upgraded-to-yearly' ) );
 
 		} );


### PR DESCRIPTION
This modifies the interfaces to allow easier implementation of the new tracking schema when we get to it.

* Moved event rate out of events and into maps
* Added event data interface based off the new schema description
* Marked old interfaces and implementations as deprecated
* Fixed tests and linting issues