### PR TITLE
Make display switch test width configurable

### DIFF
--- a/test/banners/desktop/components/BannerCtrl.spec.ts
+++ b/test/banners/desktop/components/BannerCtrl.spec.ts
@@ -69,9 +69,9 @@ describe( 'BannerCtrl.vue', () => {
 
 		test.each( [
 			[ 'expectShowsSlideShowOnSmallSizes' ],
-			[ 'expectShowsMessageOnSmallSizes' ]
+			[ 'expectShowsMessageOnLargeSizes' ]
 		] )( '%s', async ( testName: string ) => {
-			await bannerContentDisplaySwitchFeatures[ testName ]( getWrapper );
+			await bannerContentDisplaySwitchFeatures[ testName ]( getWrapper, 1300 );
 		} );
 
 		test.skip.each( [

--- a/test/banners/desktop/components/BannerVar.spec.ts
+++ b/test/banners/desktop/components/BannerVar.spec.ts
@@ -69,9 +69,9 @@ describe( 'BannerVar.vue', () => {
 
 		test.each( [
 			[ 'expectShowsSlideShowOnSmallSizes' ],
-			[ 'expectShowsMessageOnSmallSizes' ]
+			[ 'expectShowsMessageOnLargeSizes' ]
 		] )( '%s', async ( testName: string ) => {
-			await bannerContentDisplaySwitchFeatures[ testName ]( getWrapper );
+			await bannerContentDisplaySwitchFeatures[ testName ]( getWrapper, 1300 );
 		} );
 
 		test.skip.each( [

--- a/test/banners/english/components/BannerCtrl.spec.ts
+++ b/test/banners/english/components/BannerCtrl.spec.ts
@@ -64,9 +64,9 @@ describe( 'BannerCtrl.vue', () => {
 
 		test.each( [
 			[ 'expectShowsSlideShowOnSmallSizes' ],
-			[ 'expectShowsMessageOnSmallSizes' ]
+			[ 'expectShowsMessageOnLargeSizes' ]
 		] )( '%s', async ( testName: string ) => {
-			await bannerContentDisplaySwitchFeatures[ testName ]( getWrapper );
+			await bannerContentDisplaySwitchFeatures[ testName ]( getWrapper, 1300 );
 		} );
 	} );
 

--- a/test/banners/english/components/BannerVar.spec.ts
+++ b/test/banners/english/components/BannerVar.spec.ts
@@ -64,9 +64,9 @@ describe( 'BannerCtrl.vue', () => {
 
 		test.each( [
 			[ 'expectShowsSlideShowOnSmallSizes' ],
-			[ 'expectShowsMessageOnSmallSizes' ]
+			[ 'expectShowsMessageOnLargeSizes' ]
 		] )( '%s', async ( testName: string ) => {
-			await bannerContentDisplaySwitchFeatures[ testName ]( getWrapper );
+			await bannerContentDisplaySwitchFeatures[ testName ]( getWrapper, 1300 );
 		} );
 	} );
 

--- a/test/banners/wpde_desktop/components/BannerCtrl.spec.ts
+++ b/test/banners/wpde_desktop/components/BannerCtrl.spec.ts
@@ -70,9 +70,9 @@ describe( 'BannerCtrl.vue', () => {
 
 		test.each( [
 			[ 'expectShowsSlideShowOnSmallSizes' ],
-			[ 'expectShowsMessageOnSmallSizes' ]
+			[ 'expectShowsMessageOnLargeSizes' ]
 		] )( '%s', async ( testName: string ) => {
-			await bannerContentDisplaySwitchFeatures[ testName ]( getWrapper );
+			await bannerContentDisplaySwitchFeatures[ testName ]( getWrapper, 1300 );
 		} );
 
 		test.each( [

--- a/test/banners/wpde_desktop/components/BannerVar.spec.ts
+++ b/test/banners/wpde_desktop/components/BannerVar.spec.ts
@@ -66,9 +66,9 @@ describe( 'BannerCtrl.vue', () => {
 
 		test.each( [
 			[ 'expectShowsSlideShowOnSmallSizes' ],
-			[ 'expectShowsMessageOnSmallSizes' ]
+			[ 'expectShowsMessageOnLargeSizes' ]
 		] )( '%s', async ( testName: string ) => {
-			await bannerContentDisplaySwitchFeatures[ testName ]( getWrapper );
+			await bannerContentDisplaySwitchFeatures[ testName ]( getWrapper, 1300 );
 		} );
 	} );
 

--- a/test/features/BannerContent.ts
+++ b/test/features/BannerContent.ts
@@ -22,15 +22,15 @@ const expectSlideShowStopsOnFormInteraction = async ( wrapper: VueWrapper<any> )
 	vi.restoreAllMocks();
 };
 
-const expectShowsSlideShowOnSmallSizes = async ( getWrapper: () => VueWrapper<any> ): Promise<any> => {
-	Object.defineProperty( window, 'innerWidth', { writable: true, configurable: true, value: 1300 } );
+const expectShowsSlideShowOnSmallSizes = async ( getWrapper: () => VueWrapper<any>, minWidthForLargeScreen: number ): Promise<any> => {
+	Object.defineProperty( window, 'innerWidth', { writable: true, configurable: true, value: minWidthForLargeScreen } );
 	const wrapper = getWrapper();
 
 	expect( wrapper.find( '.wmde-banner-slider' ).exists() ).toBeTruthy();
 };
 
-const expectShowsMessageOnSmallSizes = async ( getWrapper: () => VueWrapper<any> ): Promise<any> => {
-	Object.defineProperty( window, 'innerWidth', { writable: true, configurable: true, value: 1301 } );
+const expectShowsMessageOnLargeSizes = async ( getWrapper: () => VueWrapper<any>, minWidthForLargeScreen: number ): Promise<any> => {
+	Object.defineProperty( window, 'innerWidth', { writable: true, configurable: true, value: minWidthForLargeScreen + 1 } );
 	const wrapper = getWrapper();
 
 	expect( wrapper.find( '.wmde-banner-message' ).exists() ).toBeTruthy();
@@ -71,9 +71,9 @@ export const bannerContentFeatures: Record<string, ( wrapper: VueWrapper<any> ) 
 	expectSlideShowStopsOnFormInteraction
 };
 
-export const bannerContentDisplaySwitchFeatures: Record<string, ( getWrapper: () => VueWrapper<any> ) => Promise<any>> = {
+export const bannerContentDisplaySwitchFeatures: Record<string, ( getWrapper: () => VueWrapper<any>, minWidthForLargeScreen: number ) => Promise<any>> = {
 	expectShowsSlideShowOnSmallSizes,
-	expectShowsMessageOnSmallSizes
+	expectShowsMessageOnLargeSizes
 };
 
 export const bannerContentAnimatedTextFeatures: Record<string, ( getWrapper: () => VueWrapper<any> ) => Promise<any>> = {


### PR DESCRIPTION
We're going to test if displaying the slider to larger sizes has an effect. The window width in the tests for the switcher now needs to be configurable.

Ticket: https://phabricator.wikimedia.org/T350573