### PR TITLE
Fix runtime issues with dev dashboard

### DIFF
--- a/dashboard/components/BannerActions.vue
+++ b/dashboard/components/BannerActions.vue
@@ -65,12 +65,14 @@ import { CompileInfo } from '../util';
 import LoadingSpinner from './BuildingAnimation.vue';
 import CopyingAnimation from './CopyingAnimation.vue';
 
-const props = defineProps<{
-	banner: Banner,
-	campaign: Campaign,
-	isWPDE: boolean,
-	compileInfo?: CompileInfo
-}>();
+interface Props {
+	banner: Banner;
+	campaign: Campaign;
+	isWPDE: boolean;
+	compileInfo?: CompileInfo;
+}
+
+const props = defineProps<Props>();
 
 const bannerPageName = ref( props.banner.pageName );
 

--- a/dashboard/components/BannerCampaign.vue
+++ b/dashboard/components/BannerCampaign.vue
@@ -77,7 +77,7 @@ import { CompileInfo } from '../util';
 
 interface Props {
 	campaign: Campaign,
-	compileInfo: CompileInfo
+	compileInfo?: CompileInfo
 }
 
 defineProps<Props>();

--- a/dashboard/components/DevDashboard.vue
+++ b/dashboard/components/DevDashboard.vue
@@ -57,8 +57,8 @@ const compileInfo = ref<Record<string, CompileInfo>>( {} );
 const gitFailurePrefix = /^UNKNOWN -/;
 
 const campaignList = computed( (): Campaign[] => Object.values( props.campaigns ) );
-const currentCampaign = computed( (): Campaign => Object.values( props.campaigns ).find( ( c: Campaign ) => c.campaign === branchName.value ) );
-const filteredCampaignList = computed( (): Campaign[] => campaignList.value.filter( ( c: Campaign ) => c !== currentCampaign.value ) );
+const currentCampaign = computed( (): Campaign => campaignList.value.find( ( c: Campaign ) => c.campaign === branchName.value ) );
+const filteredCampaignList = computed( (): Campaign[] => campaignList.value.filter( ( c: Campaign ) => c.campaign !== branchName.value ) );
 
 onMounted( () => {
 	fetch( '/compiled-banners/' )


### PR DESCRIPTION
This stops the intermittent issue we have at runtime where the campaign config sometimes isn't available when we try to filter it in a computed ref.

It also fixes an issue that was throwing warnings when the compileInfo for a banner is missing.