### PR TITLE
Re-enable credit card option in Desktop+Mobile

### DIFF
--- a/banners/desktop/form_items.ts
+++ b/banners/desktop/form_items.ts
@@ -17,6 +17,7 @@ export function createFormItems( translations: Translator, amountFormatter: Numb
 		.setPaymentMethods(
 			PaymentMethods.PAYPAL,
 			PaymentMethods.BANK_TRANSFER,
+			PaymentMethods.CREDIT_CARD,
 			PaymentMethods.DIRECT_DEBIT
 		).getItems();
 }

--- a/banners/desktop/form_items_var.ts
+++ b/banners/desktop/form_items_var.ts
@@ -18,6 +18,7 @@ export function createFormItems( translations: Translator, amountFormatter: Numb
 		.setPaymentMethods(
 			PaymentMethods.PAYPAL,
 			PaymentMethods.BANK_TRANSFER,
+			PaymentMethods.CREDIT_CARD,
 			PaymentMethods.DIRECT_DEBIT
 		)
 		.setAddressTypes(

--- a/banners/mobile/form_items.ts
+++ b/banners/mobile/form_items.ts
@@ -17,6 +17,7 @@ export function createFormItems( translations: Translator, amountFormatter: Numb
 			PaymentMethods.PAYPAL,
 			PaymentMethods.DIRECT_DEBIT,
 			PaymentMethods.BANK_TRANSFER,
+			PaymentMethods.CREDIT_CARD,
 			PaymentMethods.SOFORT
 		).getItems();
 }

--- a/banners/mobile/form_items_var.ts
+++ b/banners/mobile/form_items_var.ts
@@ -16,7 +16,8 @@ export function createFormItems( translations: Translator, amountFormatter: Numb
 		.setAmounts( 5, 15, 25, 50, 100 )
 		.setPaymentMethods(
 			PaymentMethods.PAYPAL,
-			PaymentMethods.DIRECT_DEBIT
+			PaymentMethods.DIRECT_DEBIT,
+			PaymentMethods.CREDIT_CARD
 		)
 		.setAddressTypes(
 			AddressTypes.FULL,

--- a/banners/mobile/styles/styles_var.scss
+++ b/banners/mobile/styles/styles_var.scss
@@ -20,9 +20,3 @@
 .wmde-banner-sms-box {
 	display: none;
 }
-
-.payment-ppl,
-.payment-bez {
-	flex: 0 0 50%;
-	width: 50%;
-}


### PR DESCRIPTION
- due to some provider issues the credit card option had to be disabled
- it can now be a payment option in the banners and on the donation page again

:warning: 

- [x] Change and deploy the fundraising application to allow for credit card payments again BEFORE pushing these changes to Central Notice

https://phabricator.wikimedia.org/T341452