### PR TITLE
Move timer mocking into banner tests

### DIFF
--- a/src/components/Slider/KeenSlider.vue
+++ b/src/components/Slider/KeenSlider.vue
@@ -48,6 +48,7 @@ enum SliderPlayingStates {
 
 interface Props {
 	interval?: number;
+	delay?: number;
 	withNavigation: boolean;
 	sliderOptions?: KeenSliderOptions;
 	play?: boolean;
@@ -56,10 +57,12 @@ interface Props {
 const props = withDefaults( defineProps<Props>(), {
 	sliderOptions: () => ( {} ),
 	interval: 5000,
+	delay: 0,
 	play: false
 } );
 
 const sliderPlayingState = ref<SliderPlayingStates>( SliderPlayingStates.PENDING );
+const timeout = ref<number>( 0 );
 const timer = ref<number>( 0 );
 
 const currentSlide = ref<number>( 0 );
@@ -77,12 +80,15 @@ const startAutoplay = (): void => {
 	if ( sliderPlayingState.value === SliderPlayingStates.PLAYING ) {
 		return;
 	}
-	timer.value = window.setInterval( slider.value.next, props.interval );
-	sliderPlayingState.value = SliderPlayingStates.PLAYING;
+	timeout.value = window.setTimeout( () => {
+		timer.value = window.setInterval( slider.value.next, props.interval );
+		sliderPlayingState.value = SliderPlayingStates.PLAYING;
+	}, props.delay );
 };
 
 const stopAutoplay = (): void => {
 	clearInterval( timer.value );
+	clearTimeout( timeout.value );
 	sliderPlayingState.value = SliderPlayingStates.STOPPED;
 };
 

--- a/src/components/Slider/KeenSlider.vue
+++ b/src/components/Slider/KeenSlider.vue
@@ -48,7 +48,7 @@ enum SliderPlayingStates {
 
 interface Props {
 	interval?: number;
-	delay?: number;
+	startDelay?: number;
 	withNavigation: boolean;
 	sliderOptions?: KeenSliderOptions;
 	play?: boolean;
@@ -57,12 +57,12 @@ interface Props {
 const props = withDefaults( defineProps<Props>(), {
 	sliderOptions: () => ( {} ),
 	interval: 5000,
-	delay: 0,
+	startDelay: 0,
 	play: false
 } );
 
 const sliderPlayingState = ref<SliderPlayingStates>( SliderPlayingStates.PENDING );
-const timeout = ref<number>( 0 );
+const startAnimationTimeout = ref<number>( 0 );
 const timer = ref<number>( 0 );
 
 const currentSlide = ref<number>( 0 );
@@ -80,15 +80,15 @@ const startAutoplay = (): void => {
 	if ( sliderPlayingState.value === SliderPlayingStates.PLAYING ) {
 		return;
 	}
-	timeout.value = window.setTimeout( () => {
+	startAnimationTimeout.value = window.setTimeout( () => {
 		timer.value = window.setInterval( slider.value.next, props.interval );
 		sliderPlayingState.value = SliderPlayingStates.PLAYING;
-	}, props.delay );
+	}, props.startDelay );
 };
 
 const stopAutoplay = (): void => {
 	clearInterval( timer.value );
-	clearTimeout( timeout.value );
+	clearTimeout( startAnimationTimeout.value );
 	sliderPlayingState.value = SliderPlayingStates.STOPPED;
 };
 

--- a/test/banners/desktop/components/BannerCtrl.spec.ts
+++ b/test/banners/desktop/components/BannerCtrl.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, test } from 'vitest';
+import { afterEach, beforeEach, describe, test, vi } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/desktop/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -27,6 +27,12 @@ describe( 'BannerCtrl.vue', () => {
 
 	beforeEach( () => {
 		resetFormModel( formModel );
+		vi.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
 	} );
 
 	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {

--- a/test/banners/desktop/components/BannerVar.spec.ts
+++ b/test/banners/desktop/components/BannerVar.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, test } from 'vitest';
+import { afterEach, beforeEach, describe, test, vi } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/desktop/components/BannerVar.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -27,6 +27,12 @@ describe( 'BannerVar.vue', () => {
 
 	beforeEach( () => {
 		resetFormModel( formModel );
+		vi.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
 	} );
 
 	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {

--- a/test/banners/english/components/BannerCtrl.spec.ts
+++ b/test/banners/english/components/BannerCtrl.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, test } from 'vitest';
+import { afterEach, beforeEach, describe, test, vi } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/english/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -22,6 +22,12 @@ describe( 'BannerCtrl.vue', () => {
 
 	beforeEach( () => {
 		resetFormModel( formModel );
+		vi.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
 	} );
 
 	const getWrapper = (): VueWrapper<any> => {

--- a/test/banners/english/components/BannerVar.spec.ts
+++ b/test/banners/english/components/BannerVar.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, test } from 'vitest';
+import { afterEach, beforeEach, describe, test, vi } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/english/components/BannerVar.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -18,10 +18,16 @@ import { bannerMainFeatures } from '@test/features/MainBanner';
 const formModel = useFormModel();
 const translator = ( key: string ): string => key;
 
-describe( 'BannerCtrl.vue', () => {
+describe( 'BannerVar.vue', () => {
 
 	beforeEach( () => {
 		resetFormModel( formModel );
+		vi.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
 	} );
 
 	const getWrapper = (): VueWrapper<any> => {

--- a/test/banners/mobile/components/BannerCtrl.spec.ts
+++ b/test/banners/mobile/components/BannerCtrl.spec.ts
@@ -27,6 +27,7 @@ describe( 'BannerCtrl.vue', () => {
 	let wrapper: VueWrapper<any>;
 	beforeEach( () => {
 		resetFormModel( formModel );
+		vi.useFakeTimers();
 
 		pageScroller = {
 			scrollIntoView: vi.fn(),
@@ -64,6 +65,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	afterEach( () => {
 		wrapper.unmount();
+		vi.restoreAllMocks();
+		vi.useRealTimers();
 	} );
 
 	// skipped because the sentence is not part of the current test

--- a/test/banners/mobile/components/BannerVar.spec.ts
+++ b/test/banners/mobile/components/BannerVar.spec.ts
@@ -28,6 +28,7 @@ describe( 'BannerVar.vue', () => {
 	let wrapper: VueWrapper<any>;
 	beforeEach( () => {
 		resetFormModel( formModel );
+		vi.useFakeTimers();
 
 		pageScroller = {
 			scrollIntoView: vi.fn(),
@@ -69,6 +70,8 @@ describe( 'BannerVar.vue', () => {
 
 	afterEach( () => {
 		wrapper.unmount();
+		vi.restoreAllMocks();
+		vi.useRealTimers();
 	} );
 
 	// skipped because the sentence is not part of the current test

--- a/test/banners/mobile_english/components/BannerCtrl.spec.ts
+++ b/test/banners/mobile_english/components/BannerCtrl.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, test, vi } from 'vitest';
+import { beforeEach, describe, it, vi, test, afterEach } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/mobile_english/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -27,6 +27,7 @@ describe( 'BannerCtrl.vue', () => {
 	let wrapper: VueWrapper<any>;
 	beforeEach( () => {
 		resetFormModel( formModel );
+		vi.useFakeTimers();
 
 		pageScroller = {
 			scrollIntoView: vi.fn(),
@@ -53,6 +54,11 @@ describe( 'BannerCtrl.vue', () => {
 				}
 			}
 		} );
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
 	} );
 
 	describe( 'Donation Form Happy Paths', () => {

--- a/test/banners/mobile_english/components/BannerVar.spec.ts
+++ b/test/banners/mobile_english/components/BannerVar.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, test, vi } from 'vitest';
+import { beforeEach, describe, it, vi, test, afterEach } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/mobile_english/components/BannerVar.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -27,6 +27,7 @@ describe( 'BannerVar.vue', () => {
 	let wrapper: VueWrapper<any>;
 	beforeEach( () => {
 		resetFormModel( formModel );
+		vi.useFakeTimers();
 
 		pageScroller = {
 			scrollIntoView: vi.fn(),
@@ -53,6 +54,11 @@ describe( 'BannerVar.vue', () => {
 				}
 			}
 		} );
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
 	} );
 
 	describe( 'Donation Form Happy Paths', () => {

--- a/test/banners/pad/components/BannerCtrl.spec.ts
+++ b/test/banners/pad/components/BannerCtrl.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test } from 'vitest';
+import { afterEach, beforeEach, describe, test, vi } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/pad/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -24,6 +24,13 @@ describe( 'BannerCtrl.vue', () => {
 	let wrapper: VueWrapper<any>;
 	beforeEach( () => {
 		resetFormModel( formModel );
+		vi.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		wrapper.unmount();
+		vi.restoreAllMocks();
+		vi.useRealTimers();
 	} );
 
 	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
@@ -52,10 +59,6 @@ describe( 'BannerCtrl.vue', () => {
 
 		return wrapper;
 	};
-
-	afterEach( () => {
-		wrapper.unmount();
-	} );
 
 	describe( 'Main Banner', () => {
 		test.each( [

--- a/test/banners/pad/components/BannerVar.spec.ts
+++ b/test/banners/pad/components/BannerVar.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test } from 'vitest';
+import { afterEach, beforeEach, describe, test, vi } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/pad/components/BannerVar.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -23,6 +23,13 @@ describe( 'BannerVar.vue', () => {
 	let wrapper: VueWrapper<any>;
 	beforeEach( () => {
 		resetFormModel( formModel );
+		vi.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		wrapper.unmount();
+		vi.restoreAllMocks();
+		vi.useRealTimers();
 	} );
 
 	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
@@ -51,10 +58,6 @@ describe( 'BannerVar.vue', () => {
 
 		return wrapper;
 	};
-
-	afterEach( () => {
-		wrapper.unmount();
-	} );
 
 	describe( 'Main Banner', () => {
 		test.each( [

--- a/test/banners/pad_english/components/BannerCtrl.spec.ts
+++ b/test/banners/pad_english/components/BannerCtrl.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test } from 'vitest';
+import { afterEach, beforeEach, describe, test, vi } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/pad_english/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -21,6 +21,7 @@ describe( 'BannerCtrl.vue', () => {
 	let wrapper: VueWrapper<any>;
 	beforeEach( () => {
 		resetFormModel( formModel );
+		vi.useFakeTimers();
 
 		// attachTo the document body to fix an issue with Vue Test Utils where
 		// clicking a submit button in a form does not fire the submit event
@@ -48,6 +49,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	afterEach( () => {
 		wrapper.unmount();
+		vi.restoreAllMocks();
+		vi.useRealTimers();
 	} );
 
 	describe( 'Main Banner', () => {

--- a/test/banners/pad_english/components/BannerVar.spec.ts
+++ b/test/banners/pad_english/components/BannerVar.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test } from 'vitest';
+import { afterEach, beforeEach, describe, test, vi } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/pad_english/components/BannerVar.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -22,6 +22,7 @@ describe( 'BannerVar.vue', () => {
 	let wrapper: VueWrapper<any>;
 	beforeEach( () => {
 		resetFormModel( formModel );
+		vi.useFakeTimers();
 
 		// attachTo the document body to fix an issue with Vue Test Utils where
 		// clicking a submit button in a form does not fire the submit event
@@ -49,6 +50,8 @@ describe( 'BannerVar.vue', () => {
 
 	afterEach( () => {
 		wrapper.unmount();
+		vi.restoreAllMocks();
+		vi.useRealTimers();
 	} );
 
 	describe( 'Main Banner', () => {

--- a/test/banners/wpde_desktop/components/BannerCtrl.spec.ts
+++ b/test/banners/wpde_desktop/components/BannerCtrl.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, test } from 'vitest';
+import { afterEach, beforeEach, describe, test, vi } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/wpde_desktop/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -28,6 +28,12 @@ describe( 'BannerCtrl.vue', () => {
 
 	beforeEach( () => {
 		resetFormModel( formModel );
+		vi.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
 	} );
 
 	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {

--- a/test/banners/wpde_desktop/components/BannerVar.spec.ts
+++ b/test/banners/wpde_desktop/components/BannerVar.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, test } from 'vitest';
+import { afterEach, beforeEach, describe, test, vi } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '../../../../banners/wpde_desktop/components/BannerVar.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -24,6 +24,12 @@ describe( 'BannerCtrl.vue', () => {
 
 	beforeEach( () => {
 		resetFormModel( formModel );
+		vi.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
 	} );
 
 	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {

--- a/test/banners/wpde_mobile/components/BannerCtrl.spec.ts
+++ b/test/banners/wpde_mobile/components/BannerCtrl.spec.ts
@@ -27,11 +27,18 @@ describe( 'BannerCtrl.vue', () => {
 	let wrapper: VueWrapper<any>;
 	beforeEach( () => {
 		resetFormModel( formModel );
+		vi.useFakeTimers();
 
 		pageScroller = {
 			scrollIntoView: vi.fn(),
 			scrollToTop: vi.fn()
 		};
+	} );
+
+	afterEach( () => {
+		wrapper.unmount();
+		vi.restoreAllMocks();
+		vi.useRealTimers();
 	} );
 
 	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
@@ -61,10 +68,6 @@ describe( 'BannerCtrl.vue', () => {
 
 		return wrapper;
 	};
-
-	afterEach( () => {
-		wrapper.unmount();
-	} );
 
 	describe( 'Content', () => {
 		test.each( [

--- a/test/components/Slider/KeenSlider.spec.ts
+++ b/test/components/Slider/KeenSlider.spec.ts
@@ -59,7 +59,7 @@ describe( 'KeenSlider', () => {
 	it( 'should start after a delay if one is passed', async () => {
 		const wrapper = getWrapper();
 
-		await wrapper.setProps( { delay: 100 } );
+		await wrapper.setProps( { startDelay: 100 } );
 		await wrapper.setProps( { play: true } );
 
 		await vi.advanceTimersByTimeAsync( 99 );

--- a/test/components/Slider/KeenSlider.spec.ts
+++ b/test/components/Slider/KeenSlider.spec.ts
@@ -11,6 +11,7 @@ describe( 'KeenSlider', () => {
 
 	afterEach( () => {
 		vi.restoreAllMocks();
+		vi.useRealTimers();
 	} );
 
 	const getWrapper = (): VueWrapper<any> => {
@@ -47,9 +48,25 @@ describe( 'KeenSlider', () => {
 		const wrapper = getWrapper();
 
 		await wrapper.setProps( { play: true } );
-		await vi.advanceTimersByTimeAsync( 400 );
 
-		expect( wrapper.find( '.wmde-banner-slide:nth-child(2) .wmde-banner-slide--current' ).exists ).toBeTruthy();
+		await vi.advanceTimersByTimeAsync( 199 );
+		expect( wrapper.find( '.wmde-banner-slide:nth-child(1) .wmde-banner-slide--current' ).exists() ).toBeTruthy();
+
+		await vi.advanceTimersByTimeAsync( 2 );
+		expect( wrapper.find( '.wmde-banner-slide:nth-child(2) .wmde-banner-slide--current' ).exists() ).toBeTruthy();
+	} );
+
+	it( 'should start after a delay if one is passed', async () => {
+		const wrapper = getWrapper();
+
+		await wrapper.setProps( { delay: 100 } );
+		await wrapper.setProps( { play: true } );
+
+		await vi.advanceTimersByTimeAsync( 99 );
+		expect( wrapper.find( '.wmde-banner-slider--pending' ).exists() ).toBeTruthy();
+
+		await vi.advanceTimersByTimeAsync( 2 );
+		expect( wrapper.find( '.wmde-banner-slider--playing' ).exists() ).toBeTruthy();
 	} );
 
 	it( 'should show a pagination dot for each exising slide', async () => {

--- a/test/features/BannerContent.ts
+++ b/test/features/BannerContent.ts
@@ -7,6 +7,8 @@ import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 const expectSlideShowPlaysWhenBecomesVisible = async ( wrapper: VueWrapper<any> ): Promise<any> => {
 	await wrapper.setProps( { bannerState: BannerStates.Visible } );
 
+	await vi.runOnlyPendingTimersAsync();
+
 	expect( wrapper.find( '.wmde-banner-slider--playing' ).exists() ).toBeTruthy();
 };
 

--- a/test/features/BannerContent.ts
+++ b/test/features/BannerContent.ts
@@ -11,15 +11,12 @@ const expectSlideShowPlaysWhenBecomesVisible = async ( wrapper: VueWrapper<any> 
 };
 
 const expectSlideShowStopsOnFormInteraction = async ( wrapper: VueWrapper<any> ): Promise<any> => {
-	vi.useFakeTimers();
-
 	await wrapper.setProps( { bannerState: BannerStates.Visible } );
 	await wrapper.find( '.wmde-banner-form' ).trigger( 'click' );
-	await vi.runOnlyPendingTimers();
+
+	await vi.runAllTimersAsync();
 
 	expect( wrapper.find( '.wmde-banner-slider--stopped' ).exists() ).toBeTruthy();
-
-	vi.restoreAllMocks();
 };
 
 const expectShowsSlideShowOnSmallSizes = async ( getWrapper: () => VueWrapper<any> ): Promise<any> => {

--- a/test/features/MiniBanner.ts
+++ b/test/features/MiniBanner.ts
@@ -1,9 +1,11 @@
 import { VueWrapper } from '@vue/test-utils';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 
 const expectSlideShowPlaysWhenMiniBannerBecomesVisible = async ( wrapper: VueWrapper<any> ): Promise<any> => {
 	await wrapper.setProps( { bannerState: BannerStates.Visible } );
+
+	await vi.runOnlyPendingTimersAsync();
 
 	expect( wrapper.find( '.wmde-banner-slider--playing' ).exists() ).toBeTruthy();
 };

--- a/test/features/SetCookieImage.ts
+++ b/test/features/SetCookieImage.ts
@@ -9,14 +9,11 @@ const expectSetsCookieImageOnSoftCloseClose = async ( wrapper: VueWrapper<any> )
 };
 
 const expectSetsCookieImageOnSoftCloseTimeOut = async ( wrapper: VueWrapper<any> ): Promise<any> => {
-	vi.useFakeTimers();
-
 	await wrapper.find( '.wmde-banner-close' ).trigger( 'click' );
-	await vi.runAllTimers();
+
+	await vi.runAllTimersAsync();
 
 	expect( wrapper.find( '.wmde-banner-set-cookie-image' ).exists() ).toBeTruthy();
-
-	vi.restoreAllMocks();
 };
 
 const expectDoesNotSetCookieImageOnSoftCloseMaybeLater = async ( wrapper: VueWrapper<any> ): Promise<any> => {

--- a/test/features/SoftCloseDesktop.ts
+++ b/test/features/SoftCloseDesktop.ts
@@ -26,15 +26,12 @@ const expectEmitsSoftCloseMaybeLaterEvent = async ( wrapper: VueWrapper<any> ): 
 };
 
 const expectEmitsSoftCloseTimeOutEvent = async ( wrapper: VueWrapper<any> ): Promise<any> => {
-	vi.useFakeTimers();
-
 	await wrapper.find( '.wmde-banner-close' ).trigger( 'click' );
-	await vi.runAllTimers();
+
+	await vi.runAllTimersAsync();
 
 	expect( wrapper.emitted( 'bannerClosed' ).length ).toBe( 1 );
 	expect( wrapper.emitted( 'bannerClosed' )[ 0 ][ 0 ] ).toEqual( new CloseEvent( 'SoftClose', CloseChoices.TimeOut ) );
-
-	vi.restoreAllMocks();
 };
 
 const expectEmitsBannerContentChangedOnSoftClose = async ( wrapper: VueWrapper<any> ): Promise<any> => {

--- a/test/features/SoftCloseMobile.ts
+++ b/test/features/SoftCloseMobile.ts
@@ -35,15 +35,12 @@ const expectEmitsSoftCloseMaybeLaterEvent = async ( wrapper: VueWrapper<any> ): 
 };
 
 const expectEmitsSoftCloseTimeOutEvent = async ( wrapper: VueWrapper<any> ): Promise<any> => {
-	vi.useFakeTimers();
-
 	await wrapper.find( '.wmde-banner-mini-close-button' ).trigger( 'click' );
+
 	await vi.runAllTimersAsync();
 
 	expect( wrapper.emitted( 'bannerClosed' ).length ).toBe( 1 );
 	expect( wrapper.emitted( 'bannerClosed' )[ 0 ][ 0 ] ).toEqual( new CloseEvent( 'SoftClose', CloseChoices.TimeOut ) );
-
-	vi.restoreAllMocks();
 };
 
 const expectEmitsBannerContentChangedOnSoftClose = async ( wrapper: VueWrapper<any> ): Promise<any> => {


### PR DESCRIPTION
Some of the timer mocking in the Banner tests weren't set up correctly and tests were only working because of their order.

This moves the mocking and resetting into `beforeEach` and `afterEach` methods so every feature test is
set up and cleared properly.