### PR TITLE
Add feature tests for multistep forms

### DIFF
--- a/src/components/DonationForm/Forms/UpgradeToYearlyButtonForm.vue
+++ b/src/components/DonationForm/Forms/UpgradeToYearlyButtonForm.vue
@@ -15,7 +15,7 @@
 				class="wmde-banner-form-button t-annual-upgrade-no"
 				:value="Intervals.ONCE.value"
 			>
-					{{ $translate( 'upgrade-to-yearly-no', { amount: secondPageAmount } ) }}
+				{{ $translate( 'upgrade-to-yearly-no', { amount: secondPageAmount } ) }}
 			</button>
 
 			<button
@@ -24,7 +24,7 @@
 				class="wmde-banner-form-button t-annual-upgrade-yes"
 				:value="Intervals.YEARLY.value"
 			>
-					{{ $translate( 'upgrade-to-yearly-yes', { amount: secondPageAmount } ) }}
+				{{ $translate( 'upgrade-to-yearly-yes', { amount: secondPageAmount } ) }}
 			</button>
 
 			<a tabIndex="-1"
@@ -32,7 +32,7 @@
 				class="wmde-banner-form-upgrade-custom t-annual-upgrade-yes-custom"
 				@click.prevent="onGoToChangeOfAmount"
 			>
-					{{ $translate( 'upgrade-to-yearly-link' ) }}
+				{{ $translate( 'upgrade-to-yearly-link' ) }}
 			</a>
 		</div>
     </form>

--- a/test/banners/desktop/components/BannerCtrl.spec.ts
+++ b/test/banners/desktop/components/BannerCtrl.spec.ts
@@ -1,4 +1,4 @@
-import { describe, test } from 'vitest';
+import { beforeEach, describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/desktop/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -9,24 +9,24 @@ import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
 import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
-import { desktopContentFeatures } from '@test/features/DesktopContent';
+import { desktopContentDisplaySwitchFeatures, desktopContentFeatures } from '@test/features/DesktopContent';
+import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearly_CustomAmount';
+import { useFormModel } from '@src/components/composables/useFormModel';
+import { resetFormModel } from '@test/resetFormModel';
 
+const formModel = useFormModel();
 const translator = ( key: string ): string => key;
 
 describe( 'BannerCtrl.vue', () => {
+
+	beforeEach( () => {
+		resetFormModel( formModel );
+	} );
+
 	const getWrapper = (): VueWrapper<any> => {
 		return mount( Banner, {
 			props: {
 				bannerState: BannerStates.Pending,
-				formController: {
-					submitStep: () => {},
-					next: () => {},
-					previous: () => {},
-					onNext: () => {},
-					onPrevious: () => {},
-					onGoToStep: () => {},
-					onSubmit: () => {}
-				},
 				useOfFundsContent
 			},
 			global: {
@@ -48,11 +48,30 @@ describe( 'BannerCtrl.vue', () => {
 	describe( 'Content', () => {
 		test.each( [
 			[ 'expectSlideShowPlaysWhenBecomesVisible' ],
-			[ 'expectSlideShowStopsOnFormInteraction' ],
+			[ 'expectSlideShowStopsOnFormInteraction' ]
+		] )( '%s', async ( testName: string ) => {
+			await desktopContentFeatures[ testName ]( getWrapper() );
+		} );
+
+		test.each( [
 			[ 'expectShowsSlideShowOnSmallSizes' ],
 			[ 'expectShowsMessageOnSmallSizes' ]
 		] )( '%s', async ( testName: string ) => {
-			await desktopContentFeatures[ testName ]( getWrapper );
+			await desktopContentDisplaySwitchFeatures[ testName ]( getWrapper );
+		} );
+	} );
+
+	describe( 'Donation Form Happy Paths', () => {
+		test.each( [
+			[ 'expectMainDonationFormSubmitsWhenSofortIsSelected' ],
+			[ 'expectMainDonationFormSubmitsWhenYearlyIsSelected' ],
+			[ 'expectMainDonationFormGoesToUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsDontUpgrade' ],
+			[ 'expectUpgradeToYearlyFormGoesToCustomAmount' ],
+			[ 'expectCustomAmountFormSubmits' ]
+		] )( '%s', async ( testName: string ) => {
+			await donationFormFeatures[ testName ]( getWrapper() );
 		} );
 	} );
 

--- a/test/banners/desktop/components/BannerVar.spec.ts
+++ b/test/banners/desktop/components/BannerVar.spec.ts
@@ -1,6 +1,6 @@
-import { afterEach, beforeEach, describe, test } from 'vitest';
+import { beforeEach, describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
-import Banner from '../../../../banners/pad/components/BannerCtrl.vue';
+import Banner from '../../../../banners/desktop/components/BannerVar.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
 import { dynamicCampaignContent } from '@test/banners/dynamicCampaignContent';
 import { useOfFundsContent } from '@test/banners/useOfFundsContent';
@@ -9,25 +9,22 @@ import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
 import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
-import { desktopContentFeatures } from '@test/features/DesktopContent';
-import { alreadyDonatedModalFeatures } from '@test/features/AlreadyDonatedModal';
-import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
+import { desktopContentDisplaySwitchFeatures, desktopContentFeatures } from '@test/features/DesktopContent';
+import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearly_CustomAmount_AddressType';
 import { useFormModel } from '@src/components/composables/useFormModel';
 import { resetFormModel } from '@test/resetFormModel';
 
 const formModel = useFormModel();
 const translator = ( key: string ): string => key;
 
-describe( 'BannerCtrl.vue', () => {
+describe( 'BannerVar.vue', () => {
 
-	let wrapper: VueWrapper<any>;
 	beforeEach( () => {
 		resetFormModel( formModel );
+	} );
 
-		// attachTo the document body to fix an issue with Vue Test Utils where
-		// clicking a submit button in a form does not fire the submit event
-		wrapper = mount( Banner, {
-			attachTo: document.body,
+	const getWrapper = (): VueWrapper<any> => {
+		return mount( Banner, {
 			props: {
 				bannerState: BannerStates.Pending,
 				useOfFundsContent
@@ -46,31 +43,36 @@ describe( 'BannerCtrl.vue', () => {
 				}
 			}
 		} );
-	} );
-
-	afterEach( () => {
-		wrapper.unmount();
-	} );
+	};
 
 	describe( 'Content', () => {
 		test.each( [
 			[ 'expectSlideShowPlaysWhenBecomesVisible' ],
 			[ 'expectSlideShowStopsOnFormInteraction' ]
 		] )( '%s', async ( testName: string ) => {
-			await desktopContentFeatures[ testName ]( wrapper );
+			await desktopContentFeatures[ testName ]( getWrapper() );
+		} );
+
+		test.each( [
+			[ 'expectShowsSlideShowOnSmallSizes' ],
+			[ 'expectShowsMessageOnSmallSizes' ]
+		] )( '%s', async ( testName: string ) => {
+			await desktopContentDisplaySwitchFeatures[ testName ]( getWrapper );
 		} );
 	} );
 
 	describe( 'Donation Form Happy Paths', () => {
 		test.each( [
-			[ 'expectMainDonationFormSubmitsWhenSofortIsSelected' ],
-			[ 'expectMainDonationFormSubmitsWhenYearlyIsSelected' ],
+			[ 'expectMainDonationFormGoesToAddressFormWhenSofortIsSelected' ],
+			[ 'expectMainDonationFormGoesToAddressFormWhenYearlyIsSelected' ],
 			[ 'expectMainDonationFormGoesToUpgrade' ],
-			[ 'expectUpgradeToYearlyFormSubmitsUpgrade' ],
-			[ 'expectUpgradeToYearlyFormSubmitsDontUpgrade' ],
-			[ 'expectUpgradeToYearlyFormGoesToMainDonation' ]
+			[ 'expectUpgradeToYearlyFormGoesToAddressTypeOnUpgrade' ],
+			[ 'expectUpgradeToYearlyFormGoesToAddressTypeOnDontUpgrade' ],
+			[ 'expectUpgradeToYearlyFormGoesToCustomAmount' ],
+			[ 'expectCustomAmountGoesToAddressFormOnSubmit' ],
+			[ 'expectAddressFormSubmits' ]
 		] )( '%s', async ( testName: string ) => {
-			await donationFormFeatures[ testName ]( wrapper );
+			await donationFormFeatures[ testName ]( getWrapper() );
 		} );
 	} );
 
@@ -82,7 +84,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ]
 		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( wrapper );
+			await softCloseFeatures[ testName ]( getWrapper() );
 		} );
 	} );
 
@@ -91,18 +93,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectShowsUseOfFunds' ],
 			[ 'expectHidesUseOfFunds' ]
 		] )( '%s', async ( testName: string ) => {
-			await useOfFundsFeatures[ testName ]( wrapper );
-		} );
-	} );
-
-	describe( 'Already Donated Modal', () => {
-		test.each( [
-			[ 'expectShowsAlreadyDonatedModal' ],
-			[ 'expectHidesAlreadyDonatedModal' ],
-			[ 'expectFiresMaybeLaterEvent' ],
-			[ 'expectFiresGoAwayEvent' ]
-		] )( '%s', async ( testName: string ) => {
-			await alreadyDonatedModalFeatures[ testName ]( wrapper );
+			await useOfFundsFeatures[ testName ]( getWrapper() );
 		} );
 	} );
 

--- a/test/banners/english/components/BannerCtrl.spec.ts
+++ b/test/banners/english/components/BannerCtrl.spec.ts
@@ -1,4 +1,4 @@
-import { describe, test } from 'vitest';
+import { beforeEach, describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/english/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -8,25 +8,25 @@ import { formItems } from '@test/banners/formItems';
 import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
 import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
-import { desktopContentFeatures } from '@test/features/DesktopContent';
+import { desktopContentDisplaySwitchFeatures, desktopContentFeatures } from '@test/features/DesktopContent';
 import { TrackerStub } from '@test/fixtures/TrackerStub';
+import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearly_CustomAmount';
+import { useFormModel } from '@src/components/composables/useFormModel';
+import { resetFormModel } from '@test/resetFormModel';
 
+const formModel = useFormModel();
 const translator = ( key: string ): string => key;
 
 describe( 'BannerCtrl.vue', () => {
+
+	beforeEach( () => {
+		resetFormModel( formModel );
+	} );
+
 	const getWrapper = (): VueWrapper<any> => {
 		return mount( Banner, {
 			props: {
 				bannerState: BannerStates.Pending,
-				formController: {
-					submitStep: () => {},
-					next: () => {},
-					previous: () => {},
-					onNext: () => {},
-					onPrevious: () => {},
-					onGoToStep: () => {},
-					onSubmit: () => {}
-				},
 				useOfFundsContent
 			},
 			global: {
@@ -48,11 +48,30 @@ describe( 'BannerCtrl.vue', () => {
 	describe( 'Content', () => {
 		test.each( [
 			[ 'expectSlideShowPlaysWhenBecomesVisible' ],
-			[ 'expectSlideShowStopsOnFormInteraction' ],
+			[ 'expectSlideShowStopsOnFormInteraction' ]
+		] )( '%s', async ( testName: string ) => {
+			await desktopContentFeatures[ testName ]( getWrapper() );
+		} );
+
+		test.each( [
 			[ 'expectShowsSlideShowOnSmallSizes' ],
 			[ 'expectShowsMessageOnSmallSizes' ]
 		] )( '%s', async ( testName: string ) => {
-			await desktopContentFeatures[ testName ]( getWrapper );
+			await desktopContentDisplaySwitchFeatures[ testName ]( getWrapper );
+		} );
+	} );
+
+	describe( 'Donation Form Happy Paths', () => {
+		test.each( [
+			[ 'expectMainDonationFormSubmitsWhenSofortIsSelected' ],
+			[ 'expectMainDonationFormSubmitsWhenYearlyIsSelected' ],
+			[ 'expectMainDonationFormGoesToUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsDontUpgrade' ],
+			[ 'expectUpgradeToYearlyFormGoesToCustomAmount' ],
+			[ 'expectCustomAmountFormSubmits' ]
+		] )( '%s', async ( testName: string ) => {
+			await donationFormFeatures[ testName ]( getWrapper() );
 		} );
 	} );
 

--- a/test/banners/english/components/BannerVar.spec.ts
+++ b/test/banners/english/components/BannerVar.spec.ts
@@ -1,4 +1,4 @@
-import { describe, test } from 'vitest';
+import { beforeEach, describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/english/components/BannerVar.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -8,26 +8,26 @@ import { formItems } from '@test/banners/formItems';
 import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
 import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
-import { desktopContentFeatures } from '@test/features/DesktopContent';
+import { desktopContentDisplaySwitchFeatures, desktopContentFeatures } from '@test/features/DesktopContent';
 import { alreadyDonatedModalFeatures } from '@test/features/AlreadyDonatedModal';
 import { TrackerStub } from '@test/fixtures/TrackerStub';
+import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearly_CustomAmount';
+import { resetFormModel } from '@test/resetFormModel';
+import { useFormModel } from '@src/components/composables/useFormModel';
 
+const formModel = useFormModel();
 const translator = ( key: string ): string => key;
 
 describe( 'BannerVar.vue', () => {
+
+	beforeEach( () => {
+		resetFormModel( formModel );
+	} );
+
 	const getWrapper = (): VueWrapper<any> => {
 		return mount( Banner, {
 			props: {
 				bannerState: BannerStates.Pending,
-				formController: {
-					submitStep: () => {},
-					next: () => {},
-					previous: () => {},
-					onNext: () => {},
-					onPrevious: () => {},
-					onGoToStep: () => {},
-					onSubmit: () => {}
-				},
 				useOfFundsContent
 			},
 			global: {
@@ -49,11 +49,30 @@ describe( 'BannerVar.vue', () => {
 	describe( 'Content', () => {
 		test.each( [
 			[ 'expectSlideShowPlaysWhenBecomesVisible' ],
-			[ 'expectSlideShowStopsOnFormInteraction' ],
+			[ 'expectSlideShowStopsOnFormInteraction' ]
+		] )( '%s', async ( testName: string ) => {
+			await desktopContentFeatures[ testName ]( getWrapper() );
+		} );
+
+		test.each( [
 			[ 'expectShowsSlideShowOnSmallSizes' ],
 			[ 'expectShowsMessageOnSmallSizes' ]
 		] )( '%s', async ( testName: string ) => {
-			await desktopContentFeatures[ testName ]( getWrapper );
+			await desktopContentDisplaySwitchFeatures[ testName ]( getWrapper );
+		} );
+	} );
+
+	describe( 'Donation Form Happy Paths', () => {
+		test.each( [
+			[ 'expectMainDonationFormSubmitsWhenSofortIsSelected' ],
+			[ 'expectMainDonationFormSubmitsWhenYearlyIsSelected' ],
+			[ 'expectMainDonationFormGoesToUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsDontUpgrade' ],
+			[ 'expectUpgradeToYearlyFormGoesToCustomAmount' ],
+			[ 'expectCustomAmountFormSubmits' ]
+		] )( '%s', async ( testName: string ) => {
+			await donationFormFeatures[ testName ]( getWrapper() );
 		} );
 	} );
 

--- a/test/banners/formItems.ts
+++ b/test/banners/formItems.ts
@@ -4,11 +4,11 @@ import { Intervals } from '@src/utils/FormItemsBuilder/fields/Intervals';
 import { PaymentMethods } from '@src/utils/FormItemsBuilder/fields/PaymentMethods';
 
 export const formItems: DonationFormItems = {
-	addressType: [ AddressTypes.ANONYMOUS, AddressTypes.EMAIL ],
+	addressType: [ AddressTypes.FULL, AddressTypes.ANONYMOUS, AddressTypes.EMAIL ],
 	amounts: [
 		{ value: '1', label: '€1', className: 'amount-1' },
 		{ value: '5', label: '€5', className: 'amount-5' }
 	],
-	intervals: [ Intervals.ONCE, Intervals.MONTHLY ],
-	paymentMethods: [ PaymentMethods.PAYPAL, PaymentMethods.CREDIT_CARD ]
+	intervals: [ Intervals.ONCE, Intervals.MONTHLY, Intervals.QUARTERLY, Intervals.YEARLY ],
+	paymentMethods: [ PaymentMethods.PAYPAL, PaymentMethods.CREDIT_CARD, PaymentMethods.SOFORT, PaymentMethods.DIRECT_DEBIT, PaymentMethods.BANK_TRANSFER ]
 };

--- a/test/banners/mobile/components/BannerCtrl.spec.ts
+++ b/test/banners/mobile/components/BannerCtrl.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, vi, test } from 'vitest';
+import { beforeEach, describe, vi, test, afterEach } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/mobile/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -11,32 +11,31 @@ import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { softCloseFeatures } from '@test/features/SoftCloseMobile';
 import { useOfFundsFeatures, useOfFundsScrollFeatures } from '@test/features/UseOfFunds';
 import { miniBannerFeatures } from '@test/features/MiniBanner';
+import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
+import { useFormModel } from '@src/components/composables/useFormModel';
+import { resetFormModel } from '@test/resetFormModel';
 
 let pageScroller: PageScroller;
+const formModel = useFormModel();
 const translator = ( key: string ): string => key;
 
 describe( 'BannerCtrl.vue', () => {
 
 	let wrapper: VueWrapper<any>;
 	beforeEach( () => {
+		resetFormModel( formModel );
+
 		pageScroller = {
 			scrollIntoView: vi.fn(),
 			scrollToTop: vi.fn()
 		};
 
+		// attachTo the document body to fix an issue with Vue Test Utils where
+		// clicking a submit button in a form does not fire the submit event
 		wrapper = mount( Banner, {
+			attachTo: document.body,
 			props: {
 				bannerState: BannerStates.Pending,
-				formController: {
-					submitStep: () => {},
-					next: () => {},
-					previous: () => {},
-					onNext: () => {},
-					onPrevious: () => {},
-					onGoToStep: () => {},
-					onSubmit: () => {}
-				},
-				forms: [],
 				useOfFundsContent,
 				pageScroller
 			},
@@ -53,6 +52,23 @@ describe( 'BannerCtrl.vue', () => {
 					tracker: new TrackerStub()
 				}
 			}
+		} );
+	} );
+
+	afterEach( () => {
+		wrapper.unmount();
+	} );
+
+	describe( 'Donation Form Happy Paths', () => {
+		test.each( [
+			[ 'expectMainDonationFormSubmitsWhenSofortIsSelected' ],
+			[ 'expectMainDonationFormSubmitsWhenYearlyIsSelected' ],
+			[ 'expectMainDonationFormGoesToUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsDontUpgrade' ],
+			[ 'expectUpgradeToYearlyFormGoesToMainDonation' ]
+		] )( '%s', async ( testName: string ) => {
+			await donationFormFeatures[ testName ]( wrapper );
 		} );
 	} );
 

--- a/test/banners/mobile_english/components/BannerCtrl.spec.ts
+++ b/test/banners/mobile_english/components/BannerCtrl.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, vi, test } from 'vitest';
+import { beforeEach, describe, vi, test, it } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/mobile_english/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -11,14 +11,22 @@ import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { softCloseFeatures } from '@test/features/SoftCloseMobile';
 import { useOfFundsFeatures, useOfFundsScrollFeatures } from '@test/features/UseOfFunds';
 import { miniBannerFeatures } from '@test/features/MiniBanner';
+import { expectMainDonationFormSubmits } from '@test/features/forms/subForms/MainDonationForm';
+import { Intervals } from '@src/utils/FormItemsBuilder/fields/Intervals';
+import { PaymentMethods } from '@src/utils/FormItemsBuilder/fields/PaymentMethods';
+import { resetFormModel } from '@test/resetFormModel';
+import { useFormModel } from '@src/components/composables/useFormModel';
 
 let pageScroller: PageScroller;
+const formModel = useFormModel();
 const translator = ( key: string ): string => key;
 
 describe( 'BannerCtrl.vue', () => {
 
 	let wrapper: VueWrapper<any>;
 	beforeEach( () => {
+		resetFormModel( formModel );
+
 		pageScroller = {
 			scrollIntoView: vi.fn(),
 			scrollToTop: vi.fn()
@@ -27,16 +35,6 @@ describe( 'BannerCtrl.vue', () => {
 		wrapper = mount( Banner, {
 			props: {
 				bannerState: BannerStates.Pending,
-				formController: {
-					submitStep: () => {},
-					next: () => {},
-					previous: () => {},
-					onNext: () => {},
-					onPrevious: () => {},
-					onGoToStep: () => {},
-					onSubmit: () => {}
-				},
-				forms: [],
 				useOfFundsContent,
 				pageScroller
 			},
@@ -53,6 +51,12 @@ describe( 'BannerCtrl.vue', () => {
 					tracker: new TrackerStub()
 				}
 			}
+		} );
+	} );
+
+	describe( 'Donation Form Happy Paths', () => {
+		it( 'Submits the main donation form', () => {
+			expectMainDonationFormSubmits( wrapper, Intervals.ONCE, PaymentMethods.PAYPAL );
 		} );
 	} );
 

--- a/test/banners/mobile_english/components/BannerVar.spec.ts
+++ b/test/banners/mobile_english/components/BannerVar.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, vi, test } from 'vitest';
+import { beforeEach, describe, vi, test, it } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/mobile_english/components/BannerVar.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -11,14 +11,22 @@ import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { softCloseFeatures } from '@test/features/SoftCloseMobile';
 import { useOfFundsFeatures, useOfFundsScrollFeatures } from '@test/features/UseOfFunds';
 import { miniBannerFeatures } from '@test/features/MiniBanner';
+import { expectMainDonationFormSubmits } from '@test/features/forms/subForms/MainDonationForm';
+import { Intervals } from '@src/utils/FormItemsBuilder/fields/Intervals';
+import { PaymentMethods } from '@src/utils/FormItemsBuilder/fields/PaymentMethods';
+import { useFormModel } from '@src/components/composables/useFormModel';
+import { resetFormModel } from '@test/resetFormModel';
 
 let pageScroller: PageScroller;
+const formModel = useFormModel();
 const translator = ( key: string ): string => key;
 
 describe( 'BannerVar.vue', () => {
 
 	let wrapper: VueWrapper<any>;
 	beforeEach( () => {
+		resetFormModel( formModel );
+
 		pageScroller = {
 			scrollIntoView: vi.fn(),
 			scrollToTop: vi.fn()
@@ -27,16 +35,6 @@ describe( 'BannerVar.vue', () => {
 		wrapper = mount( Banner, {
 			props: {
 				bannerState: BannerStates.Pending,
-				formController: {
-					submitStep: () => {},
-					next: () => {},
-					previous: () => {},
-					onNext: () => {},
-					onPrevious: () => {},
-					onGoToStep: () => {},
-					onSubmit: () => {}
-				},
-				forms: [],
 				useOfFundsContent,
 				pageScroller
 			},
@@ -53,6 +51,12 @@ describe( 'BannerVar.vue', () => {
 					tracker: new TrackerStub()
 				}
 			}
+		} );
+	} );
+
+	describe( 'Donation Form Happy Paths', () => {
+		it( 'Submits the main donation form', () => {
+			expectMainDonationFormSubmits( wrapper, Intervals.ONCE, PaymentMethods.PAYPAL );
 		} );
 	} );
 

--- a/test/banners/pad/components/BannerVar.spec.ts
+++ b/test/banners/pad/components/BannerVar.spec.ts
@@ -1,4 +1,4 @@
-import { describe, test } from 'vitest';
+import { afterEach, beforeEach, describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/pad/components/BannerVar.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -11,23 +11,24 @@ import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
 import { desktopContentFeatures } from '@test/features/DesktopContent';
 import { alreadyDonatedModalFeatures } from '@test/features/AlreadyDonatedModal';
+import { resetFormModel } from '@test/resetFormModel';
+import { useFormModel } from '@src/components/composables/useFormModel';
+import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
 
+const formModel = useFormModel();
 const translator = ( key: string ): string => key;
 
 describe( 'BannerVar.vue', () => {
-	const getWrapper = (): VueWrapper<any> => {
-		return mount( Banner, {
+	let wrapper: VueWrapper<any>;
+	beforeEach( () => {
+		resetFormModel( formModel );
+
+		// attachTo the document body to fix an issue with Vue Test Utils where
+		// clicking a submit button in a form does not fire the submit event
+		wrapper = mount( Banner, {
+			attachTo: document.body,
 			props: {
 				bannerState: BannerStates.Pending,
-				formController: {
-					submitStep: () => {},
-					next: () => {},
-					previous: () => {},
-					onNext: () => {},
-					onPrevious: () => {},
-					onGoToStep: () => {},
-					onSubmit: () => {}
-				},
 				useOfFundsContent
 			},
 			global: {
@@ -44,14 +45,31 @@ describe( 'BannerVar.vue', () => {
 				}
 			}
 		} );
-	};
+	} );
+
+	afterEach( () => {
+		wrapper.unmount();
+	} );
 
 	describe( 'Content', () => {
 		test.each( [
 			[ 'expectSlideShowPlaysWhenBecomesVisible' ],
 			[ 'expectSlideShowStopsOnFormInteraction' ]
 		] )( '%s', async ( testName: string ) => {
-			await desktopContentFeatures[ testName ]( getWrapper );
+			await desktopContentFeatures[ testName ]( wrapper );
+		} );
+	} );
+
+	describe( 'Donation Form Happy Paths', () => {
+		test.each( [
+			[ 'expectMainDonationFormSubmitsWhenSofortIsSelected' ],
+			[ 'expectMainDonationFormSubmitsWhenYearlyIsSelected' ],
+			[ 'expectMainDonationFormGoesToUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsDontUpgrade' ],
+			[ 'expectUpgradeToYearlyFormGoesToMainDonation' ]
+		] )( '%s', async ( testName: string ) => {
+			await donationFormFeatures[ testName ]( wrapper );
 		} );
 	} );
 
@@ -63,7 +81,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ]
 		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper() );
+			await softCloseFeatures[ testName ]( wrapper );
 		} );
 	} );
 
@@ -72,7 +90,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectShowsUseOfFunds' ],
 			[ 'expectHidesUseOfFunds' ]
 		] )( '%s', async ( testName: string ) => {
-			await useOfFundsFeatures[ testName ]( getWrapper() );
+			await useOfFundsFeatures[ testName ]( wrapper );
 		} );
 	} );
 
@@ -83,7 +101,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectFiresMaybeLaterEvent' ],
 			[ 'expectFiresGoAwayEvent' ]
 		] )( '%s', async ( testName: string ) => {
-			await alreadyDonatedModalFeatures[ testName ]( getWrapper() );
+			await alreadyDonatedModalFeatures[ testName ]( wrapper );
 		} );
 	} );
 

--- a/test/banners/pad_english/components/BannerCtrl.spec.ts
+++ b/test/banners/pad_english/components/BannerCtrl.spec.ts
@@ -1,4 +1,4 @@
-import { describe, test } from 'vitest';
+import { afterEach, beforeEach, describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/pad_english/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -9,23 +9,24 @@ import { formItems } from '@test/banners/formItems';
 import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
 import { desktopContentFeatures } from '@test/features/DesktopContent';
+import { resetFormModel } from '@test/resetFormModel';
+import { useFormModel } from '@src/components/composables/useFormModel';
+import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton_CustomAmount';
 
+const formModel = useFormModel();
 const translator = ( key: string ): string => key;
 
 describe( 'BannerCtrl.vue', () => {
-	const getWrapper = (): VueWrapper<any> => {
-		return mount( Banner, {
+	let wrapper: VueWrapper<any>;
+	beforeEach( () => {
+		resetFormModel( formModel );
+
+		// attachTo the document body to fix an issue with Vue Test Utils where
+		// clicking a submit button in a form does not fire the submit event
+		wrapper = mount( Banner, {
+			attachTo: document.body,
 			props: {
 				bannerState: BannerStates.Pending,
-				formController: {
-					submitStep: () => {},
-					next: () => {},
-					previous: () => {},
-					onNext: () => {},
-					onPrevious: () => {},
-					onGoToStep: () => {},
-					onSubmit: () => {}
-				},
 				useOfFundsContent
 			},
 			global: {
@@ -35,21 +36,39 @@ describe( 'BannerCtrl.vue', () => {
 				provide: {
 					translator: { translate: translator },
 					dynamicCampaignText: dynamicCampaignContent,
-					formActions: {},
+					formActions: { donateWithAddressAction: 'https://example.com', donateWithoutAddressAction: 'https://example.com' },
 					currencyFormatter: new CurrencyEn(),
 					formItems,
 					tracker: new TrackerStub()
 				}
 			}
 		} );
-	};
+	} );
+
+	afterEach( () => {
+		wrapper.unmount();
+	} );
 
 	describe( 'Content', () => {
 		test.each( [
 			[ 'expectSlideShowPlaysWhenBecomesVisible' ],
 			[ 'expectSlideShowStopsOnFormInteraction' ]
 		] )( '%s', async ( testName: string ) => {
-			await desktopContentFeatures[ testName ]( getWrapper );
+			await desktopContentFeatures[ testName ]( wrapper );
+		} );
+	} );
+
+	describe( 'Donation Form Happy Paths', () => {
+		test.each( [
+			[ 'expectMainDonationFormSubmitsWhenSofortIsSelected' ],
+			[ 'expectMainDonationFormSubmitsWhenYearlyIsSelected' ],
+			[ 'expectMainDonationFormGoesToUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsDontUpgrade' ],
+			[ 'expectUpgradeToYearlyFormGoesCustomAmount' ],
+			[ 'expectCustomAmountFormSubmits' ]
+		] )( '%s', async ( testName: string ) => {
+			await donationFormFeatures[ testName ]( wrapper );
 		} );
 	} );
 
@@ -58,7 +77,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectShowsUseOfFunds' ],
 			[ 'expectHidesUseOfFunds' ]
 		] )( '%s', async ( testName: string ) => {
-			await useOfFundsFeatures[ testName ]( getWrapper() );
+			await useOfFundsFeatures[ testName ]( wrapper );
 		} );
 	} );
 

--- a/test/banners/pad_english/components/BannerVar.spec.ts
+++ b/test/banners/pad_english/components/BannerVar.spec.ts
@@ -1,4 +1,4 @@
-import { describe, test } from 'vitest';
+import { afterEach, beforeEach, describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/pad_english/components/BannerVar.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -9,23 +9,24 @@ import { formItems } from '@test/banners/formItems';
 import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
 import { desktopContentFeatures } from '@test/features/DesktopContent';
+import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton_CustomAmount';
+import { useFormModel } from '@src/components/composables/useFormModel';
+import { resetFormModel } from '@test/resetFormModel';
 
+const formModel = useFormModel();
 const translator = ( key: string ): string => key;
 
 describe( 'BannerVar.vue', () => {
-	const getWrapper = (): VueWrapper<any> => {
-		return mount( Banner, {
+	let wrapper: VueWrapper<any>;
+	beforeEach( () => {
+		resetFormModel( formModel );
+
+		// attachTo the document body to fix an issue with Vue Test Utils where
+		// clicking a submit button in a form does not fire the submit event
+		wrapper = mount( Banner, {
+			attachTo: document.body,
 			props: {
 				bannerState: BannerStates.Pending,
-				formController: {
-					submitStep: () => {},
-					next: () => {},
-					previous: () => {},
-					onNext: () => {},
-					onPrevious: () => {},
-					onGoToStep: () => {},
-					onSubmit: () => {}
-				},
 				useOfFundsContent
 			},
 			global: {
@@ -35,21 +36,39 @@ describe( 'BannerVar.vue', () => {
 				provide: {
 					translator: { translate: translator },
 					dynamicCampaignText: dynamicCampaignContent,
-					formActions: {},
+					formActions: { donateWithAddressAction: 'https://example.com', donateWithoutAddressAction: 'https://example.com' },
 					currencyFormatter: new CurrencyEn(),
 					formItems,
 					tracker: new TrackerStub()
 				}
 			}
 		} );
-	};
+	} );
+
+	afterEach( () => {
+		wrapper.unmount();
+	} );
 
 	describe( 'Content', () => {
 		test.each( [
 			[ 'expectSlideShowPlaysWhenBecomesVisible' ],
 			[ 'expectSlideShowStopsOnFormInteraction' ]
 		] )( '%s', async ( testName: string ) => {
-			await desktopContentFeatures[ testName ]( getWrapper );
+			await desktopContentFeatures[ testName ]( wrapper );
+		} );
+	} );
+
+	describe( 'Donation Form Happy Paths', () => {
+		test.each( [
+			[ 'expectMainDonationFormSubmitsWhenSofortIsSelected' ],
+			[ 'expectMainDonationFormSubmitsWhenYearlyIsSelected' ],
+			[ 'expectMainDonationFormGoesToUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsDontUpgrade' ],
+			[ 'expectUpgradeToYearlyFormGoesCustomAmount' ],
+			[ 'expectCustomAmountFormSubmits' ]
+		] )( '%s', async ( testName: string ) => {
+			await donationFormFeatures[ testName ]( wrapper );
 		} );
 	} );
 
@@ -58,7 +77,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectShowsUseOfFunds' ],
 			[ 'expectHidesUseOfFunds' ]
 		] )( '%s', async ( testName: string ) => {
-			await useOfFundsFeatures[ testName ]( getWrapper() );
+			await useOfFundsFeatures[ testName ]( wrapper );
 		} );
 	} );
 

--- a/test/banners/wpde_desktop/components/BannerCtrl.spec.ts
+++ b/test/banners/wpde_desktop/components/BannerCtrl.spec.ts
@@ -1,4 +1,4 @@
-import { describe, test } from 'vitest';
+import { beforeEach, describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/wpde_desktop/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -7,25 +7,25 @@ import { useOfFundsContent } from '@test/banners/useOfFundsContent';
 import { formItems } from '@test/banners/formItems';
 import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
-import { desktopContentFeatures } from '@test/features/DesktopContent';
+import { desktopContentDisplaySwitchFeatures, desktopContentFeatures } from '@test/features/DesktopContent';
 import { TrackerStub } from '@test/fixtures/TrackerStub';
+import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearly_CustomAmount';
+import { useFormModel } from '@src/components/composables/useFormModel';
+import { resetFormModel } from '@test/resetFormModel';
 
+const formModel = useFormModel();
 const translator = ( key: string ): string => key;
 
 describe( 'BannerCtrl.vue', () => {
+
+	beforeEach( () => {
+		resetFormModel( formModel );
+	} );
+
 	const getWrapper = (): VueWrapper<any> => {
 		return mount( Banner, {
 			props: {
 				bannerState: BannerStates.Pending,
-				formController: {
-					submitStep: () => {},
-					next: () => {},
-					previous: () => {},
-					onNext: () => {},
-					onPrevious: () => {},
-					onGoToStep: () => {},
-					onSubmit: () => {}
-				},
 				useOfFundsContent
 			},
 			global: {
@@ -47,11 +47,30 @@ describe( 'BannerCtrl.vue', () => {
 	describe( 'Content', () => {
 		test.each( [
 			[ 'expectSlideShowPlaysWhenBecomesVisible' ],
-			[ 'expectSlideShowStopsOnFormInteraction' ],
+			[ 'expectSlideShowStopsOnFormInteraction' ]
+		] )( '%s', async ( testName: string ) => {
+			await desktopContentFeatures[ testName ]( getWrapper() );
+		} );
+
+		test.each( [
 			[ 'expectShowsSlideShowOnSmallSizes' ],
 			[ 'expectShowsMessageOnSmallSizes' ]
 		] )( '%s', async ( testName: string ) => {
-			await desktopContentFeatures[ testName ]( getWrapper );
+			await desktopContentDisplaySwitchFeatures[ testName ]( getWrapper );
+		} );
+	} );
+
+	describe( 'Donation Form Happy Paths', () => {
+		test.each( [
+			[ 'expectMainDonationFormSubmitsWhenSofortIsSelected' ],
+			[ 'expectMainDonationFormSubmitsWhenYearlyIsSelected' ],
+			[ 'expectMainDonationFormGoesToUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsDontUpgrade' ],
+			[ 'expectUpgradeToYearlyFormGoesToCustomAmount' ],
+			[ 'expectCustomAmountFormSubmits' ]
+		] )( '%s', async ( testName: string ) => {
+			await donationFormFeatures[ testName ]( getWrapper() );
 		} );
 	} );
 

--- a/test/features/DesktopContent.ts
+++ b/test/features/DesktopContent.ts
@@ -2,17 +2,15 @@ import { VueWrapper } from '@vue/test-utils';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
 import { expect, vi } from 'vitest';
 
-const expectSlideShowPlaysWhenBecomesVisible = async ( getWrapper: () => VueWrapper<any> ): Promise<any> => {
-	const wrapper = getWrapper();
+const expectSlideShowPlaysWhenBecomesVisible = async ( wrapper: VueWrapper<any> ): Promise<any> => {
 	await wrapper.setProps( { bannerState: BannerStates.Visible } );
 
 	expect( wrapper.find( '.wmde-banner-slider--playing' ).exists() ).toBeTruthy();
 };
 
-const expectSlideShowStopsOnFormInteraction = async ( getWrapper: () => VueWrapper<any> ): Promise<any> => {
+const expectSlideShowStopsOnFormInteraction = async ( wrapper: VueWrapper<any> ): Promise<any> => {
 	vi.useFakeTimers();
 
-	const wrapper = getWrapper();
 	await wrapper.setProps( { bannerState: BannerStates.Visible } );
 	await wrapper.find( '.wmde-banner-form' ).trigger( 'click' );
 	await vi.runOnlyPendingTimers();
@@ -38,9 +36,12 @@ const expectShowsMessageOnSmallSizes = async ( getWrapper: () => VueWrapper<any>
 	expect( wrapper.find( '.wmde-banner-message' ).exists() ).toBeTruthy();
 };
 
-export const desktopContentFeatures: Record<string, ( getWrapper: () => VueWrapper<any> ) => Promise<any>> = {
+export const desktopContentFeatures: Record<string, ( wrapper: VueWrapper<any> ) => Promise<any>> = {
 	expectSlideShowPlaysWhenBecomesVisible,
-	expectSlideShowStopsOnFormInteraction,
+	expectSlideShowStopsOnFormInteraction
+};
+
+export const desktopContentDisplaySwitchFeatures: Record<string, ( getWrapper: () => VueWrapper<any> ) => Promise<any>> = {
 	expectShowsSlideShowOnSmallSizes,
 	expectShowsMessageOnSmallSizes
 };

--- a/test/features/forms/MainDonation_UpgradeToYearlyButton.ts
+++ b/test/features/forms/MainDonation_UpgradeToYearlyButton.ts
@@ -1,0 +1,47 @@
+import { VueWrapper } from '@vue/test-utils';
+import {
+	expectMainDonationFormGoesToPageOnSubmit,
+	expectMainDonationFormSubmits,
+	submitMainDonationForm
+} from '@test/features/forms/subForms/MainDonationForm';
+import {
+	expectUpgradeToYearlyFormGoesToPageOnLinkClick,
+	expectUpgradeToYearlyFormSubmits
+} from '@test/features/forms/subForms/UpgradeToYearlyButtonForm';
+import { Intervals } from '@src/utils/FormItemsBuilder/fields/Intervals';
+import { PaymentMethods } from '@src/utils/FormItemsBuilder/fields/PaymentMethods';
+
+enum Pages {
+	MainDonation = 1,
+	UpgradeToYearly = 2
+}
+
+export const donationFormFeatures: Record<string, ( wrapper: VueWrapper<any> ) => Promise<any>> = {
+	expectMainDonationFormSubmitsWhenSofortIsSelected: ( wrapper: VueWrapper<any> ) => expectMainDonationFormSubmits(
+		wrapper,
+		Intervals.ONCE,
+		PaymentMethods.SOFORT
+	),
+	expectMainDonationFormSubmitsWhenYearlyIsSelected: ( wrapper: VueWrapper<any> ) => expectMainDonationFormSubmits(
+		wrapper,
+		Intervals.YEARLY,
+		PaymentMethods.PAYPAL
+	),
+	expectMainDonationFormGoesToUpgrade: ( wrapper: VueWrapper<any> ) => expectMainDonationFormGoesToPageOnSubmit( wrapper,
+		Pages.UpgradeToYearly,
+		Intervals.ONCE,
+		PaymentMethods.PAYPAL
+	),
+	expectUpgradeToYearlyFormSubmitsUpgrade: async ( wrapper: VueWrapper<any> ) => {
+		await submitMainDonationForm( wrapper, Intervals.ONCE, '5', PaymentMethods.PAYPAL );
+		await expectUpgradeToYearlyFormSubmits( wrapper, 'yes' );
+	},
+	expectUpgradeToYearlyFormSubmitsDontUpgrade: async ( wrapper: VueWrapper<any> ) => {
+		await submitMainDonationForm( wrapper, Intervals.ONCE, '5', PaymentMethods.PAYPAL );
+		await expectUpgradeToYearlyFormSubmits( wrapper, 'no' );
+	},
+	expectUpgradeToYearlyFormGoesToMainDonation: async ( wrapper: VueWrapper<any> ) => {
+		await submitMainDonationForm( wrapper, Intervals.ONCE, '5', PaymentMethods.PAYPAL );
+		await expectUpgradeToYearlyFormGoesToPageOnLinkClick( wrapper, Pages.MainDonation );
+	}
+};

--- a/test/features/forms/MainDonation_UpgradeToYearlyButton_AddressTypeButton.ts
+++ b/test/features/forms/MainDonation_UpgradeToYearlyButton_AddressTypeButton.ts
@@ -1,0 +1,55 @@
+import { VueWrapper } from '@vue/test-utils';
+import {
+	expectMainDonationFormGoesToPageOnSubmit,
+	submitMainDonationForm
+} from '@test/features/forms/subForms/MainDonationForm';
+import {
+	expectUpgradeToYearlyFormGoesToPageOnLinkClick,
+	expectUpgradeToYearlyFormGoesToPageOnSubmit
+} from '@test/features/forms/subForms/UpgradeToYearlyButtonForm';
+import { Intervals } from '@src/utils/FormItemsBuilder/fields/Intervals';
+import { PaymentMethods } from '@src/utils/FormItemsBuilder/fields/PaymentMethods';
+import { expectAddressTypeFormSubmits } from '@test/features/forms/subForms/AddressTypeButtonForm';
+import { AddressTypes } from '@src/utils/FormItemsBuilder/fields/AddressTypes';
+
+enum Pages {
+	MainDonation = 1,
+	UpgradeToYearly = 2,
+	AddressType = 3,
+}
+
+export const donationFormFeatures: Record<string, ( wrapper: VueWrapper<any> ) => Promise<any>> = {
+	expectMainDonationFormGoesToAddressFormWhenSofortIsSelected: ( wrapper: VueWrapper<any> ) => expectMainDonationFormGoesToPageOnSubmit(
+		wrapper,
+		Pages.AddressType,
+		Intervals.ONCE,
+		PaymentMethods.SOFORT
+	),
+	expectMainDonationFormGoesToAddressFormWhenYearlyIsSelected: ( wrapper: VueWrapper<any> ) => expectMainDonationFormGoesToPageOnSubmit(
+		wrapper,
+		Pages.AddressType,
+		Intervals.YEARLY,
+		PaymentMethods.PAYPAL
+	),
+	expectMainDonationFormGoesToUpgrade: ( wrapper: VueWrapper<any> ) => expectMainDonationFormGoesToPageOnSubmit( wrapper,
+		Pages.UpgradeToYearly,
+		Intervals.ONCE,
+		PaymentMethods.PAYPAL
+	),
+	expectUpgradeToYearlyFormGoesToAddressTypeOnUpgrade: async ( wrapper: VueWrapper<any> ) => {
+		await submitMainDonationForm( wrapper, Intervals.ONCE, '5', PaymentMethods.PAYPAL );
+		await expectUpgradeToYearlyFormGoesToPageOnSubmit( wrapper, Pages.AddressType, 'yes' );
+	},
+	expectUpgradeToYearlyFormGoesToAddressTypeOnDontUpgrade: async ( wrapper: VueWrapper<any> ) => {
+		await submitMainDonationForm( wrapper, Intervals.ONCE, '5', PaymentMethods.PAYPAL );
+		await expectUpgradeToYearlyFormGoesToPageOnSubmit( wrapper, Pages.AddressType, 'no' );
+	},
+	expectUpgradeToYearlyFormGoesToMainDonation: async ( wrapper: VueWrapper<any> ) => {
+		await submitMainDonationForm( wrapper, Intervals.ONCE, '5', PaymentMethods.PAYPAL );
+		await expectUpgradeToYearlyFormGoesToPageOnLinkClick( wrapper, Pages.MainDonation );
+	},
+	expectAddressTypeButtonFormSubmits: async ( wrapper: VueWrapper<any> )=> {
+		await submitMainDonationForm( wrapper, Intervals.YEARLY, '5', PaymentMethods.PAYPAL );
+		await expectAddressTypeFormSubmits( wrapper, AddressTypes.FULL );
+	}
+};

--- a/test/features/forms/MainDonation_UpgradeToYearlyButton_CustomAmount.ts
+++ b/test/features/forms/MainDonation_UpgradeToYearlyButton_CustomAmount.ts
@@ -1,0 +1,53 @@
+import { VueWrapper } from '@vue/test-utils';
+import {
+	expectMainDonationFormGoesToPageOnSubmit,
+	expectMainDonationFormSubmits,
+	submitMainDonationForm
+} from '@test/features/forms/subForms/MainDonationForm';
+import {
+	expectUpgradeToYearlyFormGoesToPageOnLinkClick,
+	expectUpgradeToYearlyFormSubmits
+} from '@test/features/forms/subForms/UpgradeToYearlyButtonForm';
+import { Intervals } from '@src/utils/FormItemsBuilder/fields/Intervals';
+import { PaymentMethods } from '@src/utils/FormItemsBuilder/fields/PaymentMethods';
+import { expectCustomAmountFormSubmits } from '@test/features/forms/subForms/CustomAmountForm';
+
+enum Pages {
+	UpgradeToYearly = 2,
+	CustomAmount = 3
+}
+
+export const donationFormFeatures: Record<string, ( wrapper: VueWrapper<any> ) => Promise<any>> = {
+	expectMainDonationFormSubmitsWhenSofortIsSelected: ( wrapper: VueWrapper<any> ) => expectMainDonationFormSubmits(
+		wrapper,
+		Intervals.ONCE,
+		PaymentMethods.SOFORT
+	),
+	expectMainDonationFormSubmitsWhenYearlyIsSelected: ( wrapper: VueWrapper<any> ) => expectMainDonationFormSubmits(
+		wrapper,
+		Intervals.YEARLY,
+		PaymentMethods.PAYPAL
+	),
+	expectMainDonationFormGoesToUpgrade: ( wrapper: VueWrapper<any> ) => expectMainDonationFormGoesToPageOnSubmit( wrapper,
+		Pages.UpgradeToYearly,
+		Intervals.ONCE,
+		PaymentMethods.PAYPAL
+	),
+	expectUpgradeToYearlyFormSubmitsUpgrade: async ( wrapper: VueWrapper<any> ) => {
+		await submitMainDonationForm( wrapper, Intervals.ONCE, '5', PaymentMethods.PAYPAL );
+		await expectUpgradeToYearlyFormSubmits( wrapper, 'yes' );
+	},
+	expectUpgradeToYearlyFormSubmitsDontUpgrade: async ( wrapper: VueWrapper<any> ) => {
+		await submitMainDonationForm( wrapper, Intervals.ONCE, '5', PaymentMethods.PAYPAL );
+		await expectUpgradeToYearlyFormSubmits( wrapper, 'no' );
+	},
+	expectUpgradeToYearlyFormGoesCustomAmount: async ( wrapper: VueWrapper<any> ) => {
+		await submitMainDonationForm( wrapper, Intervals.ONCE, '5', PaymentMethods.PAYPAL );
+		await expectUpgradeToYearlyFormGoesToPageOnLinkClick( wrapper, Pages.CustomAmount );
+	},
+	expectCustomAmountFormSubmits: async ( wrapper: VueWrapper<any> ) => {
+		await submitMainDonationForm( wrapper, Intervals.ONCE, '5', PaymentMethods.PAYPAL );
+		await wrapper.find( '.wmde-banner-form-upgrade-custom' ).trigger( 'click' );
+		await expectCustomAmountFormSubmits( wrapper, '10' );
+	}
+};

--- a/test/features/forms/MainDonation_UpgradeToYearly_CustomAmount.ts
+++ b/test/features/forms/MainDonation_UpgradeToYearly_CustomAmount.ts
@@ -1,0 +1,53 @@
+import { VueWrapper } from '@vue/test-utils';
+import {
+	expectMainDonationFormGoesToPageOnSubmit,
+	expectMainDonationFormSubmits,
+	submitMainDonationForm
+} from '@test/features/forms/subForms/MainDonationForm';
+import {
+	expectUpgradeToYearlyFormGoesToPageOnLinkClick,
+	expectUpgradeToYearlyFormSubmits
+} from '@test/features/forms/subForms/UpgradeToYearlyForm';
+import { Intervals } from '@src/utils/FormItemsBuilder/fields/Intervals';
+import { PaymentMethods } from '@src/utils/FormItemsBuilder/fields/PaymentMethods';
+import { expectCustomAmountFormSubmits } from '@test/features/forms/subForms/CustomAmountForm';
+
+enum Pages {
+	UpgradeToYearly = 2,
+	CustomAmount = 3,
+}
+
+export const donationFormFeatures: Record<string, ( wrapper: VueWrapper<any> ) => Promise<any>> = {
+	expectMainDonationFormSubmitsWhenSofortIsSelected: ( wrapper: VueWrapper<any> ) => expectMainDonationFormSubmits(
+		wrapper,
+		Intervals.ONCE,
+		PaymentMethods.SOFORT
+	),
+	expectMainDonationFormSubmitsWhenYearlyIsSelected: ( wrapper: VueWrapper<any> ) => expectMainDonationFormSubmits(
+		wrapper,
+		Intervals.YEARLY,
+		PaymentMethods.PAYPAL
+	),
+	expectMainDonationFormGoesToUpgrade: ( wrapper: VueWrapper<any> ) => expectMainDonationFormGoesToPageOnSubmit( wrapper,
+		Pages.UpgradeToYearly,
+		Intervals.ONCE,
+		PaymentMethods.PAYPAL
+	),
+	expectUpgradeToYearlyFormSubmitsUpgrade: async ( wrapper: VueWrapper<any> ) => {
+		await submitMainDonationForm( wrapper, Intervals.ONCE, '5', PaymentMethods.PAYPAL );
+		await expectUpgradeToYearlyFormSubmits( wrapper, 'yes' );
+	},
+	expectUpgradeToYearlyFormSubmitsDontUpgrade: async ( wrapper: VueWrapper<any> ) => {
+		await submitMainDonationForm( wrapper, Intervals.ONCE, '5', PaymentMethods.PAYPAL );
+		await expectUpgradeToYearlyFormSubmits( wrapper, 'no' );
+	},
+	expectUpgradeToYearlyFormGoesToCustomAmount: async ( wrapper: VueWrapper<any> ) => {
+		await submitMainDonationForm( wrapper, Intervals.ONCE, '5', PaymentMethods.PAYPAL );
+		await expectUpgradeToYearlyFormGoesToPageOnLinkClick( wrapper, Pages.CustomAmount );
+	},
+	expectCustomAmountFormSubmits: async ( wrapper: VueWrapper<any> ) => {
+		await submitMainDonationForm( wrapper, Intervals.ONCE, '5', PaymentMethods.PAYPAL );
+		await wrapper.find( '.wmde-banner-form-upgrade-custom' ).trigger( 'click' );
+		await expectCustomAmountFormSubmits( wrapper, '10' );
+	}
+};

--- a/test/features/forms/MainDonation_UpgradeToYearly_CustomAmount_AddressType.ts
+++ b/test/features/forms/MainDonation_UpgradeToYearly_CustomAmount_AddressType.ts
@@ -1,0 +1,62 @@
+import { VueWrapper } from '@vue/test-utils';
+import {
+	expectMainDonationFormGoesToPageOnSubmit,
+	submitMainDonationForm
+} from '@test/features/forms/subForms/MainDonationForm';
+import {
+	expectUpgradeToYearlyFormGoesToPageOnLinkClick,
+	expectUpgradeToYearlyFormGoesToPageOnSubmit
+} from '@test/features/forms/subForms/UpgradeToYearlyForm';
+import { Intervals } from '@src/utils/FormItemsBuilder/fields/Intervals';
+import { PaymentMethods } from '@src/utils/FormItemsBuilder/fields/PaymentMethods';
+import { expectCustomAmountFormGoesToPageOnSubmit } from '@test/features/forms/subForms/CustomAmountForm';
+import { expectAddressTypeFormSubmits } from '@test/features/forms/subForms/AddressTypeForm';
+import { AddressTypes } from '@src/utils/FormItemsBuilder/fields/AddressTypes';
+
+enum Pages {
+	UpgradeToYearly = 2,
+	CustomAmount = 3,
+	Address = 4,
+}
+
+export const donationFormFeatures: Record<string, ( wrapper: VueWrapper<any> ) => Promise<any>> = {
+	expectMainDonationFormGoesToAddressFormWhenSofortIsSelected: ( wrapper: VueWrapper<any> ) => expectMainDonationFormGoesToPageOnSubmit(
+		wrapper,
+		Pages.Address,
+		Intervals.ONCE,
+		PaymentMethods.SOFORT
+	),
+	expectMainDonationFormGoesToAddressFormWhenYearlyIsSelected: ( wrapper: VueWrapper<any> ) => expectMainDonationFormGoesToPageOnSubmit(
+		wrapper,
+		Pages.Address,
+		Intervals.YEARLY,
+		PaymentMethods.PAYPAL
+	),
+	expectMainDonationFormGoesToUpgrade: ( wrapper: VueWrapper<any> ) => expectMainDonationFormGoesToPageOnSubmit(
+		wrapper,
+		Pages.UpgradeToYearly,
+		Intervals.ONCE,
+		PaymentMethods.PAYPAL
+	),
+	expectUpgradeToYearlyFormGoesToAddressTypeOnUpgrade: async ( wrapper: VueWrapper<any> ) => {
+		await submitMainDonationForm( wrapper, Intervals.ONCE, '5', PaymentMethods.PAYPAL );
+		await expectUpgradeToYearlyFormGoesToPageOnSubmit( wrapper, Pages.Address, 'yes' );
+	},
+	expectUpgradeToYearlyFormGoesToAddressTypeOnDontUpgrade: async ( wrapper: VueWrapper<any> ) => {
+		await submitMainDonationForm( wrapper, Intervals.ONCE, '5', PaymentMethods.PAYPAL );
+		await expectUpgradeToYearlyFormGoesToPageOnSubmit( wrapper, Pages.Address, 'no' );
+	},
+	expectUpgradeToYearlyFormGoesToCustomAmount: async ( wrapper: VueWrapper<any> ) => {
+		await submitMainDonationForm( wrapper, Intervals.ONCE, '5', PaymentMethods.PAYPAL );
+		await expectUpgradeToYearlyFormGoesToPageOnLinkClick( wrapper, Pages.CustomAmount );
+	},
+	expectCustomAmountGoesToAddressFormOnSubmit: async ( wrapper: VueWrapper<any> ) => {
+		await submitMainDonationForm( wrapper, Intervals.ONCE, '5', PaymentMethods.PAYPAL );
+		await wrapper.find( '.wmde-banner-form-upgrade-custom' ).trigger( 'click' );
+		await expectCustomAmountFormGoesToPageOnSubmit( wrapper, Pages.Address, '10' );
+	},
+	expectAddressFormSubmits: async ( wrapper: VueWrapper<any> ) => {
+		await submitMainDonationForm( wrapper, Intervals.YEARLY, '5', PaymentMethods.PAYPAL );
+		await expectAddressTypeFormSubmits( wrapper, AddressTypes.FULL );
+	}
+};

--- a/test/features/forms/subForms/AddressTypeButtonForm.ts
+++ b/test/features/forms/subForms/AddressTypeButtonForm.ts
@@ -1,0 +1,16 @@
+import { expect, vi } from 'vitest';
+import { VueWrapper } from '@vue/test-utils';
+import { FormItem } from '@src/utils/FormItemsBuilder/FormItem';
+
+export const submitAddressTypeButtonForm = async ( wrapper: VueWrapper<any>, addressType: FormItem ): Promise<void> => {
+	await wrapper.find( `button[value=${ addressType.value }]` ).trigger( 'click' );
+};
+
+export const expectAddressTypeFormSubmits = async ( wrapper: VueWrapper<any>, addressType: FormItem ): Promise<void> => {
+	const submitForm = wrapper.find<HTMLFormElement>( '.wmde-banner-submit-form' );
+	submitForm.element.submit = vi.fn();
+
+	await submitAddressTypeButtonForm( wrapper, addressType );
+
+	expect( submitForm.element.submit ).toHaveBeenCalledOnce();
+};

--- a/test/features/forms/subForms/AddressTypeForm.ts
+++ b/test/features/forms/subForms/AddressTypeForm.ts
@@ -1,0 +1,17 @@
+import { expect, vi } from 'vitest';
+import { VueWrapper } from '@vue/test-utils';
+import { FormItem } from '@src/utils/FormItemsBuilder/FormItem';
+
+export const submitAddressTypeForm = async ( wrapper: VueWrapper<any>, addressType: FormItem ): Promise<void> => {
+	await wrapper.find( `.${addressType.className} .wmde-banner-select-group-input` ).setValue();
+	await wrapper.find( '.wmde-banner-form-address-type' ).trigger( 'submit' );
+};
+
+export const expectAddressTypeFormSubmits = async ( wrapper: VueWrapper<any>, addressType: FormItem ): Promise<void> => {
+	const submitForm = wrapper.find<HTMLFormElement>( '.wmde-banner-submit-form' );
+	submitForm.element.submit = vi.fn();
+
+	await submitAddressTypeForm( wrapper, addressType );
+
+	expect( submitForm.element.submit ).toHaveBeenCalledOnce();
+};

--- a/test/features/forms/subForms/CustomAmountForm.ts
+++ b/test/features/forms/subForms/CustomAmountForm.ts
@@ -1,0 +1,23 @@
+import { VueWrapper } from '@vue/test-utils';
+import { expect, vi } from 'vitest';
+
+export const submitCustomAmountForm = async ( wrapper: VueWrapper<any>, amount: string ): Promise<void> => {
+	await wrapper.find( '.wmde-banner-form-new-custom-amount .wmde-banner-select-custom-amount-input' ).setValue( amount );
+	await wrapper.find( '.wmde-banner-form-new-custom-amount' ).trigger( 'submit' );
+};
+
+export const expectCustomAmountFormSubmits = async ( wrapper: VueWrapper<any>, amount: string ): Promise<any> => {
+	const submitForm = wrapper.find<HTMLFormElement>( '.wmde-banner-submit-form' );
+	submitForm.element.submit = vi.fn();
+
+	await submitCustomAmountForm( wrapper, amount );
+
+	expect( submitForm.element.submit ).toHaveBeenCalledOnce();
+};
+
+export const expectCustomAmountFormGoesToPageOnSubmit = async ( wrapper: VueWrapper<any>, page: number, amount: string ): Promise<any> => {
+	await submitCustomAmountForm( wrapper, amount );
+
+	expect( wrapper.find( `.wmde-banner-form-page:nth-child(${page})` ).attributes( 'class' ) )
+		.toContain( 'wmde-banner-form-page--current' );
+};

--- a/test/features/forms/subForms/MainDonationForm.ts
+++ b/test/features/forms/subForms/MainDonationForm.ts
@@ -1,0 +1,26 @@
+import { VueWrapper } from '@vue/test-utils';
+import { expect, vi } from 'vitest';
+import { FormItem } from '@src/utils/FormItemsBuilder/FormItem';
+
+export const submitMainDonationForm = async ( wrapper: VueWrapper<any>, interval: FormItem, amount: string, payment: FormItem ): Promise<void> => {
+	await wrapper.find( `.${interval.className} .wmde-banner-select-group-input` ).setValue();
+	await wrapper.find( `.amount-${amount} .wmde-banner-select-group-input` ).setValue();
+	await wrapper.find( `.${payment.className} .wmde-banner-select-group-input` ).setValue();
+	await wrapper.find( '.wmde-banner-sub-form-donation' ).trigger( 'submit' );
+};
+
+export const expectMainDonationFormSubmits = async ( wrapper: VueWrapper<any>, interval: FormItem, payment: FormItem ): Promise<any> => {
+	const submitForm = wrapper.find<HTMLFormElement>( '.wmde-banner-submit-form' );
+	submitForm.element.submit = vi.fn();
+
+	await submitMainDonationForm( wrapper, interval, '5', payment );
+
+	expect( submitForm.element.submit ).toHaveBeenCalledOnce();
+};
+
+export const expectMainDonationFormGoesToPageOnSubmit = async ( wrapper: VueWrapper<any>, page: number, interval: FormItem, payment: FormItem ): Promise<any> => {
+	await submitMainDonationForm( wrapper, interval, '5', payment );
+
+	expect( wrapper.find( `.wmde-banner-form-page:nth-child(${page})` ).attributes( 'class' ) )
+		.toContain( 'wmde-banner-form-page--current' );
+};

--- a/test/features/forms/subForms/UpgradeToYearlyButtonForm.ts
+++ b/test/features/forms/subForms/UpgradeToYearlyButtonForm.ts
@@ -1,0 +1,31 @@
+import { VueWrapper } from '@vue/test-utils';
+import { expect, vi } from 'vitest';
+import { Intervals } from '@src/utils/FormItemsBuilder/fields/Intervals';
+
+export const submitUpgradeToYearlyButtonForm = async ( wrapper: VueWrapper<any>, upgrade: 'yes' | 'no' ): Promise<void> => {
+	const buttonValue = upgrade === 'yes' ? Intervals.YEARLY.value : Intervals.ONCE.value;
+	await wrapper.find( `.wmde-banner-form-upgrade button[value="${buttonValue}"]` ).trigger( 'click' );
+};
+
+export const expectUpgradeToYearlyFormSubmits = async ( wrapper: VueWrapper<any>, upgrade: 'yes' | 'no' ): Promise<any> => {
+	const submitForm = wrapper.find<HTMLFormElement>( '.wmde-banner-submit-form' );
+	submitForm.element.submit = vi.fn();
+
+	await submitUpgradeToYearlyButtonForm( wrapper, upgrade );
+
+	expect( submitForm.element.submit ).toHaveBeenCalledOnce();
+};
+
+export const expectUpgradeToYearlyFormGoesToPageOnSubmit = async ( wrapper: VueWrapper<any>, page: number, upgrade: 'yes' | 'no' ): Promise<any> => {
+	await submitUpgradeToYearlyButtonForm( wrapper, upgrade );
+
+	expect( wrapper.find( `.wmde-banner-form-page:nth-child(${page})` ).attributes( 'class' ) )
+		.toContain( 'wmde-banner-form-page--current' );
+};
+
+export const expectUpgradeToYearlyFormGoesToPageOnLinkClick = async ( wrapper: VueWrapper<any>, page: number ): Promise<any> => {
+	await wrapper.find( '.wmde-banner-form-upgrade-custom' ).trigger( 'click' );
+
+	expect( wrapper.find( `.wmde-banner-form-page:nth-child(${page})` ).attributes( 'class' ) )
+		.toContain( 'wmde-banner-form-page--current' );
+};

--- a/test/features/forms/subForms/UpgradeToYearlyForm.ts
+++ b/test/features/forms/subForms/UpgradeToYearlyForm.ts
@@ -1,0 +1,30 @@
+import { VueWrapper } from '@vue/test-utils';
+import { expect, vi } from 'vitest';
+
+export const submitUpgradeToYearlyForm = async ( wrapper: VueWrapper<any>, upgrade: 'yes' | 'no' ): Promise<void> => {
+	await wrapper.find( `.wmde-banner-select-group-option-${upgrade} .wmde-banner-select-group-input` ).setValue();
+	await wrapper.find( '.wmde-banner-form-upgrade' ).trigger( 'submit' );
+};
+
+export const expectUpgradeToYearlyFormSubmits = async ( wrapper: VueWrapper<any>, upgrade: 'yes' | 'no' ): Promise<any> => {
+	const submitForm = wrapper.find<HTMLFormElement>( '.wmde-banner-submit-form' );
+	submitForm.element.submit = vi.fn();
+
+	await submitUpgradeToYearlyForm( wrapper, upgrade );
+
+	expect( submitForm.element.submit ).toHaveBeenCalledOnce();
+};
+
+export const expectUpgradeToYearlyFormGoesToPageOnSubmit = async ( wrapper: VueWrapper<any>, page: number, upgrade: 'yes' | 'no' ): Promise<any> => {
+	await submitUpgradeToYearlyForm( wrapper, upgrade );
+
+	expect( wrapper.find( `.wmde-banner-form-page:nth-child(${page})` ).attributes( 'class' ) )
+		.toContain( 'wmde-banner-form-page--current' );
+};
+
+export const expectUpgradeToYearlyFormGoesToPageOnLinkClick = async ( wrapper: VueWrapper<any>, page: number ): Promise<any> => {
+	await wrapper.find( '.wmde-banner-form-upgrade-custom' ).trigger( 'click' );
+
+	expect( wrapper.find( `.wmde-banner-form-page:nth-child(${page})` ).attributes( 'class' ) )
+		.toContain( 'wmde-banner-form-page--current' );
+};


### PR DESCRIPTION
* Add tests for the different form flows
* Removes form controller references from banner tests
* Update desktop content feature to split test signatures
* Add workaround to vue test-utils for catching form submits in sub-components