### PR TITLE
Add more event tracking for WPDE banners

### DIFF
--- a/src/components/BannerConductor/StateMachine/states/StateFactory.ts
+++ b/src/components/BannerConductor/StateMachine/states/StateFactory.ts
@@ -45,7 +45,7 @@ export class StateFactory {
 	}
 
 	public newVisibleState(): BannerState {
-		return new VisibleState( this._page, this._impressionCount );
+		return new VisibleState( this._page, this._impressionCount, this._tracker );
 	}
 
 	public newClosedState( closeEvent: TrackingEvent ): BannerState {

--- a/src/components/BannerConductor/StateMachine/states/VisibleState.ts
+++ b/src/components/BannerConductor/StateMachine/states/VisibleState.ts
@@ -2,22 +2,26 @@ import { BannerState } from '@src/components/BannerConductor/StateMachine/states
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
 import { Page } from '@src/page/Page';
 import { ImpressionCount } from '@src/utils/ImpressionCount';
+import { Tracker } from '@src/tracking/Tracker';
+import { ShownEvent } from '@src/tracking/events/ShownEvent';
 
 export class VisibleState extends BannerState {
 	public readonly stateName: BannerStates = BannerStates.Visible;
 	private _page: Page;
 	private _impressionCount: ImpressionCount;
+	private _tracker: Tracker;
 
-	public constructor( page: Page, impressionCount: ImpressionCount ) {
+	public constructor( page: Page, impressionCount: ImpressionCount, tracker: Tracker ) {
 		super();
 		this._page = page;
 		this._impressionCount = impressionCount;
+		this._tracker = tracker;
 
 		this.canMoveToStates.push( BannerStates.Closed );
 	}
 
 	public enter(): Promise<any> {
-		// TODO Fire shown events here
+		this._tracker.trackEvent( new ShownEvent() );
 		this._impressionCount.incrementImpressionCounts();
 		return Promise.resolve();
 	}

--- a/src/tracking/TrackerWPDE.ts
+++ b/src/tracking/TrackerWPDE.ts
@@ -1,6 +1,8 @@
 import { Tracker } from '@src/tracking/Tracker';
 import { TrackingEvent } from '@src/tracking/TrackingEvent';
 import { CustomAmountChangedEvent } from '@src/tracking/events/CustomAmountChangedEvent';
+import { CloseEvent } from '@src/tracking/events/CloseEvent';
+import { FormStepShownEvent } from '@src/tracking/events/FormStepShownEvent';
 
 type TrackingRatesForEvents = Map<string, number>;
 
@@ -89,8 +91,12 @@ export class TrackerWPDE implements Tracker {
 		switch ( event.eventName ) {
 			case CustomAmountChangedEvent.EVENT_NAME:
 				return event.userChoice + '-amount';
+			case CloseEvent.EVENT_NAME:
+				return 'banner-closed-' + event.userChoice;
+			case FormStepShownEvent.EVENT_NAME:
+				return event.eventName + '-' + event.feature;
 			default:
-				return event.eventName;
+				return event.eventName + ( event.userChoice !== '' ? '-' + event.userChoice : '' );
 		}
 	}
 

--- a/src/tracking/events/ShownEvent.ts
+++ b/src/tracking/events/ShownEvent.ts
@@ -1,0 +1,10 @@
+import { TrackingEvent, TrackingFeatureName } from '@src/tracking/TrackingEvent';
+
+export class ShownEvent implements TrackingEvent {
+	public static readonly EVENT_NAME = 'banner-shown';
+
+	public readonly eventName: string = ShownEvent.EVENT_NAME;
+	public readonly customData: Record<string, string|number> = {};
+	public readonly feature: TrackingFeatureName = 'Page';
+	public readonly userChoice: string = '';
+}

--- a/test/components/BannerConductor/StateMachine/states/VisibleState.spec.ts
+++ b/test/components/BannerConductor/StateMachine/states/VisibleState.spec.ts
@@ -1,14 +1,21 @@
-import { describe, expect, it, vitest } from 'vitest';
+import { beforeEach, describe, expect, it, vitest } from 'vitest';
 import { VisibleState } from '@src/components/BannerConductor/StateMachine/states/VisibleState';
 import { PageStub } from '@test/fixtures/PageStub';
 import { ImpressionCountStub } from '@test/fixtures/ImpressionCountStub';
+import { Tracker } from '@src/tracking/Tracker';
+import { ShownEvent } from '@src/tracking/events/ShownEvent';
 
 describe( 'VisibleState', function () {
+	let tracker: Tracker;
+
+	beforeEach( () => {
+		tracker = { trackEvent: vitest.fn() };
+	} );
 
 	it( 'sets banner size on resize', () => {
 		const page = new PageStub();
 		page.setSpace = vitest.fn( () => page );
-		const visibleState = new VisibleState( page, new ImpressionCountStub() );
+		const visibleState = new VisibleState( page, new ImpressionCountStub(), tracker );
 
 		visibleState.onResize( 42 );
 
@@ -19,7 +26,7 @@ describe( 'VisibleState', function () {
 	it( 'sets banner size on content change', () => {
 		const page = new PageStub();
 		page.setSpace = vitest.fn( () => page );
-		const visibleState = new VisibleState( page, new ImpressionCountStub() );
+		const visibleState = new VisibleState( page, new ImpressionCountStub(), tracker );
 
 		visibleState.onContentChanged( 42 );
 
@@ -27,10 +34,20 @@ describe( 'VisibleState', function () {
 		expect( page.setSpace ).toHaveBeenCalledWith( 42 );
 	} );
 
+	it( 'fires shown event on enter', async () => {
+		const visibleState = new VisibleState( new PageStub(), new ImpressionCountStub(), tracker );
+		const shownEvent = new ShownEvent();
+
+		await visibleState.enter();
+
+		expect( tracker.trackEvent ).toHaveBeenCalledOnce();
+		expect( tracker.trackEvent ).toHaveBeenCalledWith( shownEvent );
+	} );
+
 	it( 'increases banner impression count on enter', async () => {
 		const impressionCountStub = new ImpressionCountStub();
 		impressionCountStub.incrementImpressionCounts = vitest.fn();
-		const visibleState = new VisibleState( new PageStub(), impressionCountStub );
+		const visibleState = new VisibleState( new PageStub(), impressionCountStub, tracker );
 
 		await visibleState.enter();
 


### PR DESCRIPTION
This extends the WPDE tracker and adds an event for tracking impressions.

- Add ShownEvent
- Convert close event names
- Add userChoice to the event name if it exists

Ticket: https://phabricator.wikimedia.org/T350151