### PR TITLE
Fix EN time formatting in Chrome

### DIFF
--- a/src/utils/DynamicContent/formatters/TimeEn.ts
+++ b/src/utils/DynamicContent/formatters/TimeEn.ts
@@ -2,6 +2,6 @@ import { Time } from '@src/utils/DynamicContent/formatters/Time';
 
 export class TimeEn implements Time {
 	public getFormatted( date: Date ): string {
-		return date.toLocaleString( 'en-GB', { hour: 'numeric', hour12: true, minute: 'numeric' } );
+		return date.toLocaleString( 'en-GB', { hour: 'numeric', hourCycle: 'h12', minute: 'numeric' } );
 	}
 }


### PR DESCRIPTION
Manually set the hour cycle so Chrome formats the en-GB hour between midday and 1pm properly. Chrome is the new IE.