### PR TITLE
Set page body fixed on modal open

### DIFF
--- a/src/components/BannerConductor/BannerConductor.vue
+++ b/src/components/BannerConductor/BannerConductor.vue
@@ -10,6 +10,8 @@
 			:bannerHeight="bannerRef?.offsetHeight"
 			@banner-closed="closeHandler"
 			@banner-content-changed="onContentChanged"
+			@on-modal-opened="page.setModalOpened"
+			@on-modal-closed="page.setModalClosed"
 		/>
 	</div>
 </template>

--- a/src/components/BannerConductor/FallbackBannerConductor.vue
+++ b/src/components/BannerConductor/FallbackBannerConductor.vue
@@ -10,6 +10,8 @@
 			:bannerHeight="bannerRef?.offsetHeight"
 			@banner-closed="closeHandler"
 			@banner-content-changed="onContentChanged"
+			@on-modal-opened="page.setModalOpened"
+			@on-modal-closed="page.setModalClosed"
 		/>
 	</div>
 </template>

--- a/src/page/Page.ts
+++ b/src/page/Page.ts
@@ -18,4 +18,6 @@ export interface Page {
 	setCloseCookieIfNecessary: ( closeEvent: TrackingEvent<void> ) => Page;
 	getCampaignParameters: () => CampaignParameters;
 	getTracking: () => TrackingParameters;
+	setModalOpened: () => void;
+	setModalClosed: () => void;
 }

--- a/src/page/PageWPDE.ts
+++ b/src/page/PageWPDE.ts
@@ -84,6 +84,12 @@ class PageWPDE implements Page {
 		// WPDE banners have a hardcoded limit of 7
 		return 7;
 	}
+
+	public setModalOpened(): void {
+	}
+
+	public setModalClosed(): void {
+	}
 }
 
 export default PageWPDE;

--- a/src/page/PageWPORG.ts
+++ b/src/page/PageWPORG.ts
@@ -84,7 +84,7 @@ class PageWPORG implements Page {
 	}
 
 	public setSpace( space: number ): Page {
-		document.body.style.setProperty( bannerHeightCssVariable, `${space}px` );
+		document.body.style.setProperty( bannerHeightCssVariable, `${ space }px` );
 		return this;
 	}
 
@@ -99,7 +99,7 @@ class PageWPORG implements Page {
 	}
 
 	public setTransitionDuration( duration: number ): Page {
-		document.body.style.setProperty( bannerTransitionDurationCssVariable, `${duration}ms` );
+		document.body.style.setProperty( bannerTransitionDurationCssVariable, `${ duration }ms` );
 		return this;
 	}
 
@@ -192,6 +192,29 @@ class PageWPORG implements Page {
 		}
 
 		return Number( maxImpressions );
+	}
+
+	/**
+	 * When a modal is open we set the body to fixed in order to hide the scroll bar
+	 * and stop it interfering with the modal's scrollbar.
+	 *
+	 * We also set the top style so the page doesn't jump.
+	 */
+	public setModalOpened(): void {
+		const scrollY = window.scrollY;
+		document.body.style.position = 'fixed';
+		document.body.style.top = `-${ scrollY }px`;
+	}
+
+	/**
+	 * Remove the body position fixed and jump the window to where the user was before
+	 * they opened the modal.
+	 */
+	public setModalClosed(): void {
+		const scrollY = document.body.style.top;
+		document.body.style.position = '';
+		document.body.style.top = '';
+		window.scrollTo( 0, parseInt( scrollY || '0' ) * -1 );
 	}
 }
 

--- a/test/components/BannerConductor/BannerConductor.spec.ts
+++ b/test/components/BannerConductor/BannerConductor.spec.ts
@@ -36,7 +36,9 @@ describe( 'BannerConductor.vue', () => {
 			},
 			emits: [
 				'bannerClosed',
-				'bannerContentChanged'
+				'bannerContentChanged',
+				'onModalOpened',
+				'onModalClosed'
 			],
 			methods: {
 				onClose() {
@@ -47,6 +49,8 @@ describe( 'BannerConductor.vue', () => {
 				Hello, world!
 				<button class="emit-banner-closed" @click="onClose"></button>
 				<button class="emit-banner-content-changed" @click="$emit( 'bannerContentChanged' )"></button>
+				<button class="emit-banner-modal-open" @click="$emit( 'onModalOpened' )"></button>
+				<button class="emit-banner-modal-closed" @click="$emit( 'onModalClosed' )"></button>
 			</div>`
 		} );
 		const wrapper = mount( BannerConductor, {
@@ -204,5 +208,25 @@ describe( 'BannerConductor.vue', () => {
 		] );
 
 		expect( wrapper.classes() ).toContain( BannerStates.Closed );
+	} );
+
+	it( 'tells the page that a modal was opened', async () => {
+		const page = new PageStub();
+		page.setModalOpened = vi.fn();
+		const wrapper = await getShownBannerWrapper( page );
+
+		await wrapper.find( '.emit-banner-modal-open' ).trigger( 'click' );
+
+		expect( page.setModalOpened ).toHaveBeenCalledOnce();
+	} );
+
+	it( 'tells the page that a modal was closed', async () => {
+		const page = new PageStub();
+		page.setModalOpened = vi.fn();
+		const wrapper = await getShownBannerWrapper( page );
+
+		await wrapper.find( '.emit-banner-modal-open' ).trigger( 'click' );
+
+		expect( page.setModalOpened ).toHaveBeenCalledOnce();
 	} );
 } );

--- a/test/components/BannerConductor/FallbackBannerConductor.spec.ts
+++ b/test/components/BannerConductor/FallbackBannerConductor.spec.ts
@@ -36,7 +36,9 @@ describe( 'FallbackBannerConductor.vue', () => {
 			},
 			emits: [
 				'bannerClosed',
-				'bannerContentChanged'
+				'bannerContentChanged',
+				'onModalOpened',
+				'onModalClosed'
 			],
 			methods: {
 				onClose(): void {
@@ -47,6 +49,8 @@ describe( 'FallbackBannerConductor.vue', () => {
 				Hello, world!
 				<button class="emit-banner-closed" @click="onClose"></button>
 				<button class="emit-banner-content-changed" @click="$emit( 'bannerContentChanged' )"></button>
+				<button class="emit-banner-modal-open" @click="$emit( 'onModalOpened' )"></button>
+				<button class="emit-banner-modal-closed" @click="$emit( 'onModalClosed' )"></button>
 			</div>`
 		};
 	};
@@ -275,6 +279,26 @@ describe( 'FallbackBannerConductor.vue', () => {
 		] );
 
 		expect( wrapper.classes() ).toContain( BannerStates.Closed );
+	} );
+
+	it( 'tells the page that a modal was opened', async () => {
+		const page = new PageStub();
+		page.setModalOpened = vi.fn();
+		const wrapper = await getShownBannerWrapper( page );
+
+		await wrapper.find( '.emit-banner-modal-open' ).trigger( 'click' );
+
+		expect( page.setModalOpened ).toHaveBeenCalledOnce();
+	} );
+
+	it( 'tells the page that a modal was closed', async () => {
+		const page = new PageStub();
+		page.setModalOpened = vi.fn();
+		const wrapper = await getShownBannerWrapper( page );
+
+		await wrapper.find( '.emit-banner-modal-open' ).trigger( 'click' );
+
+		expect( page.setModalOpened ).toHaveBeenCalledOnce();
 	} );
 
 } );

--- a/test/features/UseOfFunds.ts
+++ b/test/features/UseOfFunds.ts
@@ -31,9 +31,23 @@ const expectScrollsToLinkWhenCloseIsClicked = async ( wrapper: VueWrapper<any>, 
 	expect( pageScroller.scrollIntoView ).toHaveBeenCalledWith( '.wmde-banner-full-small-print .wmde-banner-footer-usage-link' );
 };
 
+const expectEmitsModalOpenedEvent = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+	await wrapper.find( '.wmde-banner-footer-usage-link' ).trigger( 'click' );
+
+	expect( wrapper.emitted( 'onModalOpened' ).length ).toStrictEqual( 1 );
+};
+
+const expectEmitsModalClosedEvent = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+	await wrapper.find( '.banner-modal-close-link' ).trigger( 'click' );
+
+	expect( wrapper.emitted( 'onModalClosed' ).length ).toStrictEqual( 1 );
+};
+
 export const useOfFundsFeatures: Record<string, ( wrapper: VueWrapper<any> ) => Promise<any>> = {
 	expectShowsUseOfFunds,
-	expectHidesUseOfFunds
+	expectHidesUseOfFunds,
+	expectEmitsModalOpenedEvent,
+	expectEmitsModalClosedEvent
 };
 
 export const useOfFundsScrollFeatures: Record<string, ( wrapper: VueWrapper<any>, pageScroller: PageScroller ) => Promise<any>> = {

--- a/test/fixtures/PageStub.ts
+++ b/test/fixtures/PageStub.ts
@@ -83,4 +83,10 @@ export class PageStub implements Page {
 		return 10;
 	}
 
+	public setModalOpened(): void {
+	}
+
+	public setModalClosed(): void {
+	}
+
 }

--- a/test/integration/page/PageWPORG.spec.ts
+++ b/test/integration/page/PageWPORG.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vitest } from 'vitest';
+import { beforeEach, describe, expect, it, vi, vitest } from 'vitest';
 import PageWPORG, { bannerAppId } from '@src/page/PageWPORG';
 import { MediaWiki } from '@src/page/MediaWiki/MediaWiki';
 import { SkinStub } from '@test/fixtures/SkinStub';
@@ -185,5 +185,30 @@ describe( 'PageWPORG', function () {
 		const page = new PageWPORG( mediaWiki, new SkinStub(), new SizeIssueCheckerStub() );
 
 		expect( () => page.getTracking() ).toThrow( 'Banner container element not found' );
+	} );
+
+	it( 'Sets the body to fixed when a modal is opened', () => {
+		Object.defineProperty( window, 'scrollY', { writable: true, configurable: true, value: 42 } );
+		const page = new PageWPORG( mediaWiki, new SkinStub(), new SizeIssueCheckerStub() );
+
+		page.setModalOpened();
+
+		expect( document.body.style.getPropertyValue( 'position' ) ).toStrictEqual( 'fixed' );
+		expect( document.body.style.getPropertyValue( 'top' ) ).toStrictEqual( '-42px' );
+	} );
+
+	it( 'Removes the fixed from the body when a modal is closed', () => {
+		document.body.style.position = 'fixed';
+		document.body.style.top = '-42px';
+		const scrollTo = vi.fn();
+		Object.defineProperty( window, 'scrollTo', { writable: true, configurable: true, value: scrollTo } );
+		const page = new PageWPORG( mediaWiki, new SkinStub(), new SizeIssueCheckerStub() );
+
+		page.setModalClosed();
+
+		expect( document.body.style.getPropertyValue( 'position' ) ).toStrictEqual( '' );
+		expect( document.body.style.getPropertyValue( 'top' ) ).toStrictEqual( '' );
+		expect( scrollTo ).toHaveBeenCalledOnce();
+		expect( scrollTo ).toHaveBeenCalledWith( 0, 42 );
 	} );
 } );


### PR DESCRIPTION
This will prevent scrollbars from interfering with each
other when the user views a full page modal. It will also
stop the page scrolling behind the user when they're looking
at a modal and they scroll their mouse wheel.

Ticket: https://phabricator.wikimedia.org/T353435