### PR TITLE
Remove jQuery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "eslint-plugin-vue": "^9.14.0",
         "eslint-plugin-yml": "^1.7.0",
         "handlebars": "^4.7.7",
-        "jquery": "^3.6.1",
         "jsdom": "^22.0.0",
         "nodemon": "^2.0.20",
         "npm-check-updates": "^16.7.10",
@@ -7205,12 +7204,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
       "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
-      "dev": true
-    },
-    "node_modules/jquery": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.4.tgz",
-      "integrity": "sha512-v28EW9DWDFpzcD9O5iyJXg3R3+q+mET5JhnjJzQUZMHOv67bpSIHq81GEYpPNZHG+XXHsfSme3nxp/hndKEcsQ==",
       "dev": true
     },
     "node_modules/js-beautify": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "eslint-plugin-vue": "^9.14.0",
     "eslint-plugin-yml": "^1.7.0",
     "handlebars": "^4.7.7",
-    "jquery": "^3.6.1",
     "jsdom": "^22.0.0",
     "nodemon": "^2.0.20",
     "npm-check-updates": "^16.7.10",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -67,9 +67,6 @@ module.exports = {
 			}
 		]
 	},
-	externals: {
-		jquery: 'jQuery'
-	},
 	resolve: {
 		extensions: [ '.ts', '.js', '.json' ],
 		alias: {


### PR DESCRIPTION
We're not using it any more.
In the old repo, it was still used in the MediaWiki skin classes