### PR TITLE
Fix formatting of currentDay

### DIFF
--- a/src/utils/DynamicContent/formatters/OrdinalDe.ts
+++ b/src/utils/DynamicContent/formatters/OrdinalDe.ts
@@ -2,6 +2,6 @@ import { Ordinal } from '@src/utils/DynamicContent/formatters/Ordinal';
 
 export class OrdinalDe implements Ordinal {
 	public getFormatted( figures: number ): string {
-		return figures.toString();
+		return figures.toString() + '.';
 	}
 }

--- a/src/utils/DynamicContent/generators/CurrentDate.ts
+++ b/src/utils/DynamicContent/generators/CurrentDate.ts
@@ -14,6 +14,8 @@ export class CurrentDate implements TextGenerator {
 	}
 
 	public getText(): string {
-		return this._translator.translate( 'month-name-' + ( this._date.getMonth() + 1 ) ) + ' ' + this._ordinalFormatter.getFormatted( this._date.getDate() );
+		return this._translator.translate( 'date-month-' + ( this._date.getMonth() + 1 ), {
+			day: this._ordinalFormatter.getFormatted( this._date.getDate() )
+		} );
 	}
 }

--- a/src/utils/DynamicContent/messages/DynamicCampaignText.de.ts
+++ b/src/utils/DynamicContent/messages/DynamicCampaignText.de.ts
@@ -31,18 +31,18 @@ const Translations: TranslationMessages = {
 	'visitors-vs-donors-sentence': 'Über {{millionImpressionsPerDay}} Millionen Mal wird unser Spendenaufruf täglich angezeigt,' +
 		' aber nur {{totalNumberOfDonors}} Menschen haben bisher gespendet.',
 
-	'month-name-1': 'Januar',
-	'month-name-2': 'Februar',
-	'month-name-3': 'März',
-	'month-name-4': 'April',
-	'month-name-5': 'Mai',
-	'month-name-6': 'Juni',
-	'month-name-7': 'Juli',
-	'month-name-8': 'August',
-	'month-name-9': 'September',
-	'month-name-10': 'Oktober',
-	'month-name-11': 'November',
-	'month-name-12': 'Dezember'
+	'date-month-1': '{{day}}. Januar',
+	'date-month-2': '{{day}}. Februar',
+	'date-month-3': '{{day}}. März',
+	'date-month-4': '{{day}}. April',
+	'date-month-5': '{{day}}. Mai',
+	'date-month-6': '{{day}}. Juni',
+	'date-month-7': '{{day}}. Juli',
+	'date-month-8': '{{day}}. August',
+	'date-month-9': '{{day}}. September',
+	'date-month-10': '{{day}}. Oktober',
+	'date-month-11': '{{day}}. November',
+	'date-month-12': '{{day}}. Dezember'
 };
 
 export default Translations;

--- a/src/utils/DynamicContent/messages/DynamicCampaignText.de.ts
+++ b/src/utils/DynamicContent/messages/DynamicCampaignText.de.ts
@@ -31,18 +31,18 @@ const Translations: TranslationMessages = {
 	'visitors-vs-donors-sentence': 'Über {{millionImpressionsPerDay}} Millionen Mal wird unser Spendenaufruf täglich angezeigt,' +
 		' aber nur {{totalNumberOfDonors}} Menschen haben bisher gespendet.',
 
-	'date-month-1': '{{day}}. Januar',
-	'date-month-2': '{{day}}. Februar',
-	'date-month-3': '{{day}}. März',
-	'date-month-4': '{{day}}. April',
-	'date-month-5': '{{day}}. Mai',
-	'date-month-6': '{{day}}. Juni',
-	'date-month-7': '{{day}}. Juli',
-	'date-month-8': '{{day}}. August',
-	'date-month-9': '{{day}}. September',
-	'date-month-10': '{{day}}. Oktober',
-	'date-month-11': '{{day}}. November',
-	'date-month-12': '{{day}}. Dezember'
+	'date-month-1': '{{day}} Januar',
+	'date-month-2': '{{day}} Februar',
+	'date-month-3': '{{day}} März',
+	'date-month-4': '{{day}} April',
+	'date-month-5': '{{day}} Mai',
+	'date-month-6': '{{day}} Juni',
+	'date-month-7': '{{day}} Juli',
+	'date-month-8': '{{day}} August',
+	'date-month-9': '{{day}} September',
+	'date-month-10': '{{day}} Oktober',
+	'date-month-11': '{{day}} November',
+	'date-month-12': '{{day}} Dezember'
 };
 
 export default Translations;

--- a/src/utils/DynamicContent/messages/DynamicCampaignText.en.ts
+++ b/src/utils/DynamicContent/messages/DynamicCampaignText.en.ts
@@ -31,18 +31,18 @@ const Translations: TranslationMessages = {
 	'visitors-vs-donors-sentence': 'Our fundraising appeal is displayed over {{millionImpressionsPerDay}} million' +
 		' times a day, but currently only {{totalNumberOfDonors}} people have donated.',
 
-	'month-name-1': 'January',
-	'month-name-2': 'February',
-	'month-name-3': 'March',
-	'month-name-4': 'April',
-	'month-name-5': 'May',
-	'month-name-6': 'June',
-	'month-name-7': 'July',
-	'month-name-8': 'August',
-	'month-name-9': 'September',
-	'month-name-10': 'October',
-	'month-name-11': 'November',
-	'month-name-12': 'December'
+	'date-month-1': 'January {{day}}',
+	'date-month-2': 'February {{day}}',
+	'date-month-3': 'March {{day}}',
+	'date-month-4': 'April {{day}}',
+	'date-month-5': 'May {{day}}',
+	'date-month-6': 'June {{day}}',
+	'date-month-7': 'July {{day}}',
+	'date-month-8': 'August {{day}}',
+	'date-month-9': 'September {{day}}',
+	'date-month-10': 'October {{day}}',
+	'date-month-11': 'November {{day}}',
+	'date-month-12': 'December {{day}}'
 };
 
 export default Translations;

--- a/test/unit/utils/DynamicContent/DynamicCampaignText.spec.ts
+++ b/test/unit/utils/DynamicContent/DynamicCampaignText.spec.ts
@@ -11,7 +11,7 @@ import { ImpressionCount } from '@src/utils/ImpressionCount';
 
 const translator = new Translator( {
 	'campaign-day-nth-day': 'campaign day {{days}}',
-	'month-name-11': 'current month',
+	'date-month-11': 'current month {{day}}',
 	'day-name-friday': 'current day name',
 	'prefix-days-left': 'only',
 	'suffix-days-left': 'left',

--- a/test/unit/utils/DynamicContent/generators/CurrentDate.spec.ts
+++ b/test/unit/utils/DynamicContent/generators/CurrentDate.spec.ts
@@ -4,10 +4,10 @@ import { CurrentDate } from '@src/utils/DynamicContent/generators/CurrentDate';
 import { Ordinal } from '@src/utils/DynamicContent/formatters/Ordinal';
 
 const translator = new Translator( {
-	'month-name-1': 'Ick',
-	'month-name-2': 'Offle',
-	'month-name-10': 'Spune',
-	'month-name-11': 'Sektober'
+	'date-month-1': 'Ick {{day}}',
+	'date-month-2': 'Offle {{day}}',
+	'date-month-10': 'Spune {{day}}',
+	'date-month-11': 'Sektober {{day}}'
 } );
 
 const staticOrdinal: Ordinal = {


### PR DESCRIPTION
This was being formatted incorrectly for German banners, with the day coming after the month instead of before.

I added the day as a template tag in the messages to fix this.