### PR TITLE
Move fallback tests to feature

### DIFF
--- a/test/banners/desktop/components/FallbackBanner.spec.ts
+++ b/test/banners/desktop/components/FallbackBanner.spec.ts
@@ -1,16 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, test, vi } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import FallbackBanner from '../../../../banners/desktop/components/FallbackBanner.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
 import { useOfFundsContent } from '@test/banners/useOfFundsContent';
 import { newDynamicContent } from '@test/banners/dynamicCampaignContent';
-import { CloseChoices } from '@src/domain/CloseChoices';
-import { CloseEvent } from '@src/tracking/events/CloseEvent';
 import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 import { Tracker } from '@src/tracking/Tracker';
 import { TrackerStub } from '@test/fixtures/TrackerStub';
-import { TrackerSpy } from '@test/fixtures/TrackerSpy';
-import { FallbackBannerSubmitEvent } from '@src/tracking/events/FallbackBannerSubmitEvent';
+import { dynamicContentFeatures, fallbackBannerFeatures, submitFeatures } from '@test/features/FallbackBanner';
 
 const translator = ( key: string ): string => key;
 
@@ -45,101 +42,29 @@ describe( 'FallbackBanner.vue', () => {
 		} );
 	};
 
-	it( 'shows the small banner under 800px', () => {
-		const wrapper = getWrapperAtWidth( 799 );
-
-		expect( wrapper.find( '.wmde-banner-fallback-small' ).exists() ).toBeTruthy();
-		expect( wrapper.find( '.wmde-banner-fallback-large' ).exists() ).toBeFalsy();
+	test.each( [
+		[ 'showsTheSmallBanner' ],
+		[ 'showsTheLargeBanner' ],
+		[ 'emitsTheBannerCloseEvent' ],
+		[ 'playsTheSlideshowWhenBecomesVisible' ],
+		[ 'showsUseOfFundsFromSmallBanner' ],
+		[ 'hidesUseOfFundsFromSmallBanner' ],
+		[ 'showsUseOfFundsFromLargeBanner' ],
+		[ 'hidesUseOfFundsFromLargeBanner' ]
+	] )( '%s', async ( testName: string ) => {
+		await fallbackBannerFeatures[ testName ]( getWrapperAtWidth );
 	} );
 
-	it( 'shows the large banner over 800px', () => {
-		const wrapper = getWrapperAtWidth( 800 );
-
-		expect( wrapper.find( '.wmde-banner-fallback-small' ).exists() ).toBeFalsy();
-		expect( wrapper.find( '.wmde-banner-fallback-large' ).exists() ).toBeTruthy();
+	test.each( [
+		[ 'showsTheAnimatedHighlightInLargeBanner' ]
+	] )( '%s', async ( testName: string ) => {
+		await dynamicContentFeatures[ testName ]( getWrapperAtWidth );
 	} );
 
-	it( 'emits the banner close event', async () => {
-		const wrapper = getWrapperAtWidth( 799 );
-
-		await wrapper.find( '.wmde-banner-close' ).trigger( 'click' );
-
-		expect( wrapper.emitted( 'bannerClosed' ).length ).toStrictEqual( 1 );
-		expect( wrapper.emitted( 'bannerClosed' )[ 0 ][ 0 ] ).toStrictEqual( new CloseEvent( 'FallbackBanner', CloseChoices.Close ) );
-	} );
-
-	it( 'plays the slideshow when the banner becomes visible', async () => {
-		const wrapper = getWrapperAtWidth( 799 );
-
-		await wrapper.setProps( { bannerState: BannerStates.Visible } );
-		await vi.runOnlyPendingTimersAsync();
-
-		expect( wrapper.find( '.wmde-banner-slider--playing' ).exists() ).toBeTruthy();
-	} );
-
-	it( 'shows the animated text in the message', async () => {
-		const dynamicContent = newDynamicContent();
-		dynamicContent.visitorsVsDonorsSentence = 'Visitors vs donors sentence';
-		const wrapper = getWrapperAtWidth( 800, dynamicContent );
-
-		expect( wrapper.find( '.wmde-banner-message .wmde-banner-text-animated-highlight' ).exists() ).toBeTruthy();
-	} );
-
-	it( 'shows the use of funds from small banner', async () => {
-		const wrapper = getWrapperAtWidth( 799 );
-
-		await wrapper.find( '.wmde-banner-fallback-small .wmde-banner-fallback-usage-link' ).trigger( 'click' );
-
-		expect( wrapper.find( '.banner-modal' ).classes() ).toContain( 'is-visible' );
-	} );
-
-	it( 'hides the use of funds from small banner', async () => {
-		const wrapper = getWrapperAtWidth( 799 );
-
-		await wrapper.find( '.wmde-banner-fallback-small .wmde-banner-fallback-usage-link' ).trigger( 'click' );
-		await wrapper.find( '.banner-modal-close-link' ).trigger( 'click' );
-
-		expect( wrapper.find( '.banner-modal' ).classes() ).not.toContain( 'is-visible' );
-	} );
-
-	it( 'shows the use of funds from large banner', async () => {
-		const wrapper = getWrapperAtWidth( 800 );
-
-		await wrapper.find( '.wmde-banner-fallback-large .wmde-banner-fallback-usage-link' ).trigger( 'click' );
-
-		expect( wrapper.find( '.banner-modal' ).classes() ).toContain( 'is-visible' );
-	} );
-
-	it( 'hides the use of funds from large banner', async () => {
-		const wrapper = getWrapperAtWidth( 800 );
-
-		await wrapper.find( '.wmde-banner-fallback-large .wmde-banner-fallback-usage-link' ).trigger( 'click' );
-		await wrapper.find( '.banner-modal-close-link' ).trigger( 'click' );
-
-		expect( wrapper.find( '.banner-modal' ).classes() ).not.toContain( 'is-visible' );
-	} );
-
-	it( 'submits from large banner', async () => {
-		const location = { href: '' };
-		Object.defineProperty( window, 'location', { writable: true, configurable: true, value: location } );
-		const tracker = new TrackerSpy();
-		const wrapper = getWrapperAtWidth( 800, null, tracker );
-
-		await wrapper.find( '.wmde-banner-fallback-large .wmde-banner-fallback-button' ).trigger( 'click' );
-
-		expect( tracker.hasTrackedEvent( FallbackBannerSubmitEvent.EVENT_NAME ) );
-		expect( location.href ).toStrictEqual( 'https://spenden.wikimedia.de' );
-	} );
-
-	it( 'submits from small banner', async () => {
-		const location = { href: '' };
-		Object.defineProperty( window, 'location', { writable: true, configurable: true, value: location } );
-		const tracker = new TrackerSpy();
-		const wrapper = getWrapperAtWidth( 799, null, tracker );
-
-		await wrapper.find( '.wmde-banner-fallback-small .wmde-banner-fallback-button' ).trigger( 'click' );
-
-		expect( tracker.hasTrackedEvent( FallbackBannerSubmitEvent.EVENT_NAME ) );
-		expect( location.href ).toStrictEqual( 'https://spenden.wikimedia.de' );
+	test.each( [
+		[ 'submitsFromLargeBanner' ],
+		[ 'submitsFromSmallBanner' ]
+	] )( '%s', async ( testName: string ) => {
+		await submitFeatures[ testName ]( getWrapperAtWidth );
 	} );
 } );

--- a/test/features/FallbackBanner.ts
+++ b/test/features/FallbackBanner.ts
@@ -1,0 +1,132 @@
+import { VueWrapper } from '@vue/test-utils';
+import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import { Tracker } from '@src/tracking/Tracker';
+import { expect, vi } from 'vitest';
+import { CloseEvent } from '@src/tracking/events/CloseEvent';
+import { CloseChoices } from '@src/domain/CloseChoices';
+import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+import { newDynamicContent } from '@test/banners/dynamicCampaignContent';
+import { TrackerSpy } from '@test/fixtures/TrackerSpy';
+import { FallbackBannerSubmitEvent } from '@src/tracking/events/FallbackBannerSubmitEvent';
+
+const showsTheSmallBanner = async ( getWrapperAtWidth: ( width: number ) => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapperAtWidth( 799 );
+
+	expect( wrapper.find( '.wmde-banner-fallback-small' ).exists() ).toBeTruthy();
+	expect( wrapper.find( '.wmde-banner-fallback-large' ).exists() ).toBeFalsy();
+};
+
+const showsTheLargeBanner = async ( getWrapperAtWidth: ( width: number ) => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapperAtWidth( 800 );
+
+	expect( wrapper.find( '.wmde-banner-fallback-small' ).exists() ).toBeFalsy();
+	expect( wrapper.find( '.wmde-banner-fallback-large' ).exists() ).toBeTruthy();
+};
+
+const emitsTheBannerCloseEvent = async ( getWrapperAtWidth: ( width: number ) => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapperAtWidth( 799 );
+
+	await wrapper.find( '.wmde-banner-close' ).trigger( 'click' );
+
+	expect( wrapper.emitted( 'bannerClosed' ).length ).toStrictEqual( 1 );
+	expect( wrapper.emitted( 'bannerClosed' )[ 0 ][ 0 ] ).toStrictEqual( new CloseEvent( 'FallbackBanner', CloseChoices.Close ) );
+};
+
+const playsTheSlideshowWhenBecomesVisible = async ( getWrapperAtWidth: ( width: number ) => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapperAtWidth( 799 );
+
+	await wrapper.setProps( { bannerState: BannerStates.Visible } );
+	await vi.runOnlyPendingTimersAsync();
+
+	expect( wrapper.find( '.wmde-banner-slider--playing' ).exists() ).toBeTruthy();
+};
+
+const showsUseOfFundsFromSmallBanner = async ( getWrapperAtWidth: ( width: number ) => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapperAtWidth( 799 );
+
+	await wrapper.find( '.wmde-banner-fallback-small .wmde-banner-fallback-usage-link' ).trigger( 'click' );
+
+	expect( wrapper.find( '.banner-modal' ).classes() ).toContain( 'is-visible' );
+};
+
+const hidesUseOfFundsFromSmallBanner = async ( getWrapperAtWidth: ( width: number ) => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapperAtWidth( 799 );
+
+	await wrapper.find( '.wmde-banner-fallback-small .wmde-banner-fallback-usage-link' ).trigger( 'click' );
+	await wrapper.find( '.banner-modal-close-link' ).trigger( 'click' );
+
+	expect( wrapper.find( '.banner-modal' ).classes() ).not.toContain( 'is-visible' );
+};
+
+const showsUseOfFundsFromLargeBanner = async ( getWrapperAtWidth: ( width: number ) => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapperAtWidth( 800 );
+
+	await wrapper.find( '.wmde-banner-fallback-large .wmde-banner-fallback-usage-link' ).trigger( 'click' );
+
+	expect( wrapper.find( '.banner-modal' ).classes() ).toContain( 'is-visible' );
+};
+
+const hidesUseOfFundsFromLargeBanner = async ( getWrapperAtWidth: ( width: number ) => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapperAtWidth( 800 );
+
+	await wrapper.find( '.wmde-banner-fallback-large .wmde-banner-fallback-usage-link' ).trigger( 'click' );
+	await wrapper.find( '.banner-modal-close-link' ).trigger( 'click' );
+
+	expect( wrapper.find( '.banner-modal' ).classes() ).not.toContain( 'is-visible' );
+};
+
+const showsTheAnimatedHighlightInLargeBanner = async ( getWrapperAtWidth: ( width: number, dynamicContent: DynamicContent ) => VueWrapper<any> ): Promise<any> => {
+	const dynamicContent = newDynamicContent();
+	dynamicContent.visitorsVsDonorsSentence = 'Visitors vs donors sentence';
+	const wrapper = getWrapperAtWidth( 800, dynamicContent );
+
+	expect( wrapper.find( '.wmde-banner-message .wmde-banner-text-animated-highlight' ).exists() ).toBeTruthy();
+};
+
+const submitsFromLargeBanner = async ( getWrapperAtWidth: ( width: number, dynamicContent: DynamicContent, tracker: Tracker ) => VueWrapper<any> ): Promise<any> => {
+	const location = { href: '' };
+	Object.defineProperty( window, 'location', { writable: true, configurable: true, value: location } );
+	const tracker = new TrackerSpy();
+	const wrapper = getWrapperAtWidth( 800, null, tracker );
+
+	await wrapper.find( '.wmde-banner-fallback-large .wmde-banner-fallback-button' ).trigger( 'click' );
+
+	expect( tracker.hasTrackedEvent( FallbackBannerSubmitEvent.EVENT_NAME ) );
+	expect( location.href ).toStrictEqual( 'https://spenden.wikimedia.de' );
+};
+
+const submitsFromSmallBanner = async ( getWrapperAtWidth: ( width: number, dynamicContent: DynamicContent, tracker: Tracker ) => VueWrapper<any> ): Promise<any> => {
+	const location = { href: '' };
+	Object.defineProperty( window, 'location', { writable: true, configurable: true, value: location } );
+	const tracker = new TrackerSpy();
+	const wrapper = getWrapperAtWidth( 799, null, tracker );
+
+	await wrapper.find( '.wmde-banner-fallback-small .wmde-banner-fallback-button' ).trigger( 'click' );
+
+	expect( tracker.hasTrackedEvent( FallbackBannerSubmitEvent.EVENT_NAME ) );
+	expect( location.href ).toStrictEqual( 'https://spenden.wikimedia.de' );
+};
+
+export const fallbackBannerFeatures: Record<string, ( getWrapperAtWidth: ( width: number ) => VueWrapper<any> ) => Promise<any>> = {
+	showsTheSmallBanner,
+	showsTheLargeBanner,
+	emitsTheBannerCloseEvent,
+	playsTheSlideshowWhenBecomesVisible,
+	showsUseOfFundsFromSmallBanner,
+	hidesUseOfFundsFromSmallBanner,
+	showsUseOfFundsFromLargeBanner,
+	hidesUseOfFundsFromLargeBanner
+};
+
+export const dynamicContentFeatures: Record<string, ( getWrapperAtWidth: ( width: number, dynamicContent: DynamicContent ) => VueWrapper<any> ) => Promise<any>> = {
+	showsTheAnimatedHighlightInLargeBanner
+};
+
+export const submitFeatures: Record<string, ( getWrapperAtWidth: (
+	width: number,
+	dynamicContent: DynamicContent,
+	tracker: Tracker
+) => VueWrapper<any> ) => Promise<any>> = {
+	submitsFromLargeBanner,
+	submitsFromSmallBanner
+};


### PR DESCRIPTION
Fallback banners are now going to be used in more than one channel so move the tests to a feature to make them a little more DRY