### PR TITLE
Add new Dynamic Time calculation

### DIFF
--- a/src/utils/DynamicContent/DynamicCampaignText.ts
+++ b/src/utils/DynamicContent/DynamicCampaignText.ts
@@ -34,7 +34,7 @@ export default class DynamicCampaignText implements DynamicContent {
 		this._campaignParameters = campaignParameters;
 		this._impressionCount = impressionCount;
 		this._cache = new Map<string, string>();
-		this.currentDateAndTime = this.currentDateAndTime.bind( this );
+		this.getCurrentDateAndTime = this.getCurrentDateAndTime.bind( this );
 	}
 
 	private getCampaignTimeRange(): TimeRange {
@@ -71,7 +71,7 @@ export default class DynamicCampaignText implements DynamicContent {
 	 * Current time returns time to the minute, and needs to be updated dynamically
 	 * This means we can't cache the return value, so instead manually cache the CurrentTime object
 	 */
-	public currentDateAndTime(): string {
+	public getCurrentDateAndTime(): string {
 		if ( !this._currentDateAndTime ) {
 			this._currentDateAndTime = new CurrentDateAndTime( this._translator, this._formatters.ordinal, this._formatters.time );
 		}

--- a/src/utils/DynamicContent/DynamicCampaignText.ts
+++ b/src/utils/DynamicContent/DynamicCampaignText.ts
@@ -13,6 +13,7 @@ import { CampaignProjection } from '@src/utils/DynamicContent/CampaignProjection
 import { ImpressionCount } from '@src/utils/ImpressionCount';
 import { ProgressBarContent } from '@src/utils/DynamicContent/generators/ProgressBarContent';
 import { DynamicProgressBarContent } from '@src/utils/DynamicContent/DynamicProgressBarContent';
+import { CurrentDateAndTime } from '@src/utils/DynamicContent/generators/CurrentDateAndTime';
 
 export default class DynamicCampaignText implements DynamicContent {
 	private readonly _date: Date;
@@ -24,6 +25,7 @@ export default class DynamicCampaignText implements DynamicContent {
 	private _campaignTimeRange: TimeRange;
 	private _campaignProjection: CampaignProjection;
 	private _progressBarContent: ProgressBarContent;
+	private _currentDateAndTime: CurrentDateAndTime;
 
 	public constructor( date: Date, translator: Translator, formatters: Formatters, campaignParameters: CampaignParameters, impressionCount: ImpressionCount ) {
 		this._date = date;
@@ -32,6 +34,7 @@ export default class DynamicCampaignText implements DynamicContent {
 		this._campaignParameters = campaignParameters;
 		this._impressionCount = impressionCount;
 		this._cache = new Map<string, string>();
+		this.currentDateAndTime = this.currentDateAndTime.bind( this );
 	}
 
 	private getCampaignTimeRange(): TimeRange {
@@ -62,6 +65,18 @@ export default class DynamicCampaignText implements DynamicContent {
 		return this.getCachedValue( 'currentDate', () => {
 			return new CurrentDate( this._date, this._translator, this._formatters.ordinal ).getText();
 		} );
+	}
+
+	/**
+	 * Current time returns time to the minute, and needs to be updated dynamically
+	 * This means we can't cache the return value, so instead manually cache the CurrentTime object
+	 */
+	public currentDateAndTime(): string {
+		if ( !this._currentDateAndTime ) {
+			this._currentDateAndTime = new CurrentDateAndTime( this._translator, this._formatters.ordinal, this._formatters.time );
+		}
+
+		return this._currentDateAndTime.getText( new Date() );
 	}
 
 	public get currentDayName(): string {

--- a/src/utils/DynamicContent/DynamicContent.ts
+++ b/src/utils/DynamicContent/DynamicContent.ts
@@ -3,6 +3,7 @@ import { DynamicProgressBarContent } from '@src/utils/DynamicContent/DynamicProg
 export interface DynamicContent {
 	currentDayName: string;
 	currentDate: string;
+	currentDateAndTime: () => string;
 	daysLeftSentence: string;
 	campaignDaySentence: string;
 	visitorsVsDonorsSentence: string;

--- a/src/utils/DynamicContent/DynamicContent.ts
+++ b/src/utils/DynamicContent/DynamicContent.ts
@@ -1,9 +1,13 @@
 import { DynamicProgressBarContent } from '@src/utils/DynamicContent/DynamicProgressBarContent';
 
+/**
+ * Properties in this interface are for items that are generated once and are then static after
+ * Methods are for items that need to be updated per call
+ */
 export interface DynamicContent {
 	currentDayName: string;
 	currentDate: string;
-	currentDateAndTime: () => string;
+	getCurrentDateAndTime: () => string;
 	daysLeftSentence: string;
 	campaignDaySentence: string;
 	visitorsVsDonorsSentence: string;

--- a/src/utils/DynamicContent/Formatters.ts
+++ b/src/utils/DynamicContent/Formatters.ts
@@ -1,9 +1,11 @@
 import { Ordinal } from '@src/utils/DynamicContent/formatters/Ordinal';
 import { Currency } from '@src/utils/DynamicContent/formatters/Currency';
 import { Integer } from '@src/utils/DynamicContent/formatters/Integer';
+import { Time } from '@src/utils/DynamicContent/formatters/Time';
 
 export interface Formatters {
 	currency: Currency;
 	ordinal: Ordinal;
 	integer: Integer;
+	time: Time;
 }

--- a/src/utils/DynamicContent/formatters/Time.ts
+++ b/src/utils/DynamicContent/formatters/Time.ts
@@ -1,0 +1,3 @@
+export interface Time {
+	getFormatted( date: Date ): string;
+}

--- a/src/utils/DynamicContent/formatters/TimeDe.ts
+++ b/src/utils/DynamicContent/formatters/TimeDe.ts
@@ -1,0 +1,7 @@
+import { Time } from '@src/utils/DynamicContent/formatters/Time';
+
+export class TimeDe implements Time {
+	public getFormatted( date: Date ): string {
+		return date.toLocaleString( 'de-DE', { hour: 'numeric', minute: 'numeric' } );
+	}
+}

--- a/src/utils/DynamicContent/formatters/TimeEn.ts
+++ b/src/utils/DynamicContent/formatters/TimeEn.ts
@@ -1,0 +1,7 @@
+import { Time } from '@src/utils/DynamicContent/formatters/Time';
+
+export class TimeEn implements Time {
+	public getFormatted( date: Date ): string {
+		return date.toLocaleString( 'en-GB', { hour: 'numeric', hour12: true, minute: 'numeric' } );
+	}
+}

--- a/src/utils/DynamicContent/generators/CurrentDateAndTime.ts
+++ b/src/utils/DynamicContent/generators/CurrentDateAndTime.ts
@@ -1,0 +1,23 @@
+import { TextGenerator } from '@src/utils/DynamicContent/generators/TextGenerator';
+import { Translator } from '@src/Translator';
+import { Ordinal } from '@src/utils/DynamicContent/formatters/Ordinal';
+import { Time } from '@src/utils/DynamicContent/formatters/Time';
+
+export class CurrentDateAndTime implements TextGenerator<Date> {
+	private readonly _translator: Translator;
+	private _ordinalFormatter: Ordinal;
+	private _timeFormatter: Time;
+
+	public constructor( translator: Translator, ordinalFormatter: Ordinal, timeFormatter: Time ) {
+		this._translator = translator;
+		this._ordinalFormatter = ordinalFormatter;
+		this._timeFormatter = timeFormatter;
+	}
+
+	public getText( date: Date ): string {
+		return this._translator.translate( 'date-month-time-' + ( date.getMonth() + 1 ), {
+			day: this._ordinalFormatter.getFormatted( date.getDate() ),
+			time: this._timeFormatter.getFormatted( date )
+		} );
+	}
+}

--- a/src/utils/DynamicContent/generators/TextGenerator.ts
+++ b/src/utils/DynamicContent/generators/TextGenerator.ts
@@ -1,3 +1,6 @@
-export interface TextGenerator {
-	getText(): string;
+/**
+ * @param T - Defines the type of optional parameter that can be passed to getText()
+ */
+export interface TextGenerator<T = void> {
+	getText( parameter: T ): string;
 }

--- a/src/utils/DynamicContent/messages/DynamicCampaignText.de.ts
+++ b/src/utils/DynamicContent/messages/DynamicCampaignText.de.ts
@@ -42,7 +42,20 @@ const Translations: TranslationMessages = {
 	'date-month-9': '{{day}} September',
 	'date-month-10': '{{day}} Oktober',
 	'date-month-11': '{{day}} November',
-	'date-month-12': '{{day}} Dezember'
+	'date-month-12': '{{day}} Dezember',
+
+	'date-month-time-1': '{{day}} Januar, {{time}}',
+	'date-month-time-2': '{{day}} Februar, {{time}}',
+	'date-month-time-3': '{{day}} März, {{time}}',
+	'date-month-time-4': '{{day}} April, {{time}}',
+	'date-month-time-5': '{{day}} Mai, {{time}}',
+	'date-month-time-6': '{{day}} Juni, {{time}}',
+	'date-month-time-7': '{{day}} Juli, {{time}}',
+	'date-month-time-8': '{{day}} August, {{time}}',
+	'date-month-time-9': '{{day}} September, {{time}}',
+	'date-month-time-10': '{{day}} Oktober, {{time}}',
+	'date-month-time-11': '{{day}} November, {{time}}',
+	'date-month-time-12': '{{day}} Dezember, {{time}}'
 };
 
 export default Translations;

--- a/src/utils/DynamicContent/messages/DynamicCampaignText.en.ts
+++ b/src/utils/DynamicContent/messages/DynamicCampaignText.en.ts
@@ -42,7 +42,20 @@ const Translations: TranslationMessages = {
 	'date-month-9': 'September {{day}}',
 	'date-month-10': 'October {{day}}',
 	'date-month-11': 'November {{day}}',
-	'date-month-12': 'December {{day}}'
+	'date-month-12': 'December {{day}}',
+
+	'date-month-time-1': 'January {{day}}, {{time}}',
+	'date-month-time-2': 'February {{day}}, {{time}}',
+	'date-month-time-3': 'March {{day}}, {{time}}',
+	'date-month-time-4': 'April {{day}}, {{time}}',
+	'date-month-time-5': 'May {{day}}, {{time}}',
+	'date-month-time-6': 'June {{day}}, {{time}}',
+	'date-month-time-7': 'July {{day}}, {{time}}',
+	'date-month-time-8': 'August {{day}}, {{time}}',
+	'date-month-time-9': 'September {{day}}, {{time}}',
+	'date-month-time-10': 'October {{day}}, {{time}}',
+	'date-month-time-11': 'November {{day}}, {{time}}',
+	'date-month-time-12': 'December {{day}}, {{time}}'
 };
 
 export default Translations;

--- a/src/utils/LocaleFactory.ts
+++ b/src/utils/LocaleFactory.ts
@@ -4,6 +4,6 @@ import { FundsContentLoader } from '@src/utils/UseOfFunds/FundsContentLoader';
 
 export interface LocaleFactory {
 	getCurrencyFormatter(): Currency;
-	getFormatters(): Formatters
+	getFormatters(): Formatters;
 	getUseOfFundsLoader(): FundsContentLoader;
 }

--- a/src/utils/LocaleFactory/LocaleFactoryDe.ts
+++ b/src/utils/LocaleFactory/LocaleFactoryDe.ts
@@ -6,6 +6,7 @@ import { FundsContentLoader } from '@src/utils/UseOfFunds/FundsContentLoader';
 import { OrdinalDe } from '@src/utils/DynamicContent/formatters/OrdinalDe';
 import { IntegerDe } from '@src/utils/DynamicContent/formatters/IntegerDe';
 import { UseOfFundsDeLoader } from '@environment/UseOfFundsDeLoader';
+import { TimeDe } from '@src/utils/DynamicContent/formatters/TimeDe';
 
 export class LocaleFactoryDe implements LocaleFactory {
 	private readonly _currencyFormatter: Currency;
@@ -22,7 +23,8 @@ export class LocaleFactoryDe implements LocaleFactory {
 		return {
 			currency: this._currencyFormatter,
 			ordinal: new OrdinalDe(),
-			integer: new IntegerDe()
+			integer: new IntegerDe(),
+			time: new TimeDe()
 		};
 	}
 

--- a/src/utils/LocaleFactory/LocaleFactoryEn.ts
+++ b/src/utils/LocaleFactory/LocaleFactoryEn.ts
@@ -6,6 +6,7 @@ import { FundsContentLoader } from '@src/utils/UseOfFunds/FundsContentLoader';
 import { OrdinalEn } from '@src/utils/DynamicContent/formatters/OrdinalEn';
 import { IntegerEn } from '@src/utils/DynamicContent/formatters/IntegerEn';
 import { UseOfFundsEnLoader } from '@environment/UseOfFundsEnLoader';
+import { TimeEn } from '@src/utils/DynamicContent/formatters/TimeEn';
 
 export class LocaleFactoryEn implements LocaleFactory {
 	private readonly _currencyFormatter: Currency;
@@ -22,7 +23,8 @@ export class LocaleFactoryEn implements LocaleFactory {
 		return {
 			currency: this._currencyFormatter,
 			ordinal: new OrdinalEn(),
-			integer: new IntegerEn()
+			integer: new IntegerEn(),
+			time: new TimeEn()
 		};
 	}
 

--- a/src/utils/LocaleFactory/LocaleFactoryWpDe.ts
+++ b/src/utils/LocaleFactory/LocaleFactoryWpDe.ts
@@ -6,6 +6,7 @@ import { FundsContentLoader } from '@src/utils/UseOfFunds/FundsContentLoader';
 import { OrdinalDe } from '@src/utils/DynamicContent/formatters/OrdinalDe';
 import { IntegerDe } from '@src/utils/DynamicContent/formatters/IntegerDe';
 import { DeJSONFundsContentLoader } from '@src/utils/UseOfFunds/DeJSONFundsContentLoader';
+import { TimeDe } from '@src/utils/DynamicContent/formatters/TimeDe';
 
 export class LocaleFactoryWpDe implements LocaleFactory {
 	private readonly _currencyFormatter: Currency;
@@ -22,7 +23,8 @@ export class LocaleFactoryWpDe implements LocaleFactory {
 		return {
 			currency: this._currencyFormatter,
 			ordinal: new OrdinalDe(),
-			integer: new IntegerDe()
+			integer: new IntegerDe(),
+			time: new TimeDe()
 		};
 	}
 

--- a/test/banners/dynamicCampaignContent.ts
+++ b/test/banners/dynamicCampaignContent.ts
@@ -4,7 +4,7 @@ export function newDynamicContent(): DynamicContent {
 	return {
 		campaignDaySentence: '',
 		currentDate: '',
-		currentDateAndTime: () => '',
+		getCurrentDateAndTime: () => '',
 		currentDayName: '',
 		daysLeftSentence: 'daysLeftSentence',
 		donorsNeededSentence: '',

--- a/test/banners/dynamicCampaignContent.ts
+++ b/test/banners/dynamicCampaignContent.ts
@@ -4,6 +4,7 @@ export function newDynamicContent(): DynamicContent {
 	return {
 		campaignDaySentence: '',
 		currentDate: '',
+		currentDateAndTime: () => '',
 		currentDayName: '',
 		daysLeftSentence: 'daysLeftSentence',
 		donorsNeededSentence: '',

--- a/test/components/ProgressBar/ProgressBar.spec.ts
+++ b/test/components/ProgressBar/ProgressBar.spec.ts
@@ -8,7 +8,7 @@ describe( 'ProgressBar.vue', () => {
 	const dynamicCampaignContent: DynamicContent = {
 		campaignDaySentence: '',
 		currentDate: '',
-		currentDateAndTime: () => '',
+		getCurrentDateAndTime: () => '',
 		currentDayName: '',
 		daysLeftSentence: 'daysLeftSentence',
 		donorsNeededSentence: '',

--- a/test/components/ProgressBar/ProgressBar.spec.ts
+++ b/test/components/ProgressBar/ProgressBar.spec.ts
@@ -8,6 +8,7 @@ describe( 'ProgressBar.vue', () => {
 	const dynamicCampaignContent: DynamicContent = {
 		campaignDaySentence: '',
 		currentDate: '',
+		currentDateAndTime: () => '',
 		currentDayName: '',
 		daysLeftSentence: 'daysLeftSentence',
 		donorsNeededSentence: '',

--- a/test/unit/utils/DynamicContent/DynamicCampaignText.spec.ts
+++ b/test/unit/utils/DynamicContent/DynamicCampaignText.spec.ts
@@ -78,7 +78,7 @@ describe( 'DynamicCampaignText', () => {
 		vi.setSystemTime( new Date( 2023, 10, 10, 13, 42, 0 ) );
 		// In some test environments the output of Date.toLocaleString includes the code for a space,
 		// but in others it doesn't. To fix that we manually replace it in this test
-		expect( dynamicCampaignText.currentDateAndTime().replace( '\u202f', ' ' ) ).toBe( 'current month 10th current time 1:42 pm' );
+		expect( dynamicCampaignText.getCurrentDateAndTime().replace( '\u202f', ' ' ) ).toBe( 'current month 10th current time 1:42 pm' );
 	} );
 
 	it( 'Gets the current day name', () => {

--- a/test/unit/utils/DynamicContent/DynamicCampaignText.spec.ts
+++ b/test/unit/utils/DynamicContent/DynamicCampaignText.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import DynamicCampaignText from '@src/utils/DynamicContent/DynamicCampaignText';
 import { Translator } from '@src/Translator';
 import { Formatters } from '@src/utils/DynamicContent/Formatters';
@@ -8,10 +8,12 @@ import { IntegerEn } from '@src/utils/DynamicContent/formatters/IntegerEn';
 import { CampaignParameters } from '@src/domain/CampaignParameters';
 import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 import { ImpressionCount } from '@src/utils/ImpressionCount';
+import { TimeEn } from '@src/utils/DynamicContent/formatters/TimeEn';
 
 const translator = new Translator( {
 	'campaign-day-nth-day': 'campaign day {{days}}',
 	'date-month-11': 'current month {{day}}',
+	'date-month-time-11': 'current month {{day}} current time {{time}}',
 	'day-name-friday': 'current day name',
 	'prefix-days-left': 'only',
 	'suffix-days-left': 'left',
@@ -22,7 +24,7 @@ const translator = new Translator( {
 	'amount-total': 'Progress total',
 	'missing-amount': 'Progress missing'
 } );
-const formatters: Formatters = { currency: new CurrencyEn(), ordinal: new OrdinalEn(), integer: new IntegerEn() };
+const formatters: Formatters = { currency: new CurrencyEn(), ordinal: new OrdinalEn(), integer: new IntegerEn(), time: new TimeEn() };
 const campaignParameters: CampaignParameters = {
 	campaignProjection: {
 		averageAmountPerDonation: 20,
@@ -50,6 +52,7 @@ describe( 'DynamicCampaignText', () => {
 	let dynamicCampaignText: DynamicContent;
 
 	beforeEach( () => {
+		vi.useFakeTimers();
 		dynamicCampaignText = new DynamicCampaignText(
 			new Date( 2023, 10, 10, 12, 0, 0 ),
 			translator,
@@ -59,12 +62,23 @@ describe( 'DynamicCampaignText', () => {
 		);
 	} );
 
+	afterEach( () => {
+		vi.useRealTimers();
+	} );
+
 	it( 'Gets the campaign day sentence', () => {
 		expect( dynamicCampaignText.campaignDaySentence ).toBe( 'campaign day 8th' );
 	} );
 
 	it( 'Gets the current date', () => {
 		expect( dynamicCampaignText.currentDate ).toBe( 'current month 10th' );
+	} );
+
+	it( 'Gets the current time', () => {
+		vi.setSystemTime( new Date( 2023, 10, 10, 13, 42, 0 ) );
+		// In some test environments the output of Date.toLocaleString includes the code for a space,
+		// but in others it doesn't. To fix that we manually replace it in this test
+		expect( dynamicCampaignText.currentDateAndTime().replace( '\u202f', ' ' ) ).toBe( 'current month 10th current time 1:42 pm' );
 	} );
 
 	it( 'Gets the current day name', () => {

--- a/test/unit/utils/DynamicContent/formatters/TimeDe.spec.ts
+++ b/test/unit/utils/DynamicContent/formatters/TimeDe.spec.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { TimeDe } from '@src/utils/DynamicContent/formatters/TimeDe';
+
+describe( 'TimeDe', () => {
+	it( 'returns the formatted time', () => {
+		const time = new TimeDe();
+		const date = new Date( 2023, 11, 1, 13, 42, 12 );
+
+		expect( time.getFormatted( date ) ).toBe( '13:42' );
+	} );
+} );

--- a/test/unit/utils/DynamicContent/formatters/TimeEn.spec.ts
+++ b/test/unit/utils/DynamicContent/formatters/TimeEn.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { TimeEn } from '@src/utils/DynamicContent/formatters/TimeEn';
+
+describe( 'TimeEn', () => {
+	it( 'returns the formatted time', () => {
+		const time = new TimeEn();
+		const date = new Date( 2023, 11, 1, 13, 42, 12 );
+
+		// In some test environments the output of Date.toLocaleString includes the code for a space,
+		// but in others it doesn't. To fix that we manually replace it in this test
+		expect( time.getFormatted( date ).replace( '\u202f', ' ' ) ).toStrictEqual( '1:42 pm' );
+	} );
+} );

--- a/test/unit/utils/DynamicContent/generators/CurrentTime.spec.ts
+++ b/test/unit/utils/DynamicContent/generators/CurrentTime.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'vitest';
+import { Translator } from '@src/Translator';
+import { CurrentDateAndTime } from '@src/utils/DynamicContent/generators/CurrentDateAndTime';
+import { Ordinal } from '@src/utils/DynamicContent/formatters/Ordinal';
+import { Time } from '@src/utils/DynamicContent/formatters/Time';
+
+const translator = new Translator( {
+	'date-month-time-1': 'Ick {{day}} - {{time}}',
+	'date-month-time-2': 'Offle {{day}} - {{time}}',
+	'date-month-time-10': 'Spune {{day}} - {{time}}',
+	'date-month-time-11': 'Sektober {{day}} - {{time}}'
+} );
+
+const staticOrdinal: Ordinal = {
+	getFormatted: ( figure: number ) => figure + 'sth'
+};
+
+const staticTime: Time = {
+	getFormatted: ( date: Date ) => `${date.getHours()} ${date.getMinutes()}`
+};
+
+describe( 'CurrentTime', () => {
+	test.each( [
+		[ 1, 14, 13, 42, 'Ick 14sth - 13 42' ],
+		[ 2, 27, 8, 16, 'Offle 27sth - 8 16' ],
+		[ 10, 2, 1, 59, 'Spune 2sth - 1 59' ],
+		[ 11, 8, 23, 0, 'Sektober 8sth - 23 0' ]
+	] )( 'returns the proper month name, date, and time', ( month: number, day: number, hours: number, minutes: number, expected: string ) => {
+		const currentDate = new CurrentDateAndTime( translator, staticOrdinal, staticTime );
+
+		expect( currentDate.getText( new Date( 2023, month - 1, day, hours, minutes, 0 ) ) ).toEqual( expected );
+	} );
+} );


### PR DESCRIPTION
This adds a new time display item to be used in the banner content

Ticket: https://phabricator.wikimedia.org/T351623

To acceptance test this you'll need to add a ref in a banner content component that can be updated periodically:

```js
const {
	currentDayName,
	currentDate,
	currentTime
}: DynamicContent = inject<DynamicContent>( 'dynamicCampaignText' );

const time = ref<string>( currentTime() );

setInterval( () => {
	time.value = currentTime();
}, 1000 );
```