### PR TITLE
[FollowUp] Remove !important rule

### DIFF
--- a/banners/desktop/C24_WMDE_Desktop_DE_02/content/BannerSlidesVar.vue
+++ b/banners/desktop/C24_WMDE_Desktop_DE_02/content/BannerSlidesVar.vue
@@ -1,13 +1,13 @@
 <template>
 	<KeenSliderSlide :is-current="currentSlide === 0">
-		<p class="wmde-banner-message-title">
+		<div class="wmde-banner-message-title">
 			<InfoIcon fill="#990000" width="21.5" height="21.5" type="italic"/>
 			<strong>&nbsp;Kostenlos, aber nicht kostenfrei</strong>
-		</p>
-		<p class="wmde-banner-message-date">
+		</div>
+		<div class="wmde-banner-message-date">
 			<strong>{{ liveDateAndTime.currentDate }}, {{ liveDateAndTime.currentTime }} - An alle, die Wikipedia in
 			Deutschland nutzen</strong>
-		</p>
+		</div>
 		<p>
 			Vielleicht kommen wir gerade ungelegen, aber dennoch: Klicken Sie jetzt bitte nicht weg! Am heutigen
 			{{ currentDayName }} bitten wir Sie, die Unabhängigkeit von Wikipedia zu unterstützen.

--- a/banners/desktop/C24_WMDE_Desktop_DE_02/content/BannerTextVar.vue
+++ b/banners/desktop/C24_WMDE_Desktop_DE_02/content/BannerTextVar.vue
@@ -1,14 +1,14 @@
 <template>
 	<div class="wmde-banner-message">
 		<div>
-			<p class="wmde-banner-message-title">
+			<div class="wmde-banner-message-title">
 				<InfoIcon fill="#990000" width="21.5" height="21.5" type="italic"/>
 				<strong>&nbsp;Kostenlos, aber nicht kostenfrei</strong>
-			</p>
-			<p class="wmde-banner-message-date">
+			</div>
+			<div class="wmde-banner-message-date">
 				<strong>{{ liveDateAndTime.currentDate }}, {{ liveDateAndTime.currentTime }} - An alle, die Wikipedia
 				in Deutschland nutzen</strong>
-			</p>
+			</div>
 			<p>
 				Vielleicht kommen wir gerade ungelegen, aber dennoch: Klicken Sie jetzt bitte nicht weg! Am heutigen
 				{{ currentDayName }} bitten wir Sie, die Unabhängigkeit von Wikipedia zu unterstützen.

--- a/src/themes/Svingle/Message/Message.scss
+++ b/src/themes/Svingle/Message/Message.scss
@@ -29,7 +29,7 @@ $font-sizes: ( breakpoints.$extra-small: 18px ) !default;
 
 		&-title {
 			max-height: 62px;
-			margin-bottom: 4px !important;
+			margin: 0 0 4px;
 			text-align: center;
 			font-size: 25px;
 			font-weight: bold;
@@ -51,6 +51,7 @@ $font-sizes: ( breakpoints.$extra-small: 18px ) !default;
 
 		&-date {
 			text-align: center;
+			padding-bottom: 15px;
 		}
 	}
 }

--- a/src/themes/Svingle/Slider/KeenSlider.scss
+++ b/src/themes/Svingle/Slider/KeenSlider.scss
@@ -51,7 +51,7 @@ $margin-bottom: 15px !default;
 
 		&-title {
 			max-height: 62px;
-			margin-bottom: 4px !important;
+			margin: 0 0 4px;
 			text-align: center;
 			font-size: 25px;
 			font-weight: bold;
@@ -73,6 +73,7 @@ $margin-bottom: 15px !default;
 
 		&-date {
 			text-align: center;
+			padding-bottom: 15px;
 		}
 	}
 


### PR DESCRIPTION
-  using `!important` in CSS is often a sign of a code smell when writing CSS and we try to avoid it,
    because it means there might was trouble with the CSS's specificity rules (
    see e.g. https://csswizardry.com/2012/11/code-smells-in-css/ -> "Reactive !important")
	`!important` should only be used in very exceptional cases
    
- exchange the p tag (which have strong rather global css rules) with a normal div tag
    (that is easier to style, we don't have to overwrite p rules)
