### PR TITLE
Add time function to dynamic text

### DIFF
--- a/src/components/composables/useCurrentTime.ts
+++ b/src/components/composables/useCurrentTime.ts
@@ -1,21 +1,18 @@
 import { ref, Ref } from 'vue';
 
 type ReturnType = {
-	currentDateTime: Ref<string>;
+	currentTime: Ref<string>;
 	startTimer: () => void;
 	stopTimer: () => void;
 }
 
-/**
- * @deprecated
- */
-export function useCurrentDateAndTime( getCurrentDateAndTime: () => string ): ReturnType {
+export function useCurrentTime( getCurrentTime: () => string ): ReturnType {
 	const timer = ref<number>( 0 );
-	const currentDateTime = ref<string>( getCurrentDateAndTime() );
+	const currentTime = ref<string>( getCurrentTime() );
 
 	const startTimer = (): void => {
 		timer.value = window.setInterval( () => {
-			currentDateTime.value = getCurrentDateAndTime();
+			currentTime.value = getCurrentTime();
 		}, 1000 );
 	};
 
@@ -24,7 +21,7 @@ export function useCurrentDateAndTime( getCurrentDateAndTime: () => string ): Re
 	};
 
 	return {
-		currentDateTime,
+		currentTime,
 		startTimer,
 		stopTimer
 	};

--- a/src/utils/DynamicContent/DynamicCampaignText.ts
+++ b/src/utils/DynamicContent/DynamicCampaignText.ts
@@ -14,6 +14,7 @@ import { ImpressionCount } from '@src/utils/ImpressionCount';
 import { ProgressBarContent } from '@src/utils/DynamicContent/generators/ProgressBarContent';
 import { DynamicProgressBarContent } from '@src/utils/DynamicContent/DynamicProgressBarContent';
 import { CurrentDateAndTime } from '@src/utils/DynamicContent/generators/CurrentDateAndTime';
+import { CurrentTime } from '@src/utils/DynamicContent/generators/CurrentTime';
 
 export default class DynamicCampaignText implements DynamicContent {
 	private readonly _date: Date;
@@ -26,6 +27,7 @@ export default class DynamicCampaignText implements DynamicContent {
 	private _campaignProjection: CampaignProjection;
 	private _progressBarContent: ProgressBarContent;
 	private _currentDateAndTime: CurrentDateAndTime;
+	private _currentTime: CurrentTime;
 
 	public constructor( date: Date, translator: Translator, formatters: Formatters, campaignParameters: CampaignParameters, impressionCount: ImpressionCount ) {
 		this._date = date;
@@ -35,6 +37,7 @@ export default class DynamicCampaignText implements DynamicContent {
 		this._impressionCount = impressionCount;
 		this._cache = new Map<string, string>();
 		this.getCurrentDateAndTime = this.getCurrentDateAndTime.bind( this );
+		this.getCurrentTime = this.getCurrentTime.bind( this );
 	}
 
 	private getCampaignTimeRange(): TimeRange {
@@ -70,6 +73,7 @@ export default class DynamicCampaignText implements DynamicContent {
 	/**
 	 * Current time returns time to the minute, and needs to be updated dynamically
 	 * This means we can't cache the return value, so instead manually cache the CurrentTime object
+	 * @deprecated
 	 */
 	public getCurrentDateAndTime(): string {
 		if ( !this._currentDateAndTime ) {
@@ -77,6 +81,14 @@ export default class DynamicCampaignText implements DynamicContent {
 		}
 
 		return this._currentDateAndTime.getText( new Date() );
+	}
+
+	public getCurrentTime(): string {
+		if ( !this._currentTime ) {
+			this._currentTime = new CurrentTime( this._formatters.time );
+		}
+
+		return this._currentTime.getText( new Date() );
 	}
 
 	public get currentDayName(): string {

--- a/src/utils/DynamicContent/DynamicContent.ts
+++ b/src/utils/DynamicContent/DynamicContent.ts
@@ -7,7 +7,11 @@ import { DynamicProgressBarContent } from '@src/utils/DynamicContent/DynamicProg
 export interface DynamicContent {
 	currentDayName: string;
 	currentDate: string;
+	/**
+	 * @deprecated
+	 */
 	getCurrentDateAndTime: () => string;
+	getCurrentTime: () => string;
 	daysLeftSentence: string;
 	campaignDaySentence: string;
 	visitorsVsDonorsSentence: string;

--- a/src/utils/DynamicContent/generators/CurrentDateAndTime.ts
+++ b/src/utils/DynamicContent/generators/CurrentDateAndTime.ts
@@ -3,6 +3,9 @@ import { Translator } from '@src/Translator';
 import { Ordinal } from '@src/utils/DynamicContent/formatters/Ordinal';
 import { Time } from '@src/utils/DynamicContent/formatters/Time';
 
+/**
+ * @deprecated
+ */
 export class CurrentDateAndTime implements TextGenerator<Date> {
 	private readonly _translator: Translator;
 	private _ordinalFormatter: Ordinal;

--- a/src/utils/DynamicContent/generators/CurrentTime.ts
+++ b/src/utils/DynamicContent/generators/CurrentTime.ts
@@ -1,0 +1,14 @@
+import { TextGenerator } from '@src/utils/DynamicContent/generators/TextGenerator';
+import { Time } from '@src/utils/DynamicContent/formatters/Time';
+
+export class CurrentTime implements TextGenerator<Date> {
+	private _timeFormatter: Time;
+
+	public constructor( timeFormatter: Time ) {
+		this._timeFormatter = timeFormatter;
+	}
+
+	public getText( date: Date ): string {
+		return this._timeFormatter.getFormatted( date );
+	}
+}

--- a/test/banners/dynamicCampaignContent.ts
+++ b/test/banners/dynamicCampaignContent.ts
@@ -5,6 +5,7 @@ export function newDynamicContent(): DynamicContent {
 		campaignDaySentence: '',
 		currentDate: '',
 		getCurrentDateAndTime: () => '',
+		getCurrentTime: () => '',
 		currentDayName: '',
 		daysLeftSentence: 'daysLeftSentence',
 		donorsNeededSentence: '',

--- a/test/components/ProgressBar/ProgressBar.spec.ts
+++ b/test/components/ProgressBar/ProgressBar.spec.ts
@@ -9,6 +9,7 @@ describe( 'ProgressBar.vue', () => {
 		campaignDaySentence: '',
 		currentDate: '',
 		getCurrentDateAndTime: () => '',
+		getCurrentTime: () => '',
 		currentDayName: '',
 		daysLeftSentence: 'daysLeftSentence',
 		donorsNeededSentence: '',

--- a/test/features/BannerContent.ts
+++ b/test/features/BannerContent.ts
@@ -105,6 +105,46 @@ const expectShowsLiveDateAndTimeInSlideshow = async ( getWrapper: ( dynamicConte
 	expect( wrapper.find( '.wmde-banner-slider' ).text() ).toContain( 'Third Date and Time' );
 };
 
+const expectShowsLiveTimeInMessage = async ( getWrapper: ( dynamicContent: DynamicContent ) => VueWrapper<any> ): Promise<any> => {
+	Object.defineProperty( window, 'innerWidth', { writable: true, configurable: true, value: 1301 } );
+	const dynamicContent = newDynamicContent();
+	dynamicContent.getCurrentTime = vi.fn().mockReturnValueOnce( 'Initial Date and Time' )
+		.mockReturnValueOnce( 'Second Date and Time' )
+		.mockReturnValueOnce( 'Third Date and Time' );
+
+	const wrapper = getWrapper( dynamicContent );
+
+	expect( wrapper.find( '.wmde-banner-message' ).text() ).toContain( 'Initial Date and Time' );
+
+	await vi.advanceTimersByTimeAsync( 1000 );
+
+	expect( wrapper.find( '.wmde-banner-message' ).text() ).toContain( 'Second Date and Time' );
+
+	await vi.advanceTimersByTimeAsync( 1000 );
+
+	expect( wrapper.find( '.wmde-banner-message' ).text() ).toContain( 'Third Date and Time' );
+};
+
+const expectShowsLiveTimeInSlideshow = async ( getWrapper: ( dynamicContent: DynamicContent ) => VueWrapper<any> ): Promise<any> => {
+	Object.defineProperty( window, 'innerWidth', { writable: true, configurable: true, value: 1300 } );
+	const dynamicContent = newDynamicContent();
+	dynamicContent.getCurrentTime = vi.fn().mockReturnValueOnce( 'Initial Date and Time' )
+		.mockReturnValueOnce( 'Second Date and Time' )
+		.mockReturnValueOnce( 'Third Date and Time' );
+
+	const wrapper = getWrapper( dynamicContent );
+
+	expect( wrapper.find( '.wmde-banner-slider' ).text() ).toContain( 'Initial Date and Time' );
+
+	await vi.advanceTimersByTimeAsync( 1000 );
+
+	expect( wrapper.find( '.wmde-banner-slider' ).text() ).toContain( 'Second Date and Time' );
+
+	await vi.advanceTimersByTimeAsync( 1000 );
+
+	expect( wrapper.find( '.wmde-banner-slider' ).text() ).toContain( 'Third Date and Time' );
+};
+
 export const bannerContentFeatures: Record<string, ( wrapper: VueWrapper<any> ) => Promise<any>> = {
 	expectSlideShowPlaysWhenBecomesVisible,
 	expectSlideShowStopsOnFormInteraction
@@ -124,5 +164,7 @@ export const bannerContentAnimatedTextFeatures: Record<string, ( getWrapper: () 
 
 export const bannerContentDateAndTimeFeatures: Record<string, ( getWrapper: () => VueWrapper<any> ) => Promise<any>> = {
 	expectShowsLiveDateAndTimeInMessage,
-	expectShowsLiveDateAndTimeInSlideshow
+	expectShowsLiveDateAndTimeInSlideshow,
+	expectShowsLiveTimeInMessage,
+	expectShowsLiveTimeInSlideshow
 };

--- a/test/unit/utils/DynamicContent/DynamicCampaignText.spec.ts
+++ b/test/unit/utils/DynamicContent/DynamicCampaignText.spec.ts
@@ -77,11 +77,18 @@ describe( 'DynamicCampaignText', () => {
 		expect( dynamicCampaignText.currentDate ).toBe( 'current month 10th' );
 	} );
 
-	it( 'Gets the current time', () => {
+	it( 'Gets the current date and time', () => {
 		vi.setSystemTime( new Date( 2023, 10, 10, 13, 42, 0 ) );
 		// In some test environments the output of Date.toLocaleString includes the code for a space,
 		// but in others it doesn't. To fix that we manually replace it in this test
 		expect( dynamicCampaignText.getCurrentDateAndTime().replace( '\u202f', ' ' ) ).toBe( 'current month 10th current time 1:42 pm' );
+	} );
+
+	it( 'Gets the current time', () => {
+		vi.setSystemTime( new Date( 2023, 10, 10, 13, 42, 0 ) );
+		// In some test environments the output of Date.toLocaleString includes the code for a space,
+		// but in others it doesn't. To fix that we manually replace it in this test
+		expect( dynamicCampaignText.getCurrentTime().replace( '\u202f', ' ' ) ).toBe( '1:42 pm' );
 	} );
 
 	it( 'Gets the current day name', () => {


### PR DESCRIPTION
We already have a date function in the dynamic text, so creating one that only outputs the current time lets our content be more versatile.

Also deprecates the currentDateAndTime method.