### PR TITLE
Remove American Express Logo from iPad banner

### DIFF
--- a/banners/pad/components/BannerVar.vue
+++ b/banners/pad/components/BannerVar.vue
@@ -49,7 +49,6 @@
 								<span class="wmde-banner-select-group-label with-logos credit-cards">
 									<VisaLogo/>
 									<MastercardLogo/>
-									<AmexLogo/>
 								</span>
 							</template>
 
@@ -116,7 +115,6 @@ import { TrackingFeatureName } from '@src/tracking/TrackingEvent';
 import MastercardLogo from '@src/components/PaymentLogos/MastercardLogo.vue';
 import SepaLogo from '@src/components/PaymentLogos/SepaLogo.vue';
 import VisaLogo from '@src/components/PaymentLogos/VisaLogo.vue';
-import AmexLogo from '@src/components/PaymentLogos/AmexLogo.vue';
 import PayPalLogo from '@src/components/PaymentLogos/PayPalLogo.vue';
 import BannerFooter from '@src/components/Footer/BannerFooter.vue';
 


### PR DESCRIPTION
Our payment provider doesn't support AmEx

Ticket: https://phabricator.wikimedia.org/T352980
