### PR TITLE
Decrease page gap for Vector2022

### DIFF
--- a/src/page/skin/Vector2022.ts
+++ b/src/page/skin/Vector2022.ts
@@ -1,6 +1,9 @@
 import Vector from '@src/page/skin/Vector';
 
 class Vector2022 extends Vector {
+	public minimumVisiblePageBeneathBanner(): number {
+		return 72;
+	}
 }
 
 export default Vector2022;


### PR DESCRIPTION
One of the rules for showing a banner is that the Wikipedia logo must be visible on a person's screen when the banner is loaded. But on Vector2022 the logo is much smaller than on Vector meaning we can decrease this gap and reduce size issues.