### PR TITLE
Never track events with a rate of 0

### DIFF
--- a/src/tracking/LegacyTrackerWPORG.ts
+++ b/src/tracking/LegacyTrackerWPORG.ts
@@ -26,13 +26,22 @@ export class LegacyTrackerWPORG implements Tracker {
 		this._runtimeEnvironment = runtimeEnvironment ?? new UrlRuntimeEnvironment( window.location );
 	}
 
+	private shouldTrackEvent( eventRate: number ): boolean {
+		// Never track 0 rated events, even in devMode
+		if ( eventRate === 0 ) {
+			return false;
+		}
+
+		return this._runtimeEnvironment.isInDevMode || Math.random() <= eventRate;
+	}
+
 	public trackEvent( event: TrackingEvent<void> ): void {
 		if ( !this._supportedTrackingEvents.has( event.eventName ) ) {
 			return;
 		}
 		const wpOrgEvent = this._supportedTrackingEvents.get( event.eventName )( event );
 		const eventData = wpOrgEvent.getEventData( this._bannerName );
-		if ( this._runtimeEnvironment.isInDevMode || Math.random() <= eventData.eventRate ) {
+		if ( this.shouldTrackEvent( eventData.eventRate ) ) {
 			this._mediaWiki.track( wpOrgEvent.eventType, eventData );
 		}
 	}

--- a/test/integration/tracking/LegacyTrackerWPORG.spec.ts
+++ b/test/integration/tracking/LegacyTrackerWPORG.spec.ts
@@ -63,7 +63,20 @@ describe( 'LegacyTrackerWPORG', function () {
 		Math.random = oldRandom;
 	} );
 
-	it( 'should always track in "devMode" and ignore tracking rate', () => {
+	it( 'should always track in "devMode" and ignore tracking rate when rate is > 0', () => {
+		const mediaWikiStub = new MediaWikiStub();
+		mediaWikiStub.track = vi.fn();
+		const runtimeEnvironmentStub = { isInDevMode: true, runsInDevEnvironment: true };
+		const trackingEventConverter = vi.fn( () => new WMDELegacyBannerEvent( 'test', 0.1 ) );
+		const eventNameMap = new Map<string, TrackingEventConverterFactory>( [ [ ClickAlreadyDonatedEvent.EVENT_NAME, trackingEventConverter ] ] );
+		const tracker = new LegacyTrackerWPORG( mediaWikiStub, 'someotherweirdbannername05', eventNameMap, runtimeEnvironmentStub );
+
+		tracker.trackEvent( new ClickAlreadyDonatedEvent() );
+
+		expect( mediaWikiStub.track ).toHaveBeenCalled();
+	} );
+
+	it( 'should never track when event tracking rate is 0', () => {
 		const mediaWikiStub = new MediaWikiStub();
 		mediaWikiStub.track = vi.fn();
 		const runtimeEnvironmentStub = { isInDevMode: true, runsInDevEnvironment: true };
@@ -73,7 +86,7 @@ describe( 'LegacyTrackerWPORG', function () {
 
 		tracker.trackEvent( new ClickAlreadyDonatedEvent() );
 
-		expect( mediaWikiStub.track ).toHaveBeenCalled();
+		expect( mediaWikiStub.track ).not.toHaveBeenCalled();
 	} );
 
 } );


### PR DESCRIPTION
Tracking these events in devMode is confusing for the acceptance testers.