### PR TITLE
Improve mapNotShownEvent

### DIFF
--- a/src/page/BannerNotShownReasons.ts
+++ b/src/page/BannerNotShownReasons.ts
@@ -3,7 +3,3 @@ export enum BannerNotShownReasons {
 	DisallowedNamespace = 'DisallowedNamespace',
 	UserInteraction = 'UserInteraction'
 }
-
-export function isNotShownReason( value: any ): value is BannerNotShownReasons {
-	return typeof value === 'string' && value in BannerNotShownReasons;
-}

--- a/src/tracking/LegacyEventTracking/mapNotShownEvent.ts
+++ b/src/tracking/LegacyEventTracking/mapNotShownEvent.ts
@@ -1,24 +1,15 @@
-import { BannerNotShownReasons, isNotShownReason } from '@src/page/BannerNotShownReasons';
-import { TrackingEvent } from '@src/tracking/TrackingEvent';
+import { BannerNotShownReasons } from '@src/page/BannerNotShownReasons';
 import { WMDESizeIssueEvent } from '@src/tracking/WPORG/WMDEBannerSizeIssue';
 import { WMDELegacyBannerEvent } from '@src/tracking/WPORG/WMDELegacyBannerEvent';
-import { NotShownCustomData } from '@src/tracking/events/NotShownEvent';
-
-const notShownReasonToLegacyName = new Map<BannerNotShownReasons, string>( [
-	[ BannerNotShownReasons.SizeIssue, 'size_issue' ],
-	[ BannerNotShownReasons.DisallowedNamespace, 'namespace_tracking' ],
-	[ BannerNotShownReasons.UserInteraction, 'user_interaction' ]
-] );
-
-export const DEFAULT_UNKNOWN_EVENT = 'not-shown-for-unknown-reasons';
+import { NotShownEvent } from '@src/tracking/events/NotShownEvent';
 
 /**
  * @deprecated Will be removed when the new tracking schema is implemented
  */
-export function mapNotShownEvent( notShownEvent: TrackingEvent<NotShownCustomData> ): WMDESizeIssueEvent|WMDELegacyBannerEvent {
+export function mapNotShownEvent( notShownEvent: NotShownEvent ): WMDESizeIssueEvent|WMDELegacyBannerEvent {
 	if ( notShownEvent.customData.reason === BannerNotShownReasons.SizeIssue ) {
 		return new WMDESizeIssueEvent(
-			notShownReasonToLegacyName.get( BannerNotShownReasons.SizeIssue ),
+			'size_issue',
 			{
 				viewportWidth: Number( notShownEvent.customData.viewportWidth ),
 				viewportHeight: Number( notShownEvent.customData.viewportHeight ),
@@ -27,11 +18,7 @@ export function mapNotShownEvent( notShownEvent: TrackingEvent<NotShownCustomDat
 			1
 		);
 	}
-	// make sure we have an event name, even if we added a new entry to BannerNotShownReasons
-	// or if we're accidentally processing another TrackingEvent or a NotShownEvent with missing reason here
-	const reason = notShownEvent.customData.reason;
-	const eventName = isNotShownReason( reason ) ? notShownReasonToLegacyName.get( reason ) : DEFAULT_UNKNOWN_EVENT;
 
 	// We don't track other "not shown" events, hence the trackingRate of 0
-	return new WMDELegacyBannerEvent( eventName, 0 );
+	return new WMDELegacyBannerEvent( 'untracked-not-shown-event', 0 );
 }

--- a/test/unit/tracking/LegacyEventTracking/mapNotShownEvent.spec.ts
+++ b/test/unit/tracking/LegacyEventTracking/mapNotShownEvent.spec.ts
@@ -32,7 +32,7 @@ describe( 'mapNotShownEvent', () => {
 		);
 
 		expect( legacyEvent ).toStrictEqual(
-			new WMDELegacyBannerEvent( 'namespace_tracking', 0 )
+			new WMDELegacyBannerEvent( 'untracked-not-shown-event', 0 )
 		);
 	} );
 


### PR DESCRIPTION
This is a followup to https://github.com/wmde/fundraising-banners/pull/273 that clears out the unneeded code from mapNotShownEvent. Now that TrackingEvent customData is typed we no longer need to check the reason string matches a BannerNotShownReason.

- Remove legacy name map.
- Remove check on customData.reason string.
- Make eventName of WMDELegacyBannerEvent more descriptive.

Ticket: https://phabricator.wikimedia.org/T344027