### PR TITLE
[Follow Up] Add a type parameter to TrackingEvent 

### DIFF
--- a/archive/desktop/C23_WMDE_Desktop_DE_00/event_map.ts
+++ b/archive/desktop/C23_WMDE_Desktop_DE_00/event_map.ts
@@ -16,7 +16,7 @@ export default new Map<string, TrackingEventConverterFactory>( [
 	[ FormStepShownEvent.EVENT_NAME, mapFormStepShownEvent ],
 	[ CustomAmountChangedEvent.EVENT_NAME,
 		( e: CustomAmountChangedEvent ): WMDELegacyBannerEvent =>
-			new WMDELegacyBannerEvent( e.customData.amountChange + '-amount', 1 )
+			new WMDELegacyBannerEvent( e.userChoice + '-amount', 1 )
 	],
 	[ NotShownEvent.EVENT_NAME, mapNotShownEvent ],
 	[ BannerSubmitEvent.EVENT_NAME, ( e: BannerSubmitEvent ): WMDESizeIssueEvent => {

--- a/archive/desktop/C23_WMDE_Desktop_DE_00/event_map_var.ts
+++ b/archive/desktop/C23_WMDE_Desktop_DE_00/event_map_var.ts
@@ -13,7 +13,7 @@ CtrlEventMap.set( BannerSubmitEvent.EVENT_NAME,
 );
 CtrlEventMap.set( UpgradeToYearlyEvent.EVENT_NAME,
 	( e: BannerSubmitEvent ): WMDELegacyBannerEvent => {
-		return new WMDELegacyBannerEvent( e.customData.optionSelected, 1 );
+		return new WMDELegacyBannerEvent( e.userChoice, 1 );
 	}
 );
 

--- a/src/components/BannerConductor/BannerConductor.vue
+++ b/src/components/BannerConductor/BannerConductor.vue
@@ -71,7 +71,7 @@ function onContentChanged(): void {
 	} );
 }
 
-async function closeHandler( closeEvent: TrackingEvent ): Promise<any> {
+async function closeHandler( closeEvent: TrackingEvent<void> ): Promise<any> {
 	await stateMachine.changeState( stateFactory.newClosedState( closeEvent ) );
 }
 

--- a/src/components/BannerConductor/StateMachine/states/ClosedState.ts
+++ b/src/components/BannerConductor/StateMachine/states/ClosedState.ts
@@ -7,12 +7,12 @@ import { TrackingEvent } from '@src/tracking/TrackingEvent';
 
 export class ClosedState extends BannerState {
 	public readonly stateName: BannerStates = BannerStates.Closed;
-	private readonly _closeEvent: TrackingEvent;
+	private readonly _closeEvent: TrackingEvent<void>;
 	private _page: Page;
 	private _tracker: Tracker;
 	private _resizeHandler: ResizeHandler;
 
-	public constructor( closeEvent: TrackingEvent, page: Page, tracker: Tracker, resizeHandler: ResizeHandler ) {
+	public constructor( closeEvent: TrackingEvent<void>, page: Page, tracker: Tracker, resizeHandler: ResizeHandler ) {
 		super();
 		this._closeEvent = closeEvent;
 		this._page = page;

--- a/src/components/BannerConductor/StateMachine/states/NotShownState.ts
+++ b/src/components/BannerConductor/StateMachine/states/NotShownState.ts
@@ -24,20 +24,12 @@ export class NotShownState extends BannerState {
 	}
 
 	public enter(): Promise<any> {
-		let customEventData: Record<string, string | number> = {};
-		if ( this._bannerNotShownReason === BannerNotShownReasons.SizeIssue ) {
-			customEventData = {
-				reason: this._bannerNotShownReason,
-				bannerHeight: this._bannerHeight,
-				viewportWidth: window.innerWidth,
-				viewportHeight: window.innerHeight
-			};
-		} else {
-			customEventData = {
-				reason: this._bannerNotShownReason
-			};
-		}
-		this._tracker.trackEvent( new NotShownEvent( customEventData ) );
+		this._tracker.trackEvent( new NotShownEvent( {
+			reason: this._bannerNotShownReason,
+			bannerHeight: this._bannerHeight,
+			viewportWidth: window.innerWidth,
+			viewportHeight: window.innerHeight
+		} ) );
 		this._page
 			.preventImpressionCountForHiddenBanner()
 			.removePageEventListeners();

--- a/src/components/BannerConductor/StateMachine/states/StateFactory.ts
+++ b/src/components/BannerConductor/StateMachine/states/StateFactory.ts
@@ -48,7 +48,7 @@ export class StateFactory {
 		return new VisibleState( this._page, this._impressionCount, this._tracker );
 	}
 
-	public newClosedState( closeEvent: TrackingEvent ): BannerState {
+	public newClosedState( closeEvent: TrackingEvent<void> ): BannerState {
 		return new ClosedState( closeEvent, this._page, this._tracker, this._resizeHandler );
 	}
 }

--- a/src/components/DonationForm/MultiStepDonation.vue
+++ b/src/components/DonationForm/MultiStepDonation.vue
@@ -73,7 +73,7 @@ const multistepCallbacks = {
 		currentStepIndex.value = pageIndex;
 		slider.value.moveToIdx( pageIndex );
 	},
-	async submit( eventData: TrackingEvent ): Promise<void> {
+	async submit( eventData: TrackingEvent<void> ): Promise<void> {
 		tracker.trackEvent( eventData );
 		await nextTick();
 		submitFormRef.value.submit();

--- a/src/components/DonationForm/StepNavigation.ts
+++ b/src/components/DonationForm/StepNavigation.ts
@@ -2,5 +2,5 @@ import { TrackingEvent } from '@src/tracking/TrackingEvent';
 
 export interface StepAction {
 	goToStep( pageName: string ): Promise<void>;
-	submit( eventData: TrackingEvent ): Promise<void>;
+	submit( eventData: TrackingEvent<void> ): Promise<void>;
 }

--- a/src/page/Page.ts
+++ b/src/page/Page.ts
@@ -15,7 +15,7 @@ export interface Page {
 	unsetAnimated: () => Page;
 	showBanner: () => Page;
 	preventImpressionCountForHiddenBanner: () => Page;
-	setCloseCookieIfNecessary: ( closeEvent: TrackingEvent ) => Page;
+	setCloseCookieIfNecessary: ( closeEvent: TrackingEvent<void> ) => Page;
 	getCampaignParameters: () => CampaignParameters;
 	getTracking: () => TrackingParameters;
 }

--- a/src/page/PageWPORG.ts
+++ b/src/page/PageWPORG.ts
@@ -113,7 +113,7 @@ class PageWPORG implements Page {
 		return this;
 	}
 
-	public setCloseCookieIfNecessary( closeEvent: TrackingEvent ): Page {
+	public setCloseCookieIfNecessary( closeEvent: TrackingEvent<void> ): Page {
 		switch ( closeEvent.userChoice ) {
 			case CloseChoices.Close:
 			case CloseChoices.TimeOut:

--- a/src/tracking/LegacyEventTracking/mapNotShownEvent.ts
+++ b/src/tracking/LegacyEventTracking/mapNotShownEvent.ts
@@ -2,6 +2,7 @@ import { BannerNotShownReasons, isNotShownReason } from '@src/page/BannerNotShow
 import { TrackingEvent } from '@src/tracking/TrackingEvent';
 import { WMDESizeIssueEvent } from '@src/tracking/WPORG/WMDEBannerSizeIssue';
 import { WMDELegacyBannerEvent } from '@src/tracking/WPORG/WMDELegacyBannerEvent';
+import { NotShownCustomData } from '@src/tracking/events/NotShownEvent';
 
 const notShownReasonToLegacyName = new Map<BannerNotShownReasons, string>( [
 	[ BannerNotShownReasons.SizeIssue, 'size_issue' ],
@@ -14,7 +15,7 @@ export const DEFAULT_UNKNOWN_EVENT = 'not-shown-for-unknown-reasons';
 /**
  * @deprecated Will be removed when the new tracking schema is implemented
  */
-export function mapNotShownEvent( notShownEvent: TrackingEvent ): WMDESizeIssueEvent|WMDELegacyBannerEvent {
+export function mapNotShownEvent( notShownEvent: TrackingEvent<NotShownCustomData> ): WMDESizeIssueEvent|WMDELegacyBannerEvent {
 	if ( notShownEvent.customData.reason === BannerNotShownReasons.SizeIssue ) {
 		return new WMDESizeIssueEvent(
 			notShownReasonToLegacyName.get( BannerNotShownReasons.SizeIssue ),

--- a/src/tracking/LegacyTrackerWPORG.ts
+++ b/src/tracking/LegacyTrackerWPORG.ts
@@ -4,7 +4,7 @@ import { MediaWiki } from '@src/page/MediaWiki/MediaWiki';
 import { WMDESizeIssueEvent } from '@src/tracking/WPORG/WMDEBannerSizeIssue';
 import { WMDELegacyBannerEvent } from '@src/tracking/WPORG/WMDELegacyBannerEvent';
 
-export type TrackingEventConverterFactory = ( event: TrackingEvent ) => WMDELegacyBannerEvent|WMDESizeIssueEvent;
+export type TrackingEventConverterFactory = ( event: TrackingEvent<any> ) => WMDELegacyBannerEvent|WMDESizeIssueEvent;
 
 type EventNameMap = Map<string, TrackingEventConverterFactory>;
 
@@ -23,7 +23,7 @@ export class LegacyTrackerWPORG implements Tracker {
 		this._supportedTrackingEvents = supportedTrackingEvents;
 	}
 
-	public trackEvent( event: TrackingEvent ): void {
+	public trackEvent( event: TrackingEvent<void> ): void {
 		if ( !this._supportedTrackingEvents.has( event.eventName ) ) {
 			return;
 		}

--- a/src/tracking/Tracker.ts
+++ b/src/tracking/Tracker.ts
@@ -5,5 +5,5 @@ import { TrackingEvent } from '@src/tracking/TrackingEvent';
  * tracking system, e.g. MediaWiki event tracking (on mw.org) or Matomo (on mw.de)
  */
 export interface Tracker {
-    trackEvent: ( trackingData: TrackingEvent ) => void;
+    trackEvent: ( trackingData: TrackingEvent<any> ) => void;
 }

--- a/src/tracking/TrackerWPDE.ts
+++ b/src/tracking/TrackerWPDE.ts
@@ -43,7 +43,7 @@ export class TrackerWPDE implements Tracker {
 		this.trackItemsInEventQueue();
 	}
 
-	public trackEvent( event: TrackingEvent ): void {
+	public trackEvent( event: TrackingEvent<void> ): void {
 		if ( !this._trackingRatesForEvents.has( event.eventName ) ) {
 			return;
 		}
@@ -87,7 +87,7 @@ export class TrackerWPDE implements Tracker {
 	 * @param {TrackingEvent} event
 	 * @private
 	 */
-	private getEventNameFromEvent( event: TrackingEvent ): string {
+	private getEventNameFromEvent( event: TrackingEvent<void> ): string {
 		switch ( event.eventName ) {
 			case CustomAmountChangedEvent.EVENT_NAME:
 				return event.userChoice + '-amount';

--- a/src/tracking/TrackingEvent.ts
+++ b/src/tracking/TrackingEvent.ts
@@ -14,7 +14,10 @@ export type TrackingFeatureName = '' |
 	'UpgradeToYearlyForm' |
 	'AddressTypeForm';
 
-export interface TrackingEvent {
+/**
+ * @param T - Defines the type of the customData property
+ */
+export interface TrackingEvent<T> {
 	/**
 	 * What type of event this is
 	 *
@@ -42,5 +45,5 @@ export interface TrackingEvent {
 	 *
 	 * Example: Viewport data (banner height, screen width and height) for size issues
 	 */
-	customData: Record<string, string|number>;
+	customData: T;
 }

--- a/src/tracking/events/AlreadyDonatedShownEvent.ts
+++ b/src/tracking/events/AlreadyDonatedShownEvent.ts
@@ -1,10 +1,10 @@
 import { TrackingEvent, TrackingFeatureName } from '@src/tracking/TrackingEvent';
 
-export class AlreadyDonatedShownEvent implements TrackingEvent {
+export class AlreadyDonatedShownEvent implements TrackingEvent<void> {
 	public static readonly EVENT_NAME = 'already-donated-shown';
 
 	public readonly eventName: string = AlreadyDonatedShownEvent.EVENT_NAME;
-	public readonly customData: Record<string, string|number> = {};
+	public readonly customData: void;
 	public readonly feature: TrackingFeatureName = 'AlreadyDonatedModal';
 	public readonly userChoice: string = '';
 }

--- a/src/tracking/events/BannerSubmitEvent.ts
+++ b/src/tracking/events/BannerSubmitEvent.ts
@@ -1,12 +1,12 @@
 import { TrackingEvent, TrackingFeatureName } from '@src/tracking/TrackingEvent';
 
-export class BannerSubmitEvent implements TrackingEvent {
+export class BannerSubmitEvent implements TrackingEvent<void> {
 	public static readonly EVENT_NAME = 'submit';
 
 	public readonly eventName = BannerSubmitEvent.EVENT_NAME;
 	public readonly feature: TrackingFeatureName;
 	public readonly userChoice: string;
-	public readonly customData: Record<string, string> = {};
+	public readonly customData: void;
 
 	public constructor( feature: TrackingFeatureName, userChoice: string = '' ) {
 		this.feature = feature;

--- a/src/tracking/events/ClickAlreadyDonatedEvent.ts
+++ b/src/tracking/events/ClickAlreadyDonatedEvent.ts
@@ -1,10 +1,10 @@
 import { TrackingEvent, TrackingFeatureName } from '@src/tracking/TrackingEvent';
 
-export class ClickAlreadyDonatedEvent implements TrackingEvent {
+export class ClickAlreadyDonatedEvent implements TrackingEvent<void> {
 	public static readonly EVENT_NAME = 'clicked-already-donated';
 
 	public readonly eventName = ClickAlreadyDonatedEvent.EVENT_NAME;
-	public readonly customData: Record<string, string> = {};
+	public readonly customData: void;
 	public readonly feature: TrackingFeatureName = 'AlreadyDonatedModal';
 	public readonly userChoice: string = '';
 }

--- a/src/tracking/events/CloseEvent.ts
+++ b/src/tracking/events/CloseEvent.ts
@@ -1,10 +1,10 @@
 import { TrackingEvent, TrackingFeatureName } from '@src/tracking/TrackingEvent';
 
-export class CloseEvent implements TrackingEvent {
+export class CloseEvent implements TrackingEvent<void> {
 	public static readonly EVENT_NAME = 'close';
 
 	public readonly eventName: string = CloseEvent.EVENT_NAME;
-	public readonly customData: Record<string, string> = {};
+	public readonly customData: void;
 
 	public constructor(
 		public readonly feature: TrackingFeatureName = '',

--- a/src/tracking/events/CustomAmountChangedEvent.ts
+++ b/src/tracking/events/CustomAmountChangedEvent.ts
@@ -1,10 +1,10 @@
 import { TrackingEvent, TrackingFeatureName } from '@src/tracking/TrackingEvent';
 
-export class CustomAmountChangedEvent implements TrackingEvent {
+export class CustomAmountChangedEvent implements TrackingEvent<void> {
 	public static readonly EVENT_NAME = 'custom-amount-changed';
 
 	public readonly eventName = CustomAmountChangedEvent.EVENT_NAME;
-	public readonly customData: Record<string, string> = {};
+	public readonly customData: void;
 	public readonly feature: TrackingFeatureName = 'CustomAmountForm';
 	public readonly userChoice: string;
 

--- a/src/tracking/events/FormStepShownEvent.ts
+++ b/src/tracking/events/FormStepShownEvent.ts
@@ -1,11 +1,11 @@
 import { TrackingEvent, TrackingFeatureName } from '@src/tracking/TrackingEvent';
 
-export class FormStepShownEvent implements TrackingEvent {
+export class FormStepShownEvent implements TrackingEvent<void> {
 	public static readonly EVENT_NAME = 'form-step-shown';
 
 	public readonly eventName = FormStepShownEvent.EVENT_NAME;
 	public readonly feature: TrackingFeatureName;
-	public readonly customData: Record<string, string> = {};
+	public readonly customData: void;
 	public readonly userChoice: string = '';
 
 	public constructor( feature: TrackingFeatureName ) {

--- a/src/tracking/events/MobileMiniBannerExpandedEvent.ts
+++ b/src/tracking/events/MobileMiniBannerExpandedEvent.ts
@@ -1,11 +1,11 @@
 import { TrackingEvent, TrackingFeatureName } from '@src/tracking/TrackingEvent';
 
-export class MobileMiniBannerExpandedEvent implements TrackingEvent {
+export class MobileMiniBannerExpandedEvent implements TrackingEvent<void> {
 
 	public static readonly EVENT_NAME = 'mobile-mini-banner-expanded';
 
 	public readonly eventName = MobileMiniBannerExpandedEvent.EVENT_NAME;
-	public readonly customData: Record<string, string> = {};
+	public readonly customData: void;
 	public readonly feature: TrackingFeatureName = 'MiniBanner';
 	public readonly userChoice: string = '';
 

--- a/src/tracking/events/NotShownEvent.ts
+++ b/src/tracking/events/NotShownEvent.ts
@@ -1,16 +1,22 @@
 import { TrackingEvent, TrackingFeatureName } from '@src/tracking/TrackingEvent';
+import { BannerNotShownReasons } from '@src/page/BannerNotShownReasons';
 
-export class NotShownEvent implements TrackingEvent {
+export interface NotShownCustomData {
+	reason: BannerNotShownReasons;
+	bannerHeight: number;
+	viewportWidth: number;
+	viewportHeight: number;
+}
+
+export class NotShownEvent implements TrackingEvent<NotShownCustomData> {
 	public static readonly EVENT_NAME = 'not-shown';
-	public static readonly DEFAULT_REASON = 'unknown-reason';
 
 	public readonly eventName: string = NotShownEvent.EVENT_NAME;
-	public readonly customData: Record<string, string|number>;
+	public readonly customData: NotShownCustomData;
 	public readonly feature: TrackingFeatureName = 'Page';
 	public readonly userChoice: string = '';
 
-	public constructor( customData: Record<string, string|number> = {} ) {
+	public constructor( customData: NotShownCustomData ) {
 		this.customData = customData;
-		this.customData.reason = customData.reason || NotShownEvent.DEFAULT_REASON;
 	}
 }

--- a/src/tracking/events/ShownEvent.ts
+++ b/src/tracking/events/ShownEvent.ts
@@ -1,10 +1,10 @@
 import { TrackingEvent, TrackingFeatureName } from '@src/tracking/TrackingEvent';
 
-export class ShownEvent implements TrackingEvent {
+export class ShownEvent implements TrackingEvent<void> {
 	public static readonly EVENT_NAME = 'banner-shown';
 
 	public readonly eventName: string = ShownEvent.EVENT_NAME;
-	public readonly customData: Record<string, string|number> = {};
+	public readonly customData: void;
 	public readonly feature: TrackingFeatureName = 'Page';
 	public readonly userChoice: string = '';
 }

--- a/src/tracking/events/UpgradeToYearlyEvent.ts
+++ b/src/tracking/events/UpgradeToYearlyEvent.ts
@@ -1,10 +1,10 @@
 import { TrackingEvent, TrackingFeatureName } from '@src/tracking/TrackingEvent';
 
-export class UpgradeToYearlyEvent implements TrackingEvent {
+export class UpgradeToYearlyEvent implements TrackingEvent<void> {
 	public static readonly EVENT_NAME = 'upgrade-to-yearly';
 
 	public readonly eventName = UpgradeToYearlyEvent.EVENT_NAME;
-	public readonly customData: Record<string, string> = {};
+	public readonly customData: void;
 	public readonly feature: TrackingFeatureName = 'UpgradeToYearlyForm';
 	public readonly userChoice: string;
 

--- a/test/components/BannerConductor/StateMachine/states/NotShownState.spec.ts
+++ b/test/components/BannerConductor/StateMachine/states/NotShownState.spec.ts
@@ -8,8 +8,11 @@ import { ResizeHandlerStub } from '@test/fixtures/ResizeHandlerStub';
 
 describe( 'NotShownState', function () {
 	it( 'tracks not shown event on enter', function () {
+		Object.defineProperty( window, 'innerWidth', { writable: true, configurable: true, value: 100 } );
+		Object.defineProperty( window, 'innerHeight', { writable: true, configurable: true, value: 200 } );
+
 		const tracker = { trackEvent: vitest.fn() };
-		const trackingEvent = new NotShownEvent( { reason: BannerNotShownReasons.DisallowedNamespace } );
+		const trackingEvent = new NotShownEvent( { bannerHeight: 0, viewportHeight: 200, viewportWidth: 100, reason: BannerNotShownReasons.DisallowedNamespace } );
 		const state = new NotShownState( BannerNotShownReasons.DisallowedNamespace, new PageStub(), tracker, new ResizeHandlerStub(), 0 );
 
 		state.enter();

--- a/test/components/DonationForm/MultiStepDonation.spec.ts
+++ b/test/components/DonationForm/MultiStepDonation.spec.ts
@@ -101,7 +101,7 @@ describe( 'MultistepDonation.vue', () => {
 
 		// We submit a sub form once to cache the navigation callbacks in the StepControllerSpy
 		await wrapper.find( '.emitting-sub-form' ).trigger( 'submit' );
-		await stepController.callSubmit( { customData: { yoshi: 'horse' }, eventName: 'mushroom', feature: 'MainDonationForm', userChoice: 'badchoice' } );
+		await stepController.callSubmit( { customData: undefined, eventName: 'mushroom', feature: 'MainDonationForm', userChoice: 'badchoice' } );
 
 		expect( submitForm.element.submit ).toHaveBeenCalledOnce();
 	} );
@@ -114,12 +114,12 @@ describe( 'MultistepDonation.vue', () => {
 
 		// We submit a sub form once to cache the navigation callbacks in the StepControllerSpy
 		await wrapper.find( '.emitting-sub-form' ).trigger( 'submit' );
-		await stepController.callSubmit( { customData: { yoshi: 'horse' }, eventName: 'mushroom', feature: 'MainDonationForm', userChoice: 'goodChoice' } );
+		await stepController.callSubmit( { customData: undefined, eventName: 'mushroom', feature: 'MainDonationForm', userChoice: 'goodChoice' } );
 
 		expect( tracker.hasTrackedEvent( 'mushroom' ) ).toBeTruthy();
 		expect( tracker.getTrackedEvent( 'mushroom' ).feature ).toBe( 'MainDonationForm' );
 		expect( tracker.getTrackedEvent( 'mushroom' ).userChoice ).toBe( 'goodChoice' );
-		expect( tracker.getTrackedEvent( 'mushroom' ).customData ).toEqual( { yoshi: 'horse' } );
+		expect( tracker.getTrackedEvent( 'mushroom' ).customData ).toBeUndefined();
 	} );
 
 	it( 'should go to specified step when goToStep callback is invoked', async function () {

--- a/test/fixtures/StepControllerSpy.ts
+++ b/test/fixtures/StepControllerSpy.ts
@@ -20,7 +20,7 @@ export class StepControllerSpy implements StepController {
 		return Promise.resolve( undefined );
 	}
 
-	public async callSubmit( trackingEvent: TrackingEvent ): Promise<void> {
+	public async callSubmit( trackingEvent: TrackingEvent<void> ): Promise<void> {
 		return this._navigation.submit( trackingEvent );
 	}
 

--- a/test/fixtures/TrackerSpy.ts
+++ b/test/fixtures/TrackerSpy.ts
@@ -3,18 +3,18 @@ import { TrackingEvent } from '@src/tracking/TrackingEvent';
 
 export class TrackerSpy implements Tracker {
 
-	private _receivedEvents: TrackingEvent[] = [];
+	private _receivedEvents: TrackingEvent<any>[] = [];
 
-	public trackEvent( trackingData: TrackingEvent ): void {
+	public trackEvent( trackingData: TrackingEvent<any> ): void {
 		this._receivedEvents.push( trackingData );
 	}
 
 	public hasTrackedEvent( eventName: string ): boolean {
-		return this._receivedEvents.find( ( eventData: TrackingEvent ) => eventData.eventName === eventName ) !== undefined;
+		return this._receivedEvents.find( ( eventData: TrackingEvent<any> ) => eventData.eventName === eventName ) !== undefined;
 	}
 
-	public getTrackedEvent( eventName: string ): TrackingEvent|null {
-		return this._receivedEvents.find( ( eventData: TrackingEvent ) => eventData.eventName === eventName );
+	public getTrackedEvent( eventName: string ): TrackingEvent<any>|null {
+		return this._receivedEvents.find( ( eventData: TrackingEvent<any> ) => eventData.eventName === eventName );
 	}
 
 }

--- a/test/integration/tracking/TrackerWPDE.spec.ts
+++ b/test/integration/tracking/TrackerWPDE.spec.ts
@@ -25,7 +25,7 @@ describe( 'TrackerWPDE', function () {
 			'TestBanner05',
 			new Map<string, number>( [ [ 'some-action', 1 ] ] ) );
 
-		tracker.trackEvent( { eventName: 'some-action', feature: '', userChoice: '', customData: {} } );
+		tracker.trackEvent( { eventName: 'some-action', feature: '', userChoice: '', customData: undefined } );
 
 		expect( window.TestTracker.trackEvent ).toBeCalledWith( 'Banners', 'some-action', 'TestBanner05' );
 	} );
@@ -38,7 +38,7 @@ describe( 'TrackerWPDE', function () {
 		[ new FormStepShownEvent( 'UpgradeToYearlyForm' ), 'form-step-shown-UpgradeToYearlyForm' ],
 		[ { eventName: 'some-action', feature: '', userChoice: '', customData: {} }, 'some-action' ],
 		[ { eventName: 'some-action', feature: '', userChoice: 'with-choice', customData: {} }, 'some-action-with-choice' ]
-	] )( 'converts events', ( event: TrackingEvent, expectedName: string ) => {
+	] )( 'converts events', ( event: TrackingEvent<void>, expectedName: string ) => {
 		window.TestTracker = { trackEvent: vi.fn() };
 		const tracker = new TrackerWPDE(
 			'TestTracker',
@@ -59,8 +59,8 @@ describe( 'TrackerWPDE', function () {
 			new Map<string, number>( [ [ 'action-1', 1 ], [ 'action-2', 1 ] ] )
 		);
 
-		tracker.trackEvent( { eventName: 'action-1', feature: '', userChoice: '', customData: {} } );
-		tracker.trackEvent( { eventName: 'action-2', feature: '', userChoice: '', customData: {} } );
+		tracker.trackEvent( { eventName: 'action-1', feature: '', userChoice: '', customData: undefined } );
+		tracker.trackEvent( { eventName: 'action-2', feature: '', userChoice: '', customData: undefined } );
 
 		window.TestTracker = { trackEvent: vi.fn() };
 
@@ -82,8 +82,8 @@ describe( 'TrackerWPDE', function () {
 			new Map<string, number>( [ [ 'action-1', 1 ], [ 'action-2', 1 ] ] )
 		);
 
-		tracker.trackEvent( { eventName: 'action-1', feature: '', userChoice: '', customData: {} } );
-		tracker.trackEvent( { eventName: 'action-2', feature: '', userChoice: '', customData: {} } );
+		tracker.trackEvent( { eventName: 'action-1', feature: '', userChoice: '', customData: undefined } );
+		tracker.trackEvent( { eventName: 'action-2', feature: '', userChoice: '', customData: undefined } );
 
 		await vi.runAllTimers();
 
@@ -99,7 +99,7 @@ describe( 'TrackerWPDE', function () {
 		[ new CustomAmountChangedEvent( 'decreased' ), CustomAmountChangedEvent.EVENT_NAME, 'decreased-amount' ],
 		[ new ClickAlreadyDonatedEvent(), ClickAlreadyDonatedEvent.EVENT_NAME, ClickAlreadyDonatedEvent.EVENT_NAME ]
 	] )( 'should generate event identifiers from tracking data, data set %#',
-		( trackingEvent: TrackingEvent, allowedAction: string, expectedId: string ) => {
+		( trackingEvent: TrackingEvent<void>, allowedAction: string, expectedId: string ) => {
 			window.TestTracker = { trackEvent: vi.fn() };
 			const tracker = new TrackerWPDE(
 				'TestTracker',
@@ -128,7 +128,7 @@ describe( 'TrackerWPDE', function () {
 				'TestBanner05',
 				new Map<string, number>( [ [ 'some-action', trackingRate ] ] ) );
 
-			tracker.trackEvent( { eventName: 'some-action', feature: '', userChoice: '', customData: {} } );
+			tracker.trackEvent( { eventName: 'some-action', feature: '', userChoice: '', customData: undefined } );
 
 			expect( window.TestTracker.trackEvent ).toHaveBeenCalledTimes( wasTracked ? 1 : 0 );
 
@@ -144,7 +144,7 @@ describe( 'TrackerWPDE', function () {
 			'TestBanner05',
 			new Map<string, number>( [ [ 'some-action', 0 ] ] ) );
 
-		tracker.trackEvent( { eventName: 'some-action', feature: '', userChoice: '', customData: {} } );
+		tracker.trackEvent( { eventName: 'some-action', feature: '', userChoice: '', customData: undefined } );
 
 		expect( window.TestTracker.trackEvent ).toHaveBeenCalled();
 
@@ -160,7 +160,7 @@ describe( 'TrackerWPDE', function () {
 			'TestBanner05',
 			new Map<string, number>( [ [ 'some-action', 0 ] ] ) );
 
-		tracker.trackEvent( { eventName: 'unknown-event', feature: '', userChoice: '', customData: {} } );
+		tracker.trackEvent( { eventName: 'unknown-event', feature: '', userChoice: '', customData: undefined } );
 
 		expect( window.TestTracker.trackEvent ).not.toHaveBeenCalled();
 

--- a/test/unit/tracking/LegacyEventTracking/mapNotShownEvent.spec.ts
+++ b/test/unit/tracking/LegacyEventTracking/mapNotShownEvent.spec.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import { DEFAULT_UNKNOWN_EVENT, mapNotShownEvent } from '@src/tracking/LegacyEventTracking/mapNotShownEvent';
+import { mapNotShownEvent } from '@src/tracking/LegacyEventTracking/mapNotShownEvent';
 import { NotShownEvent } from '@src/tracking/events/NotShownEvent';
 import { BannerNotShownReasons } from '@src/page/BannerNotShownReasons';
 import { WMDESizeIssueEvent } from '@src/tracking/WPORG/WMDEBannerSizeIssue';
@@ -28,31 +28,11 @@ describe( 'mapNotShownEvent', () => {
 
 	it( 'maps other reasons to legacy event without tracking', () => {
 		const legacyEvent = mapNotShownEvent(
-			new NotShownEvent( { reason: BannerNotShownReasons.DisallowedNamespace } )
+			new NotShownEvent( { bannerHeight: 0, viewportHeight: 0, viewportWidth: 0, reason: BannerNotShownReasons.DisallowedNamespace } )
 		);
 
 		expect( legacyEvent ).toStrictEqual(
 			new WMDELegacyBannerEvent( 'namespace_tracking', 0 )
-		);
-	} );
-
-	it( 'maps new reasons to legacy event with unknown name', () => {
-		const legacyEvent = mapNotShownEvent(
-			new NotShownEvent( { reason: 'moon_is_in_the_second_house' } )
-		);
-
-		expect( legacyEvent ).toStrictEqual(
-			new WMDELegacyBannerEvent( DEFAULT_UNKNOWN_EVENT, 0 )
-		);
-	} );
-
-	it( 'maps events with missing reason to legacy event with unknown name', () => {
-		const legacyEvent = mapNotShownEvent(
-			new NotShownEvent( { } )
-		);
-
-		expect( legacyEvent ).toStrictEqual(
-			new WMDELegacyBannerEvent( DEFAULT_UNKNOWN_EVENT, 0 )
 		);
 	} );
 


### PR DESCRIPTION
This allows us to define the shape of the customData objects that are contained in the tracking events.

When a tracking event does not have any customData it's type can be set to void meaning we explicitly expect that data to be undefined.