### PR TITLE
Add SetCookieImage component

### DIFF
--- a/src/components/SetWPDECookieImage/SetCookieImage.vue
+++ b/src/components/SetWPDECookieImage/SetCookieImage.vue
@@ -1,0 +1,3 @@
+<template>
+	<img class="wmde-banner-set-cookie-image" src="https://bruce.wikipedia.de/close-banner?c=fundraising" alt="" height="0" width="0"/>
+</template>


### PR DESCRIPTION
This is for use by the WPDE banners and should be
added to the page when the banner is closed in order to set a cookie that will hide the banner from the users for 7 days.