### PR TITLE
Move banner close event tests

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -8,6 +8,7 @@
 		"stylelint-config-wikimedia"
 	],
 	"rules": {
+		"max-line-length": 180,
 		"selector-max-id": 2,
 		"function-url-quotes": "always",
 		"color-hex-length": "long",

--- a/banners/mobile/components/BannerCtrl.vue
+++ b/banners/mobile/components/BannerCtrl.vue
@@ -17,7 +17,7 @@
 
 		<FullPageBanner
 			@showFundsModal="isFundsModalVisible = true"
-			@close="() => onClose( 'FullPageBanner', CloseChoices.MaybeLater )"
+			@close="() => onClose( 'FullPageBanner', CloseChoices.Hide )"
 		>
 			<template #banner-text>
 				<BannerText/>

--- a/banners/mobile/components/BannerCtrl.vue
+++ b/banners/mobile/components/BannerCtrl.vue
@@ -17,7 +17,7 @@
 
 		<FullPageBanner
 			@showFundsModal="isFundsModalVisible = true"
-			@close="() => onClose( 'FullPageBanner', CloseChoices.Close )"
+			@close="() => onClose( 'FullPageBanner', CloseChoices.MaybeLater )"
 		>
 			<template #banner-text>
 				<BannerText/>

--- a/banners/mobile_english/components/BannerCtrl.vue
+++ b/banners/mobile_english/components/BannerCtrl.vue
@@ -17,7 +17,7 @@
 
 		<FullPageBanner
 			@showFundsModal="isFundsModalVisible = true"
-			@close="() => onClose( 'FullPageBanner', CloseChoices.MaybeLater )"
+			@close="() => onClose( 'FullPageBanner', CloseChoices.Hide )"
 		>
 			<template #banner-text>
 				<BannerText/>

--- a/banners/mobile_english/components/BannerCtrl.vue
+++ b/banners/mobile_english/components/BannerCtrl.vue
@@ -17,7 +17,7 @@
 
 		<FullPageBanner
 			@showFundsModal="isFundsModalVisible = true"
-			@close="() => onClose( 'FullPageBanner', CloseChoices.Close )"
+			@close="() => onClose( 'FullPageBanner', CloseChoices.MaybeLater )"
 		>
 			<template #banner-text>
 				<BannerText/>

--- a/banners/mobile_english/components/BannerVar.vue
+++ b/banners/mobile_english/components/BannerVar.vue
@@ -17,7 +17,7 @@
 
 		<FullPageBanner
 			@showFundsModal="isFundsModalVisible = true"
-			@close="() => onClose( 'FullPageBanner', CloseChoices.MaybeLater )"
+			@close="() => onClose( 'FullPageBanner', CloseChoices.Hide )"
 		>
 			<template #banner-text>
 				<BannerText/>

--- a/banners/mobile_english/components/BannerVar.vue
+++ b/banners/mobile_english/components/BannerVar.vue
@@ -17,7 +17,7 @@
 
 		<FullPageBanner
 			@showFundsModal="isFundsModalVisible = true"
-			@close="() => onClose( 'FullPageBanner', CloseChoices.Close )"
+			@close="() => onClose( 'FullPageBanner', CloseChoices.MaybeLater )"
 		>
 			<template #banner-text>
 				<BannerText/>

--- a/banners/wpde_mobile/components/BannerCtrl.vue
+++ b/banners/wpde_mobile/components/BannerCtrl.vue
@@ -17,7 +17,7 @@
 
 		<FullPageBanner
 			@showFundsModal="isFundsModalVisible = true"
-			@close="() => onClose( 'FullPageBanner', CloseChoices.MaybeLater )"
+			@close="() => onClose( 'FullPageBanner', CloseChoices.Hide )"
 		>
 			<template #banner-text>
 				<BannerText/>

--- a/banners/wpde_mobile/components/BannerCtrl.vue
+++ b/banners/wpde_mobile/components/BannerCtrl.vue
@@ -17,7 +17,7 @@
 
 		<FullPageBanner
 			@showFundsModal="isFundsModalVisible = true"
-			@close="() => onClose( 'FullPageBanner', CloseChoices.Close )"
+			@close="() => onClose( 'FullPageBanner', CloseChoices.MaybeLater )"
 		>
 			<template #banner-text>
 				<BannerText/>

--- a/src/domain/CloseChoices.ts
+++ b/src/domain/CloseChoices.ts
@@ -1,6 +1,8 @@
 export enum CloseChoices {
 	/** user clicked close button */
 	Close = 'close',
+	/** user clicked close button on a mobile full page banner */
+	Hide = 'hide',
 	/** user clicked maybe later button */
 	MaybeLater = 'maybe-later',
 	/** user ignored soft close timer */

--- a/src/page/PageWPORG.ts
+++ b/src/page/PageWPORG.ts
@@ -109,6 +109,7 @@ class PageWPORG implements Page {
 			case CloseChoices.NoMoreBannersForCampaign:
 				this._mediaWiki.preventBannerDisplayUntilEndOfCampaign();
 				break;
+			case CloseChoices.Hide:
 			case CloseChoices.MaybeLater:
 				// Don't add cookie
 				break;

--- a/test/banners/desktop/components/BannerCtrl.spec.ts
+++ b/test/banners/desktop/components/BannerCtrl.spec.ts
@@ -18,6 +18,7 @@ import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeT
 import { useFormModel } from '@src/components/composables/useFormModel';
 import { resetFormModel } from '@test/resetFormModel';
 import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import { bannerMainFeatures } from '@test/features/MainBanner';
 
 const formModel = useFormModel();
 const translator = ( key: string ): string => key;
@@ -49,6 +50,14 @@ describe( 'BannerCtrl.vue', () => {
 			}
 		} );
 	};
+
+	describe( 'Main Banner', () => {
+		test.each( [
+			[ 'expectDoesNotEmitCloseEvent' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerMainFeatures[ testName ]( getWrapper() );
+		} );
+	} );
 
 	describe( 'Content', () => {
 		test.each( [

--- a/test/banners/desktop/components/BannerVar.spec.ts
+++ b/test/banners/desktop/components/BannerVar.spec.ts
@@ -18,6 +18,7 @@ import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeT
 import { useFormModel } from '@src/components/composables/useFormModel';
 import { resetFormModel } from '@test/resetFormModel';
 import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import { bannerMainFeatures } from '@test/features/MainBanner';
 
 const formModel = useFormModel();
 const translator = ( key: string ): string => key;
@@ -49,6 +50,14 @@ describe( 'BannerVar.vue', () => {
 			}
 		} );
 	};
+
+	describe( 'Main Banner', () => {
+		test.each( [
+			[ 'expectDoesNotEmitCloseEvent' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerMainFeatures[ testName ]( getWrapper() );
+		} );
+	} );
 
 	describe( 'Content', () => {
 		test.each( [

--- a/test/banners/english/components/BannerCtrl.spec.ts
+++ b/test/banners/english/components/BannerCtrl.spec.ts
@@ -13,6 +13,7 @@ import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearly_CustomAmount';
 import { useFormModel } from '@src/components/composables/useFormModel';
 import { resetFormModel } from '@test/resetFormModel';
+import { bannerMainFeatures } from '@test/features/MainBanner';
 
 const formModel = useFormModel();
 const translator = ( key: string ): string => key;
@@ -44,6 +45,14 @@ describe( 'BannerCtrl.vue', () => {
 			}
 		} );
 	};
+
+	describe( 'Main Banner', () => {
+		test.each( [
+			[ 'expectDoesNotEmitCloseEvent' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerMainFeatures[ testName ]( getWrapper() );
+		} );
+	} );
 
 	describe( 'Content', () => {
 		test.each( [

--- a/test/banners/english/components/BannerVar.spec.ts
+++ b/test/banners/english/components/BannerVar.spec.ts
@@ -14,6 +14,7 @@ import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearly_CustomAmount';
 import { resetFormModel } from '@test/resetFormModel';
 import { useFormModel } from '@src/components/composables/useFormModel';
+import { bannerMainFeatures } from '@test/features/MainBanner';
 
 const formModel = useFormModel();
 const translator = ( key: string ): string => key;
@@ -45,6 +46,14 @@ describe( 'BannerVar.vue', () => {
 			}
 		} );
 	};
+
+	describe( 'Main Banner', () => {
+		test.each( [
+			[ 'expectDoesNotEmitCloseEvent' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerMainFeatures[ testName ]( getWrapper() );
+		} );
+	} );
 
 	describe( 'Content', () => {
 		test.each( [

--- a/test/banners/mobile/components/BannerCtrl.spec.ts
+++ b/test/banners/mobile/components/BannerCtrl.spec.ts
@@ -16,6 +16,7 @@ import { useFormModel } from '@src/components/composables/useFormModel';
 import { resetFormModel } from '@test/resetFormModel';
 import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 import { bannerContentAnimatedTextFeatures } from '@test/features/BannerContent';
+import { fullPageBannerFeatures } from '@test/features/FullPageBanner';
 
 let pageScroller: PageScroller;
 const formModel = useFormModel();
@@ -127,6 +128,14 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsBannerContentChangedEventWhenCallToActionIsClicked' ]
 		] )( '%s', async ( testName: string ) => {
 			await miniBannerFeatures[ testName ]( getWrapper() );
+		} );
+	} );
+
+	describe( 'Full Page Banner', () => {
+		test.each( [
+			[ 'expectEmitsCloseEvent' ]
+		] )( '%s', async ( testName: string ) => {
+			await fullPageBannerFeatures[ testName ]( getWrapper() );
 		} );
 	} );
 

--- a/test/banners/mobile_english/components/BannerCtrl.spec.ts
+++ b/test/banners/mobile_english/components/BannerCtrl.spec.ts
@@ -16,6 +16,7 @@ import { Intervals } from '@src/utils/FormItemsBuilder/fields/Intervals';
 import { PaymentMethods } from '@src/utils/FormItemsBuilder/fields/PaymentMethods';
 import { resetFormModel } from '@test/resetFormModel';
 import { useFormModel } from '@src/components/composables/useFormModel';
+import { fullPageBannerFeatures } from '@test/features/FullPageBanner';
 
 let pageScroller: PageScroller;
 const formModel = useFormModel();
@@ -97,6 +98,14 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsBannerContentChangedEventWhenCallToActionIsClicked' ]
 		] )( '%s', async ( testName: string ) => {
 			await miniBannerFeatures[ testName ]( wrapper );
+		} );
+	} );
+
+	describe( 'Full Page Banner', () => {
+		test.each( [
+			[ 'expectEmitsCloseEvent' ]
+		] )( '%s', async ( testName: string ) => {
+			await fullPageBannerFeatures[ testName ]( wrapper );
 		} );
 	} );
 

--- a/test/banners/mobile_english/components/BannerVar.spec.ts
+++ b/test/banners/mobile_english/components/BannerVar.spec.ts
@@ -16,6 +16,7 @@ import { Intervals } from '@src/utils/FormItemsBuilder/fields/Intervals';
 import { PaymentMethods } from '@src/utils/FormItemsBuilder/fields/PaymentMethods';
 import { useFormModel } from '@src/components/composables/useFormModel';
 import { resetFormModel } from '@test/resetFormModel';
+import { fullPageBannerFeatures } from '@test/features/FullPageBanner';
 
 let pageScroller: PageScroller;
 const formModel = useFormModel();
@@ -97,6 +98,14 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectEmitsBannerContentChangedEventWhenCallToActionIsClicked' ]
 		] )( '%s', async ( testName: string ) => {
 			await miniBannerFeatures[ testName ]( wrapper );
+		} );
+	} );
+
+	describe( 'Full Page Banner', () => {
+		test.each( [
+			[ 'expectEmitsCloseEvent' ]
+		] )( '%s', async ( testName: string ) => {
+			await fullPageBannerFeatures[ testName ]( wrapper );
 		} );
 	} );
 

--- a/test/banners/pad/components/BannerCtrl.spec.ts
+++ b/test/banners/pad/components/BannerCtrl.spec.ts
@@ -15,6 +15,7 @@ import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeT
 import { useFormModel } from '@src/components/composables/useFormModel';
 import { resetFormModel } from '@test/resetFormModel';
 import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import { bannerMainFeatures } from '@test/features/MainBanner';
 
 const formModel = useFormModel();
 const translator = ( key: string ): string => key;
@@ -55,6 +56,14 @@ describe( 'BannerCtrl.vue', () => {
 
 	afterEach( () => {
 		wrapper.unmount();
+	} );
+
+	describe( 'Main Banner', () => {
+		test.each( [
+			[ 'expectDoesNotEmitCloseEvent' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerMainFeatures[ testName ]( getWrapper() );
+		} );
 	} );
 
 	describe( 'Content', () => {

--- a/test/banners/pad/components/BannerVar.spec.ts
+++ b/test/banners/pad/components/BannerVar.spec.ts
@@ -15,6 +15,7 @@ import { resetFormModel } from '@test/resetFormModel';
 import { useFormModel } from '@src/components/composables/useFormModel';
 import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
 import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import { bannerMainFeatures } from '@test/features/MainBanner';
 
 const formModel = useFormModel();
 const translator = ( key: string ): string => key;
@@ -54,6 +55,14 @@ describe( 'BannerVar.vue', () => {
 
 	afterEach( () => {
 		wrapper.unmount();
+	} );
+
+	describe( 'Main Banner', () => {
+		test.each( [
+			[ 'expectDoesNotEmitCloseEvent' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerMainFeatures[ testName ]( getWrapper() );
+		} );
 	} );
 
 	describe( 'Content', () => {

--- a/test/banners/pad_english/components/BannerVar.spec.ts
+++ b/test/banners/pad_english/components/BannerVar.spec.ts
@@ -13,6 +13,7 @@ import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeT
 import { useFormModel } from '@src/components/composables/useFormModel';
 import { resetFormModel } from '@test/resetFormModel';
 import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
+import { bannerMainFeatures } from '@test/features/MainBanner';
 
 const formModel = useFormModel();
 const translator = ( key: string ): string => key;
@@ -48,6 +49,14 @@ describe( 'BannerVar.vue', () => {
 
 	afterEach( () => {
 		wrapper.unmount();
+	} );
+
+	describe( 'Main Banner', () => {
+		test.each( [
+			[ 'expectDoesNotEmitCloseEvent' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerMainFeatures[ testName ]( wrapper );
+		} );
 	} );
 
 	describe( 'Content', () => {

--- a/test/banners/wpde_mobile/components/BannerCtrl.spec.ts
+++ b/test/banners/wpde_mobile/components/BannerCtrl.spec.ts
@@ -16,6 +16,7 @@ import { useFormModel } from '@src/components/composables/useFormModel';
 import { resetFormModel } from '@test/resetFormModel';
 import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 import { bannerContentAnimatedTextFeatures } from '@test/features/BannerContent';
+import { fullPageBannerFeatures } from '@test/features/FullPageBanner';
 
 let pageScroller: PageScroller;
 const formModel = useFormModel();
@@ -126,6 +127,14 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsBannerContentChangedEventWhenCallToActionIsClicked' ]
 		] )( '%s', async ( testName: string ) => {
 			await miniBannerFeatures[ testName ]( getWrapper() );
+		} );
+	} );
+
+	describe( 'Full Page Banner', () => {
+		test.each( [
+			[ 'expectEmitsCloseEvent' ]
+		] )( '%s', async ( testName: string ) => {
+			await fullPageBannerFeatures[ testName ]( getWrapper() );
 		} );
 	} );
 

--- a/test/features/FullPageBanner.ts
+++ b/test/features/FullPageBanner.ts
@@ -8,7 +8,7 @@ const expectEmitsCloseEvent = async ( wrapper: VueWrapper<any> ): Promise<any> =
 	await wrapper.find( '.wmde-banner-full-close' ).trigger( 'click' );
 
 	expect( wrapper.emitted( 'bannerClosed' ).length ).toBe( 1 );
-	expect( wrapper.emitted( 'bannerClosed' )[ 0 ][ 0 ] ).toEqual( new CloseEvent( 'FullPageBanner', CloseChoices.MaybeLater ) );
+	expect( wrapper.emitted( 'bannerClosed' )[ 0 ][ 0 ] ).toEqual( new CloseEvent( 'FullPageBanner', CloseChoices.Hide ) );
 };
 
 export const fullPageBannerFeatures: Record<string, ( wrapper: VueWrapper<any> ) => Promise<any>> = {

--- a/test/features/FullPageBanner.ts
+++ b/test/features/FullPageBanner.ts
@@ -1,0 +1,16 @@
+import { VueWrapper } from '@vue/test-utils';
+import { expect } from 'vitest';
+import { CloseEvent } from '@src/tracking/events/CloseEvent';
+import { CloseChoices } from '@src/domain/CloseChoices';
+
+const expectEmitsCloseEvent = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+	await wrapper.find( '.wmde-banner-mini-button' ).trigger( 'click' );
+	await wrapper.find( '.wmde-banner-full-close' ).trigger( 'click' );
+
+	expect( wrapper.emitted( 'bannerClosed' ).length ).toBe( 1 );
+	expect( wrapper.emitted( 'bannerClosed' )[ 0 ][ 0 ] ).toEqual( new CloseEvent( 'FullPageBanner', CloseChoices.MaybeLater ) );
+};
+
+export const fullPageBannerFeatures: Record<string, ( wrapper: VueWrapper<any> ) => Promise<any>> = {
+	expectEmitsCloseEvent
+};

--- a/test/features/MainBanner.ts
+++ b/test/features/MainBanner.ts
@@ -10,6 +10,13 @@ const expectEmitsCloseEvent = async ( wrapper: VueWrapper<any> ): Promise<any> =
 	expect( wrapper.emitted( 'bannerClosed' )[ 0 ][ 0 ] ).toEqual( new CloseEvent( 'MainBanner', CloseChoices.Close ) );
 };
 
+const expectDoesNotEmitCloseEvent = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+	await wrapper.find( '.wmde-banner-main .wmde-banner-close' ).trigger( 'click' );
+
+	expect( wrapper.emitted( 'bannerClosed' ) ).toBeUndefined();
+};
+
 export const bannerMainFeatures: Record<string, ( wrapper: VueWrapper<any> ) => Promise<any>> = {
-	expectEmitsCloseEvent
+	expectEmitsCloseEvent,
+	expectDoesNotEmitCloseEvent
 };

--- a/test/features/SoftCloseMobile.ts
+++ b/test/features/SoftCloseMobile.ts
@@ -15,10 +15,7 @@ const expectDoesNotShowSoftCloseOnFullBannerClose = async ( wrapper: VueWrapper<
 	await wrapper.find( '.wmde-banner-mini-button' ).trigger( 'click' );
 	await wrapper.find( '.wmde-banner-full-close' ).trigger( 'click' );
 
-	expect( wrapper.classes() ).toContain( 'wmde-banner-wrapper--full-page' );
 	expect( wrapper.find( '.wmde-banner-soft-close' ).exists() ).toBeFalsy();
-	expect( wrapper.emitted( 'bannerClosed' ).length ).toBe( 1 );
-	expect( wrapper.emitted( 'bannerClosed' )[ 0 ][ 0 ] ).toEqual( new CloseEvent( 'FullPageBanner', CloseChoices.Close ) );
 };
 
 const expectEmitsSoftCloseCloseEvent = async ( wrapper: VueWrapper<any> ): Promise<any> => {

--- a/test/integration/page/PageOrg.spec.ts
+++ b/test/integration/page/PageOrg.spec.ts
@@ -100,6 +100,14 @@ describe( 'PageOrg', function () {
 		expect( mediaWiki.preventBannerDisplayUntilEndOfCampaign ).not.toHaveBeenCalledOnce();
 	} );
 
+	it( 'does not store cookie for the "Hide" event', () => {
+		const page = new PageWPORG( mediaWiki, new SkinStub(), new SizeIssueCheckerStub() );
+
+		page.setCloseCookieIfNecessary( new CloseEvent( 'FullPageBanner', CloseChoices.Hide ) );
+
+		expect( mediaWiki.preventBannerDisplayUntilEndOfCampaign ).not.toHaveBeenCalledOnce();
+	} );
+
 	it( 'stores close cookie when user closes soft close', () => {
 		const page = new PageWPORG( mediaWiki, new SkinStub(), new SizeIssueCheckerStub() );
 


### PR DESCRIPTION
Close event tests in banners that use the Soft Close feature were located in the Soft Close feature tests.

This moves them to more appropriate features and makes them more explicit.