### PR TITLE
C24_WMDE_Desktop_EN_02 (round 1)

### DIFF
--- a/banners/english/C24_WMDE_Desktop_EN_02/banner_ctrl.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_02/banner_ctrl.ts
@@ -1,0 +1,73 @@
+import { createVueApp } from '@src/createVueApp';
+
+import './styles/styles.scss';
+
+import BannerConductor from '@src/components/BannerConductor/FallbackBannerConductor.vue';
+import Banner from './components/BannerCtrl.vue';
+import FallbackBanner from './components/FallbackBanner.vue';
+import { UrlRuntimeEnvironment } from '@src/utils/RuntimeEnvironment';
+import { WindowResizeHandler } from '@src/utils/ResizeHandler';
+import PageWPORG from '@src/page/PageWPORG';
+import { WindowMediaWiki } from '@src/page/MediaWiki/WindowMediaWiki';
+import { SkinFactory } from '@src/page/skin/SkinFactory';
+import { WindowSizeIssueChecker } from '@src/utils/SizeIssueChecker/WindowSizeIssueChecker';
+import TranslationPlugin from '@src/TranslationPlugin';
+import { Translator } from '@src/Translator';
+import DynamicTextPlugin from '@src/DynamicTextPlugin';
+import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
+import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
+import { Locales } from '@src/domain/Locales';
+
+// Locale-specific imports
+import messages from './messages';
+import { LocaleFactoryEn } from '@src/utils/LocaleFactory/LocaleFactoryEn';
+
+// Channel specific form setup
+import { createFormItems } from './form_items';
+import { createFormActions } from '@src/createFormActions';
+import eventMappings from './event_map';
+import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
+
+const localeFactory = new LocaleFactoryEn();
+const translator = new Translator( messages );
+const mediaWiki = new WindowMediaWiki();
+const page = new PageWPORG( mediaWiki, ( new SkinFactory( mediaWiki ) ).getSkin(), new WindowSizeIssueChecker( 400 ) );
+const runtimeEnvironment = new UrlRuntimeEnvironment( window.location );
+const impressionCount = new LocalImpressionCount( page.getTracking().keyword, runtimeEnvironment );
+const tracker = new LegacyTrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings, runtimeEnvironment );
+
+const app = createVueApp( BannerConductor, {
+	page,
+	bannerConfig: {
+		delay: runtimeEnvironment.getBannerDelay( 7500 ),
+		transitionDuration: 1000
+	},
+	bannerProps: {
+		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
+		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'english' ) ),
+		donationLink: createFallbackDonationURL( page.getTracking(), impressionCount, { locale: Locales.EN } )
+	},
+	resizeHandler: new WindowResizeHandler(),
+	banner: Banner,
+	fallbackBanner: FallbackBanner,
+	minWidthForMainBanner: 800,
+	impressionCount
+} );
+
+app.use( TranslationPlugin, translator );
+app.use( DynamicTextPlugin, {
+	campaignParameters: page.getCampaignParameters(),
+	date: new Date(),
+	formatters: localeFactory.getFormatters(),
+	impressionCount,
+	translator
+} );
+
+const currencyFormatter = localeFactory.getCurrencyFormatter();
+
+app.provide( 'currencyFormatter', currencyFormatter );
+app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
+app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { locale: Locales.EN, ap: '0' } ) );
+app.provide( 'tracker', tracker );
+
+app.mount( page.getBannerContainer() );

--- a/banners/english/C24_WMDE_Desktop_EN_02/banner_var.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_02/banner_var.ts
@@ -1,0 +1,73 @@
+import { createVueApp } from '@src/createVueApp';
+
+import './styles/styles.scss';
+
+import BannerConductor from '@src/components/BannerConductor/FallbackBannerConductor.vue';
+import Banner from './components/BannerCtrl.vue';
+import FallbackBanner from './components/FallbackBanner.vue';
+import { UrlRuntimeEnvironment } from '@src/utils/RuntimeEnvironment';
+import { WindowResizeHandler } from '@src/utils/ResizeHandler';
+import PageWPORG from '@src/page/PageWPORG';
+import { WindowMediaWiki } from '@src/page/MediaWiki/WindowMediaWiki';
+import { SkinFactory } from '@src/page/skin/SkinFactory';
+import { WindowSizeIssueChecker } from '@src/utils/SizeIssueChecker/WindowSizeIssueChecker';
+import TranslationPlugin from '@src/TranslationPlugin';
+import { Translator } from '@src/Translator';
+import DynamicTextPlugin from '@src/DynamicTextPlugin';
+import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
+import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
+import { Locales } from '@src/domain/Locales';
+
+// Locale-specific imports
+import messages from './messages';
+import { LocaleFactoryEn } from '@src/utils/LocaleFactory/LocaleFactoryEn';
+
+// Channel specific form setup
+import { createFormItems } from './form_items';
+import { createFormActions } from '@src/createFormActions';
+import eventMappings from './event_map';
+import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
+
+const localeFactory = new LocaleFactoryEn();
+const translator = new Translator( messages );
+const mediaWiki = new WindowMediaWiki();
+const page = new PageWPORG( mediaWiki, ( new SkinFactory( mediaWiki ) ).getSkin(), new WindowSizeIssueChecker( 400 ) );
+const runtimeEnvironment = new UrlRuntimeEnvironment( window.location );
+const impressionCount = new LocalImpressionCount( page.getTracking().keyword, runtimeEnvironment );
+const tracker = new LegacyTrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings, runtimeEnvironment );
+
+const app = createVueApp( BannerConductor, {
+	page,
+	bannerConfig: {
+		delay: runtimeEnvironment.getBannerDelay( 7500 ),
+		transitionDuration: 1000
+	},
+	bannerProps: {
+		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
+		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'english' ) ),
+		donationLink: createFallbackDonationURL( page.getTracking(), impressionCount, { locale: Locales.EN } )
+	},
+	resizeHandler: new WindowResizeHandler(),
+	banner: Banner,
+	fallbackBanner: FallbackBanner,
+	minWidthForMainBanner: 800,
+	impressionCount
+} );
+
+app.use( TranslationPlugin, translator );
+app.use( DynamicTextPlugin, {
+	campaignParameters: page.getCampaignParameters(),
+	date: new Date(),
+	formatters: localeFactory.getFormatters(),
+	impressionCount,
+	translator
+} );
+
+const currencyFormatter = localeFactory.getCurrencyFormatter();
+
+app.provide( 'currencyFormatter', currencyFormatter );
+app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
+app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { locale: Locales.EN, ap: '1' } ) );
+app.provide( 'tracker', tracker );
+
+app.mount( page.getBannerContainer() );

--- a/banners/english/C24_WMDE_Desktop_EN_02/banner_var.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_02/banner_var.ts
@@ -3,7 +3,7 @@ import { createVueApp } from '@src/createVueApp';
 import './styles/styles.scss';
 
 import BannerConductor from '@src/components/BannerConductor/FallbackBannerConductor.vue';
-import Banner from './components/BannerCtrl.vue';
+import Banner from './components/BannerVar.vue';
 import FallbackBanner from './components/FallbackBanner.vue';
 import { UrlRuntimeEnvironment } from '@src/utils/RuntimeEnvironment';
 import { WindowResizeHandler } from '@src/utils/ResizeHandler';
@@ -67,7 +67,7 @@ const currencyFormatter = localeFactory.getCurrencyFormatter();
 
 app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
-app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { locale: Locales.EN, ap: '1' } ) );
+app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { locale: Locales.EN, ap: '0' } ) );
 app.provide( 'tracker', tracker );
 
 app.mount( page.getBannerContainer() );

--- a/banners/english/C24_WMDE_Desktop_EN_02/components/BannerCtrl.vue
+++ b/banners/english/C24_WMDE_Desktop_EN_02/components/BannerCtrl.vue
@@ -57,11 +57,15 @@
             </template>
         </MainBanner>
 
-        <FundsModal
-            :content="useOfFundsContent"
-            :is-funds-modal-visible="isFundsModalVisible"
-            @hideFundsModal="isFundsModalVisible = false"
-        />
+		<FundsModal
+			:content="useOfFundsContent"
+			:is-funds-modal-visible="isFundsModalVisible"
+			@hideFundsModal="isFundsModalVisible = false"
+		>
+			<template #infographic>
+				<WMDEFundsForwardingEN/>
+			</template>
+		</FundsModal>
     </div>
 </template>
 
@@ -91,6 +95,7 @@ import { TrackingFeatureName } from '@src/tracking/TrackingEvent';
 import VisaLogo from '@src/components/PaymentLogos/VisaLogo.vue';
 import MastercardLogo from '@src/components/PaymentLogos/MastercardLogo.vue';
 import PayPalLogo from '@src/components/PaymentLogos/PayPalLogo.vue';
+import WMDEFundsForwardingEN from '@src/components/UseOfFunds/Infographics/WMDEFundsForwardingEN.vue';
 
 enum ContentStates {
 	Main = 'wmde-banner-wrapper--main',

--- a/banners/english/C24_WMDE_Desktop_EN_02/components/BannerCtrl.vue
+++ b/banners/english/C24_WMDE_Desktop_EN_02/components/BannerCtrl.vue
@@ -1,0 +1,135 @@
+<template>
+    <div class="wmde-banner-wrapper" :class="contentState">
+        <MainBanner
+			@close="onCloseMain"
+			@form-interaction="$emit( 'bannerContentChanged' )"
+            :banner-state="bannerState"
+            v-if="contentState === ContentStates.Main"
+        >
+            <template #banner-text>
+                <BannerText/>
+            </template>
+
+            <template #banner-slides="{ play }: any">
+                <KeenSlider :with-navigation="true" :play="play" :interval="10000" :delay="2000">
+
+                    <template #slides="{ currentSlide }: any">
+                        <BannerSlides :currentSlide="currentSlide"/>
+                    </template>
+
+                </KeenSlider>
+            </template>
+
+			<template #donation-form="{ formInteraction }: any">
+				<MultiStepDonation :step-controllers="stepControllers" @form-interaction="formInteraction">
+
+					<template #[FormStepNames.MainDonationFormStep]="{ pageIndex, submit, isCurrent, previous }: any">
+						<MainDonationForm :page-index="pageIndex" @submit="submit" :is-current="isCurrent" @previous="previous">
+							<template #label-payment-ppl>
+								<span class="wmde-banner-select-group-label with-logos paypal"><PayPalLogo/></span>
+							</template>
+
+							<template #label-payment-mcp>
+								<span class="wmde-banner-select-group-label with-logos credit-cards">
+									<VisaLogo/>
+									<MastercardLogo/>
+								</span>
+							</template>
+						</MainDonationForm>
+					</template>
+
+					<template #[FormStepNames.UpgradeToYearlyFormStep]="{ pageIndex, submit, isCurrent, previous }: any">
+						<UpgradeToYearlyButtonForm
+							:page-index="pageIndex"
+							:is-current="isCurrent"
+							:show-manual-upgrade-option="false"
+							@submit="submit"
+							@previous="previous"
+						/>
+					</template>
+
+                </MultiStepDonation>
+            </template>
+            <template #footer>
+                <BannerFooter
+                    @showFundsModal="isFundsModalVisible = true"
+                />
+            </template>
+        </MainBanner>
+
+        <FundsModal
+            :content="useOfFundsContent"
+            :is-funds-modal-visible="isFundsModalVisible"
+            @hideFundsModal="isFundsModalVisible = false"
+        />
+    </div>
+</template>
+
+<script setup lang="ts">
+import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+import { ref, watch } from 'vue';
+import MainBanner from './MainBanner.vue';
+import FundsModal from '@src/components/UseOfFunds/FundsModal.vue';
+import { UseOfFundsContent as useOfFundsContentInterface } from '@src/domain/UseOfFunds/UseOfFundsContent';
+import UpgradeToYearlyButtonForm from '@src/components/DonationForm/Forms/UpgradeToYearlyButtonForm.vue';
+import BannerSlides from '../content/BannerSlides.vue';
+import MainDonationForm from '@src/components/DonationForm/Forms/MainDonationForm.vue';
+import MultiStepDonation from '@src/components/DonationForm/MultiStepDonation.vue';
+import BannerText from '../content/BannerText.vue';
+import KeenSlider from '@src/components/Slider/KeenSlider.vue';
+import BannerFooter from '@src/components/Footer/BannerFooter.vue';
+import { useFormModel } from '@src/components/composables/useFormModel';
+import {
+	createSubmittableMainDonationForm
+} from '@src/components/DonationForm/StepControllers/SubmittableMainDonationForm';
+import {
+	createSubmittableUpgradeToYearly
+} from '@src/components/DonationForm/StepControllers/SubmittableUpgradeToYearly';
+import { CloseChoices } from '@src/domain/CloseChoices';
+import { CloseEvent } from '@src/tracking/events/CloseEvent';
+import { TrackingFeatureName } from '@src/tracking/TrackingEvent';
+import VisaLogo from '@src/components/PaymentLogos/VisaLogo.vue';
+import MastercardLogo from '@src/components/PaymentLogos/MastercardLogo.vue';
+import PayPalLogo from '@src/components/PaymentLogos/PayPalLogo.vue';
+
+enum ContentStates {
+	Main = 'wmde-banner-wrapper--main',
+	SoftClosing = 'wmde-banner-wrapper--soft-closing'
+}
+
+enum FormStepNames {
+	CustomAmountFormStep = 'CustomAmountForm',
+	MainDonationFormStep = 'MainDonationForm',
+	UpgradeToYearlyFormStep = 'UpgradeToYearlyForm'
+}
+
+interface Props {
+	bannerState: BannerStates;
+	useOfFundsContent: useOfFundsContentInterface;
+	remainingImpressions: number;
+}
+
+defineProps<Props>();
+const emit = defineEmits( [ 'bannerClosed', 'maybeLater', 'bannerContentChanged' ] );
+
+const isFundsModalVisible = ref<boolean>( false );
+const contentState = ref<ContentStates>( ContentStates.Main );
+const formModel = useFormModel();
+const stepControllers = [
+	createSubmittableMainDonationForm( formModel, FormStepNames.UpgradeToYearlyFormStep ),
+	createSubmittableUpgradeToYearly( formModel, FormStepNames.MainDonationFormStep, FormStepNames.MainDonationFormStep )
+];
+
+watch( contentState, async () => {
+	emit( 'bannerContentChanged' );
+} );
+
+function onCloseMain(): void {
+	onClose( 'MainBanner', CloseChoices.Close );
+}
+
+function onClose( feature: TrackingFeatureName, userChoice: CloseChoices ): void {
+	emit( 'bannerClosed', new CloseEvent( feature, userChoice ) );
+}
+
+</script>

--- a/banners/english/C24_WMDE_Desktop_EN_02/components/BannerVar.vue
+++ b/banners/english/C24_WMDE_Desktop_EN_02/components/BannerVar.vue
@@ -1,0 +1,156 @@
+<template>
+    <div class="wmde-banner-wrapper" :class="contentState">
+        <MainBanner
+			@close="onCloseMain"
+			@form-interaction="$emit( 'bannerContentChanged' )"
+            :banner-state="bannerState"
+            v-if="contentState === ContentStates.Main"
+        >
+            <template #banner-text>
+                <BannerText/>
+            </template>
+
+            <template #banner-slides="{ play }: any">
+                <KeenSlider :with-navigation="true" :play="play" :interval="10000" :delay="2000">
+
+                    <template #slides="{ currentSlide }: any">
+                        <BannerSlides :currentSlide="currentSlide"/>
+                    </template>
+
+                </KeenSlider>
+            </template>
+
+			<template #progress>
+				<ProgressBar amount-to-show-on-right="TARGET"/>
+			</template>
+
+			<template #donation-form="{ formInteraction }: any">
+				<MultiStepDonation :step-controllers="stepControllers" @form-interaction="formInteraction">
+
+					<template #[FormStepNames.MainDonationFormStep]="{ pageIndex, submit, isCurrent, previous }: any">
+						<MainDonationForm :page-index="pageIndex" @submit="submit" :is-current="isCurrent" @previous="previous">
+							<template #label-payment-ppl>
+								<span class="wmde-banner-select-group-label with-logos paypal"><PayPalLogo/></span>
+							</template>
+
+							<template #label-payment-mcp>
+								<span class="wmde-banner-select-group-label with-logos credit-cards">
+									<VisaLogo/>
+									<MastercardLogo/>
+								</span>
+							</template>
+						</MainDonationForm>
+					</template>
+
+					<template #[FormStepNames.UpgradeToYearlyFormStep]="{ pageIndex, submit, isCurrent, previous }: any">
+						<UpgradeToYearlyButtonForm
+							:page-index="pageIndex"
+							:is-current="isCurrent"
+							:show-manual-upgrade-option="false"
+							@submit="submit"
+							@previous="previous"
+						/>
+					</template>
+
+                </MultiStepDonation>
+            </template>
+            <template #footer>
+                <BannerFooter
+                    @showFundsModal="isFundsModalVisible = true"
+                />
+            </template>
+        </MainBanner>
+
+		<SoftClose
+			v-if="contentState === ContentStates.SoftClosing"
+			:show-close-icon="true"
+			@close="() => onClose( 'SoftClose', CloseChoices.Close )"
+			@maybe-later="() => onClose( 'SoftClose', CloseChoices.MaybeLater )"
+			@time-out-close="() => onClose( 'SoftClose', CloseChoices.TimeOut )"
+		/>
+
+        <FundsModal
+            :content="useOfFundsContent"
+            :is-funds-modal-visible="isFundsModalVisible"
+            @hideFundsModal="isFundsModalVisible = false"
+        />
+    </div>
+</template>
+
+<script setup lang="ts">
+import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+import SoftClose from '@src/components/SoftClose/SoftClose.vue';
+import { ref, watch } from 'vue';
+import MainBanner from './MainBanner.vue';
+import FundsModal from '@src/components/UseOfFunds/FundsModal.vue';
+import { UseOfFundsContent as useOfFundsContentInterface } from '@src/domain/UseOfFunds/UseOfFundsContent';
+import UpgradeToYearlyButtonForm from '@src/components/DonationForm/Forms/UpgradeToYearlyButtonForm.vue';
+import BannerSlides from '../content/BannerSlides.vue';
+import MainDonationForm from '@src/components/DonationForm/Forms/MainDonationForm.vue';
+import ProgressBar from '@src/components/ProgressBar/ProgressBarAlternative.vue';
+import MultiStepDonation from '@src/components/DonationForm/MultiStepDonation.vue';
+import BannerText from '../content/BannerText.vue';
+import KeenSlider from '@src/components/Slider/KeenSlider.vue';
+import BannerFooter from '@src/components/Footer/BannerFooter.vue';
+import { useFormModel } from '@src/components/composables/useFormModel';
+import {
+	createSubmittableMainDonationForm
+} from '@src/components/DonationForm/StepControllers/SubmittableMainDonationForm';
+import {
+	createSubmittableUpgradeToYearly
+} from '@src/components/DonationForm/StepControllers/SubmittableUpgradeToYearly';
+import { CloseChoices } from '@src/domain/CloseChoices';
+import { CloseEvent } from '@src/tracking/events/CloseEvent';
+import { TrackingFeatureName } from '@src/tracking/TrackingEvent';
+import VisaLogo from '@src/components/PaymentLogos/VisaLogo.vue';
+import MastercardLogo from '@src/components/PaymentLogos/MastercardLogo.vue';
+import PayPalLogo from '@src/components/PaymentLogos/PayPalLogo.vue';
+import { useAnonymousAddressTypeSetter } from '@src/components/composables/useAnonymousAddressTypeSetter';
+
+enum ContentStates {
+	Main = 'wmde-banner-wrapper--main',
+	SoftClosing = 'wmde-banner-wrapper--soft-closing'
+}
+
+enum FormStepNames {
+	CustomAmountFormStep = 'CustomAmountForm',
+	MainDonationFormStep = 'MainDonationForm',
+	UpgradeToYearlyFormStep = 'UpgradeToYearlyForm'
+}
+
+interface Props {
+	bannerState: BannerStates;
+	useOfFundsContent: useOfFundsContentInterface;
+	remainingImpressions: number;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits( [ 'bannerClosed', 'maybeLater', 'bannerContentChanged' ] );
+
+const isFundsModalVisible = ref<boolean>( false );
+const contentState = ref<ContentStates>( ContentStates.Main );
+const formModel = useFormModel();
+const stepControllers = [
+	createSubmittableMainDonationForm( formModel, FormStepNames.UpgradeToYearlyFormStep ),
+	createSubmittableUpgradeToYearly( formModel, FormStepNames.MainDonationFormStep, FormStepNames.MainDonationFormStep )
+];
+
+useAnonymousAddressTypeSetter();
+
+watch( contentState, async () => {
+	emit( 'bannerContentChanged' );
+} );
+
+function onCloseMain(): void {
+	if ( props.remainingImpressions > 0 ) {
+		contentState.value = ContentStates.SoftClosing;
+	} else {
+		onClose( 'MainBanner', CloseChoices.Close );
+	}
+}
+
+function onClose( feature: TrackingFeatureName, userChoice: CloseChoices ): void {
+	emit( 'bannerClosed', new CloseEvent( feature, userChoice ) );
+}
+
+</script>

--- a/banners/english/C24_WMDE_Desktop_EN_02/components/BannerVar.vue
+++ b/banners/english/C24_WMDE_Desktop_EN_02/components/BannerVar.vue
@@ -61,7 +61,11 @@
             :content="useOfFundsContent"
             :is-funds-modal-visible="isFundsModalVisible"
             @hideFundsModal="isFundsModalVisible = false"
-        />
+		>
+			<template #infographic>
+				<WMDEFundsForwardingEN/>
+			</template>
+		</FundsModal>
     </div>
 </template>
 
@@ -91,6 +95,7 @@ import { TrackingFeatureName } from '@src/tracking/TrackingEvent';
 import VisaLogo from '@src/components/PaymentLogos/VisaLogo.vue';
 import MastercardLogo from '@src/components/PaymentLogos/MastercardLogo.vue';
 import PayPalLogo from '@src/components/PaymentLogos/PayPalLogo.vue';
+import WMDEFundsForwardingEN from '@src/components/UseOfFunds/Infographics/WMDEFundsForwardingEN.vue';
 
 enum ContentStates {
 	Main = 'wmde-banner-wrapper--main',

--- a/banners/english/C24_WMDE_Desktop_EN_02/components/BannerVar.vue
+++ b/banners/english/C24_WMDE_Desktop_EN_02/components/BannerVar.vue
@@ -20,10 +20,6 @@
                 </KeenSlider>
             </template>
 
-			<template #progress>
-				<ProgressBar amount-to-show-on-right="TARGET"/>
-			</template>
-
 			<template #donation-form="{ formInteraction }: any">
 				<MultiStepDonation :step-controllers="stepControllers" @form-interaction="formInteraction">
 
@@ -61,14 +57,6 @@
             </template>
         </MainBanner>
 
-		<SoftClose
-			v-if="contentState === ContentStates.SoftClosing"
-			:show-close-icon="true"
-			@close="() => onClose( 'SoftClose', CloseChoices.Close )"
-			@maybe-later="() => onClose( 'SoftClose', CloseChoices.MaybeLater )"
-			@time-out-close="() => onClose( 'SoftClose', CloseChoices.TimeOut )"
-		/>
-
         <FundsModal
             :content="useOfFundsContent"
             :is-funds-modal-visible="isFundsModalVisible"
@@ -79,17 +67,15 @@
 
 <script setup lang="ts">
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
-import SoftClose from '@src/components/SoftClose/SoftClose.vue';
 import { ref, watch } from 'vue';
 import MainBanner from './MainBanner.vue';
 import FundsModal from '@src/components/UseOfFunds/FundsModal.vue';
 import { UseOfFundsContent as useOfFundsContentInterface } from '@src/domain/UseOfFunds/UseOfFundsContent';
 import UpgradeToYearlyButtonForm from '@src/components/DonationForm/Forms/UpgradeToYearlyButtonForm.vue';
-import BannerSlides from '../content/BannerSlides.vue';
+import BannerSlides from '../content/BannerSlides_var.vue';
 import MainDonationForm from '@src/components/DonationForm/Forms/MainDonationForm.vue';
-import ProgressBar from '@src/components/ProgressBar/ProgressBarAlternative.vue';
 import MultiStepDonation from '@src/components/DonationForm/MultiStepDonation.vue';
-import BannerText from '../content/BannerText.vue';
+import BannerText from '../content/BannerText_var.vue';
 import KeenSlider from '@src/components/Slider/KeenSlider.vue';
 import BannerFooter from '@src/components/Footer/BannerFooter.vue';
 import { useFormModel } from '@src/components/composables/useFormModel';
@@ -105,7 +91,6 @@ import { TrackingFeatureName } from '@src/tracking/TrackingEvent';
 import VisaLogo from '@src/components/PaymentLogos/VisaLogo.vue';
 import MastercardLogo from '@src/components/PaymentLogos/MastercardLogo.vue';
 import PayPalLogo from '@src/components/PaymentLogos/PayPalLogo.vue';
-import { useAnonymousAddressTypeSetter } from '@src/components/composables/useAnonymousAddressTypeSetter';
 
 enum ContentStates {
 	Main = 'wmde-banner-wrapper--main',
@@ -124,7 +109,7 @@ interface Props {
 	remainingImpressions: number;
 }
 
-const props = defineProps<Props>();
+defineProps<Props>();
 const emit = defineEmits( [ 'bannerClosed', 'maybeLater', 'bannerContentChanged' ] );
 
 const isFundsModalVisible = ref<boolean>( false );
@@ -135,18 +120,12 @@ const stepControllers = [
 	createSubmittableUpgradeToYearly( formModel, FormStepNames.MainDonationFormStep, FormStepNames.MainDonationFormStep )
 ];
 
-useAnonymousAddressTypeSetter();
-
 watch( contentState, async () => {
 	emit( 'bannerContentChanged' );
 } );
 
 function onCloseMain(): void {
-	if ( props.remainingImpressions > 0 ) {
-		contentState.value = ContentStates.SoftClosing;
-	} else {
-		onClose( 'MainBanner', CloseChoices.Close );
-	}
+	onClose( 'MainBanner', CloseChoices.Close );
 }
 
 function onClose( feature: TrackingFeatureName, userChoice: CloseChoices ): void {

--- a/banners/english/C24_WMDE_Desktop_EN_02/components/FallbackBanner.vue
+++ b/banners/english/C24_WMDE_Desktop_EN_02/components/FallbackBanner.vue
@@ -1,0 +1,101 @@
+<template>
+	<div class="wmde-banner-fallback">
+		<ButtonClose @close="onClose"/>
+
+		<div class="wmde-banner-fallback-small" v-if="!onLargeScreen">
+			<KeenSlider
+				:with-pagination="false"
+				:play="slideshowShouldPlay"
+				:interval="10000"
+				:delay="2000"
+				@slideChanged="onSlideChange"
+			>
+				<template #slides="{ currentSlide }: any">
+					<FallbackSlides :current-slide="currentSlide"/>
+				</template>
+
+				<template #left-icon>
+					<ChevronLeftIcon :fill="'#990a00'"/>
+				</template>
+
+				<template #right-icon>
+					<ChevronRightIcon :fill="'#990a00'"/>
+				</template>
+			</KeenSlider>
+
+			<FallbackButton @buttonClicked="onSubmit"/>
+
+			<SmallFooter :slide-index="slideIndex" :slide-count="slideCount" @useOfFundsButtonClicked="isFundsModalVisible = true"/>
+		</div>
+
+		<div class="wmde-banner-fallback-large" v-if="onLargeScreen">
+			<div class="wmde-banner-fallback-message">
+				<FallbackText/>
+			</div>
+
+			<LargeFooter @useOfFundsButtonClicked="isFundsModalVisible = true" @submitButtonClicked="onSubmit"/>
+		</div>
+
+		<FundsModal
+			:content="useOfFundsContent"
+			:is-funds-modal-visible="isFundsModalVisible"
+			@hideFundsModal="isFundsModalVisible = false"
+		/>
+
+	</div>
+</template>
+
+<script setup lang="ts">
+
+import ButtonClose from '@src/components/ButtonClose/ButtonClose.vue';
+import { CloseChoices } from '@src/domain/CloseChoices';
+import { CloseEvent } from '@src/tracking/events/CloseEvent';
+import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+import { UseOfFundsContent as useOfFundsContentInterface } from '@src/domain/UseOfFunds/UseOfFundsContent';
+import { computed, inject, ref } from 'vue';
+import { useDisplaySwitch } from '@src/components/composables/useDisplaySwitch';
+import KeenSlider from '@src/components/Slider/KeenSlider.vue';
+import FallbackSlides from '../content/FallbackSlides.vue';
+import ChevronLeftIcon from '@src/components/Icons/ChevronLeftIcon.vue';
+import ChevronRightIcon from '@src/components/Icons/ChevronRightIcon.vue';
+import FundsModal from '@src/components/UseOfFunds/FundsModal.vue';
+import FallbackText from '../content/FallbackText.vue';
+import FallbackButton from '@src/components/FallbackBanner/FallbackButton.vue';
+import SmallFooter from '@src/components/FallbackBanner/SmallFooter.vue';
+import LargeFooter from '@src/components/FallbackBanner/LargeFooter.vue';
+import { Tracker } from '@src/tracking/Tracker';
+import { FallbackBannerSubmitEvent } from '@src/tracking/events/FallbackBannerSubmitEvent';
+
+interface Props {
+	bannerState: BannerStates;
+	useOfFundsContent: useOfFundsContentInterface;
+	donationLink: string;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits( [ 'bannerClosed' ] );
+
+const tracker = inject<Tracker>( 'tracker' );
+const slideIndex = ref<number>( 0 );
+const slideCount = ref<number>( 0 );
+const slideShowStopped = ref<boolean>( false );
+const slideshowShouldPlay = computed( () => props.bannerState === BannerStates.Visible && !slideShowStopped.value );
+const isFundsModalVisible = ref<boolean>( false );
+
+const onLargeScreen = useDisplaySwitch( 799 );
+
+function onClose(): void {
+	emit( 'bannerClosed', new CloseEvent( 'FallbackBanner', CloseChoices.Close ) );
+}
+
+function onSlideChange( newIndex: number, newSlideCount: number ): void {
+	slideIndex.value = newIndex;
+	slideCount.value = newSlideCount;
+}
+
+function onSubmit(): void {
+	tracker.trackEvent( new FallbackBannerSubmitEvent() );
+	window.location.href = props.donationLink;
+}
+
+</script>

--- a/banners/english/C24_WMDE_Desktop_EN_02/components/FallbackBanner.vue
+++ b/banners/english/C24_WMDE_Desktop_EN_02/components/FallbackBanner.vue
@@ -40,7 +40,11 @@
 			:content="useOfFundsContent"
 			:is-funds-modal-visible="isFundsModalVisible"
 			@hideFundsModal="isFundsModalVisible = false"
-		/>
+		>
+			<template #infographic>
+				<WMDEFundsForwardingEN/>
+			</template>
+		</FundsModal>
 
 	</div>
 </template>
@@ -65,6 +69,7 @@ import SmallFooter from '@src/components/FallbackBanner/SmallFooter.vue';
 import LargeFooter from '@src/components/FallbackBanner/LargeFooter.vue';
 import { Tracker } from '@src/tracking/Tracker';
 import { FallbackBannerSubmitEvent } from '@src/tracking/events/FallbackBannerSubmitEvent';
+import WMDEFundsForwardingEN from '@src/components/UseOfFunds/Infographics/WMDEFundsForwardingEN.vue';
 
 interface Props {
 	bannerState: BannerStates;

--- a/banners/english/C24_WMDE_Desktop_EN_02/components/MainBanner.vue
+++ b/banners/english/C24_WMDE_Desktop_EN_02/components/MainBanner.vue
@@ -1,0 +1,50 @@
+<template>
+	<div class="wmde-banner-main">
+		<slot name="close-button">
+			<ButtonClose @close="$emit( 'close' )"/>
+		</slot>
+		<div class="wmde-banner-content">
+			<div class="wmde-banner-column-left">
+				<slot name="banner-text" v-if="onLargeScreen"/>
+				<slot name="banner-slides" v-else :play="slideshowShouldPlay"/>
+				<slot name="progress"/>
+			</div>
+			<div class="wmde-banner-column-right">
+				<slot name="donation-form" :form-interaction="onFormInteraction"/>
+			</div>
+		</div>
+		<slot name="footer"/>
+	</div>
+</template>
+
+<script setup lang="ts">
+
+import ButtonClose from '@src/components/ButtonClose/ButtonClose.vue';
+import { useDisplaySwitch } from '@src/components/composables/useDisplaySwitch';
+import { computed, nextTick, ref } from 'vue';
+import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+
+interface Props {
+	bannerState: BannerStates;
+	minWidthForLargeScreen?: number;
+}
+
+const props = withDefaults( defineProps<Props>(), {
+	minWidthForLargeScreen: 1300
+} );
+const emit = defineEmits( [ 'close', 'formInteraction' ] );
+
+const slideShowStopped = ref<boolean>( false );
+const slideshowShouldPlay = computed( () => props.bannerState === BannerStates.Visible && !slideShowStopped.value );
+
+const onLargeScreen = useDisplaySwitch( props.minWidthForLargeScreen );
+
+const onFormInteraction = (): void => {
+	slideShowStopped.value = true;
+
+	nextTick( () => {
+		emit( 'formInteraction' );
+	} );
+};
+
+</script>

--- a/banners/english/C24_WMDE_Desktop_EN_02/content/BannerSlides.vue
+++ b/banners/english/C24_WMDE_Desktop_EN_02/content/BannerSlides.vue
@@ -1,0 +1,58 @@
+<template>
+	<KeenSliderSlide :is-current="currentSlide === 0">
+		<p class="headline">
+			<strong>
+				<InfoIcon fill="#990a00"/>
+				{{ liveDateAndTime.currentDate }}, {{ liveDateAndTime.currentTime }}: &#8220;Wikipedia is not for
+				sale.&#8221; - A personal appeal from Wikipedia founder Jimmy Wales.
+			</strong>
+		</p>
+		<p>
+			Please don't ignore this 1-minute read. This {{ currentDayName }}, {{ currentDate }}, I ask you to reflect
+			on the number of times you visited Wikipedia in the past year, the value you got from it, and whether you're
+			able to give €5 back.
+		</p>
+	</KeenSliderSlide>
+	<KeenSliderSlide :is-current="currentSlide === 1">
+		<p>
+			If you can, please join the 1% of readers who give.
+			<AnimatedText content="If everyone reading this right now gave just €5, we'd hit our goal in a couple of hours."/>
+			It's hard to know what to trust online these days. Disinformation and scammers are everywhere.
+		</p>
+	</KeenSliderSlide>
+	<KeenSliderSlide :is-current="currentSlide === 2">
+		<p>
+			Wikipedia is different. It's not perfect, but it's not here to make a profit or to push a particular perspective.
+			It's written by everyone, together. Wikipedia is something we all share, like a library or a public park.
+		</p>
+	</KeenSliderSlide>
+	<KeenSliderSlide :is-current="currentSlide === 3">
+		<p>
+			We are passionate about our model because we want everyone to have equal access to quality information
+			- something that is becoming harder and harder to find online. If Wikipedia has given you €5 worth of
+			knowledge this year, please give back. There are no small contributions: every edit counts, every donation
+			counts. <em>Thank you.</em>
+		</p>
+	</KeenSliderSlide>
+</template>
+
+<script setup lang="ts">
+import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import { inject, onMounted, onUnmounted } from 'vue';
+import InfoIcon from '@src/components/Icons/InfoIcon.vue';
+import KeenSliderSlide from '@src/components/Slider/KeenSliderSlide.vue';
+import AnimatedText from '@src/components/AnimatedText/AnimatedText.vue';
+import { useLiveDateAndTime } from '@src/components/composables/useLiveDateAndTime';
+
+interface Props {
+	currentSlide: number
+}
+
+defineProps<Props>();
+
+const { currentDayName, currentDate, getCurrentDateAndTime }: DynamicContent = inject( 'dynamicCampaignText' );
+const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );
+onMounted( startTimer );
+onUnmounted( stopTimer );
+
+</script>

--- a/banners/english/C24_WMDE_Desktop_EN_02/content/BannerSlides_var.vue
+++ b/banners/english/C24_WMDE_Desktop_EN_02/content/BannerSlides_var.vue
@@ -1,0 +1,58 @@
+<template>
+	<KeenSliderSlide :is-current="currentSlide === 0">
+		<p class="headline">
+			<strong>
+				<InfoIcon fill="#990a00"/>
+				{{ liveDateAndTime.currentDate }}, {{ liveDateAndTime.currentTime }}: &#8220;Wikipedia is not for
+				sale.&#8221; - A personal appeal from Wikipedia founder Jimmy Wales.
+			</strong>
+		</p>
+		<p>
+			Please don't ignore this 1-minute read. This {{ currentDayName }}, {{ currentDate }}, I ask you to reflect
+			on the number of times you visited Wikipedia in the past year, the value you got from it, and whether you're
+			able to give €5 back.
+		</p>
+	</KeenSliderSlide>
+	<KeenSliderSlide :is-current="currentSlide === 1">
+		<p>
+			If you can, please join the 1% of readers who give.
+			<AnimatedText content="If everyone reading this right now gave just €5, we'd hit our goal in a couple of hours."/>
+			It's hard to know what to trust online these days. Disinformation and scammers are everywhere.
+		</p>
+	</KeenSliderSlide>
+	<KeenSliderSlide :is-current="currentSlide === 2">
+		<p>
+			Wikipedia is different. It's not perfect, but it's not here to make a profit or to push a particular perspective.
+			It's written by everyone, together. Wikipedia is something we all share, like a library or a public park.
+		</p>
+	</KeenSliderSlide>
+	<KeenSliderSlide :is-current="currentSlide === 3">
+		<p>
+			We are passionate about our model because we want everyone to have equal access to quality information
+			- something that is becoming harder and harder to find online. If Wikipedia has given you €5 worth of
+			knowledge this year, please give back. There are no small contributions: every edit counts, every donation
+			counts. <em>Thank you.</em>
+		</p>
+	</KeenSliderSlide>
+</template>
+
+<script setup lang="ts">
+import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import { inject, onMounted, onUnmounted } from 'vue';
+import InfoIcon from '@src/components/Icons/InfoIcon.vue';
+import KeenSliderSlide from '@src/components/Slider/KeenSliderSlide.vue';
+import AnimatedText from '@src/components/AnimatedText/AnimatedText.vue';
+import { useLiveDateAndTime } from '@src/components/composables/useLiveDateAndTime';
+
+interface Props {
+	currentSlide: number
+}
+
+defineProps<Props>();
+
+const { currentDayName, currentDate, getCurrentDateAndTime }: DynamicContent = inject( 'dynamicCampaignText' );
+const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );
+onMounted( startTimer );
+onUnmounted( stopTimer );
+
+</script>

--- a/banners/english/C24_WMDE_Desktop_EN_02/content/BannerSlides_var.vue
+++ b/banners/english/C24_WMDE_Desktop_EN_02/content/BannerSlides_var.vue
@@ -3,35 +3,28 @@
 		<p class="headline">
 			<strong>
 				<InfoIcon fill="#990a00"/>
-				{{ liveDateAndTime.currentDate }}, {{ liveDateAndTime.currentTime }}: &#8220;Wikipedia is not for
-				sale.&#8221; - A personal appeal from Wikipedia founder Jimmy Wales.
+				{{ liveDateAndTime.currentDate }}, {{ liveDateAndTime.currentTime }}: &#8220;Wikipedia still can't be
+				sold.&#8221; - An important update for readers in Germany.
 			</strong>
 		</p>
 		<p>
-			Please don't ignore this 1-minute read. This {{ currentDayName }}, {{ currentDate }}, I ask you to reflect
-			on the number of times you visited Wikipedia in the past year, the value you got from it, and whether you're
-			able to give €5 back.
+			Today is the day. We're sorry to interrupt, but it's {{ currentDayName }}, {{ currentDate }}, and this
+			message will be up for only a few hours.
 		</p>
 	</KeenSliderSlide>
 	<KeenSliderSlide :is-current="currentSlide === 1">
 		<p>
-			If you can, please join the 1% of readers who give.
-			<AnimatedText content="If everyone reading this right now gave just €5, we'd hit our goal in a couple of hours."/>
-			It's hard to know what to trust online these days. Disinformation and scammers are everywhere.
+			We ask you to reflect on the number of times you visited Wikipedia in the past year and if you're able to give €5 back.
+			<AnimatedText content="If everyone reading this gave just €5, we'd hit our goal in a few hours."/>
+			In the age of AI, access to verifiable facts is crucial. Wikipedia is at the heart of online information,
+			powering everything from your personal searches to emerging AI technologies.
 		</p>
 	</KeenSliderSlide>
 	<KeenSliderSlide :is-current="currentSlide === 2">
 		<p>
-			Wikipedia is different. It's not perfect, but it's not here to make a profit or to push a particular perspective.
-			It's written by everyone, together. Wikipedia is something we all share, like a library or a public park.
-		</p>
-	</KeenSliderSlide>
-	<KeenSliderSlide :is-current="currentSlide === 3">
-		<p>
-			We are passionate about our model because we want everyone to have equal access to quality information
-			- something that is becoming harder and harder to find online. If Wikipedia has given you €5 worth of
-			knowledge this year, please give back. There are no small contributions: every edit counts, every donation
-			counts. <em>Thank you.</em>
+			Your gift strengthens the knowledge of today and tomorrow. Just 1&nbsp;% of our readers donate, so if
+			you have given in the past and Wikipedia still provides you with €5 worth of knowledge, kindly donate
+			today. If you are undecided, remember that any contribution helps, whether it's €5 or €25. Thank&nbsp;you.
 		</p>
 	</KeenSliderSlide>
 </template>

--- a/banners/english/C24_WMDE_Desktop_EN_02/content/BannerText.vue
+++ b/banners/english/C24_WMDE_Desktop_EN_02/content/BannerText.vue
@@ -1,0 +1,46 @@
+<template>
+	<div class="wmde-banner-message">
+		<div>
+			<p>
+				<strong>
+					<InfoIcon fill="#990a00"/>
+					{{ liveDateAndTime.currentDate }}, {{ liveDateAndTime.currentTime }}: &#8220;Wikipedia is not for
+					sale.&#8221; - A personal appeal from Wikipedia founder Jimmy Wales.
+				</strong>
+			</p>
+			<p>
+				Please don't ignore this 1-minute read. This {{ currentDayName }}, {{ currentDate }}, I ask you to
+				reflect on the number of times you visited Wikipedia in the past year, the value you got from it,
+				and whether you're able to give €5 back. If you can, please join the 1% of readers who
+				give. <AnimatedText content="If everyone reading this right now gave just €5, we'd hit our goal in a couple of hours."/>
+			</p>
+
+			<p>
+				It's hard to know what to trust online these days. Disinformation and scammers are everywhere.
+				Wikipedia is different. It's not perfect, but it's not here to make a profit or to push a particular
+				perspective. It's written by everyone, together. Wikipedia is something we all share, like a library
+				or a public park. We are passionate about our model because we want everyone to have equal access to
+				quality information - something that is becoming harder and harder to find online.
+			</p>
+
+			<p>
+				If Wikipedia has given you €5 worth of knowledge this year, please give back. There are no small
+				contributions: every edit counts, every donation counts. Thank you.
+			</p>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { inject, onMounted, onUnmounted } from 'vue';
+import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import InfoIcon from '@src/components/Icons/InfoIcon.vue';
+import AnimatedText from '@src/components/AnimatedText/AnimatedText.vue';
+import { useLiveDateAndTime } from '@src/components/composables/useLiveDateAndTime';
+
+const { currentDayName, currentDate, getCurrentDateAndTime }: DynamicContent = inject( 'dynamicCampaignText' );
+const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );
+onMounted( startTimer );
+onUnmounted( stopTimer );
+
+</script>

--- a/banners/english/C24_WMDE_Desktop_EN_02/content/BannerText_var.vue
+++ b/banners/english/C24_WMDE_Desktop_EN_02/content/BannerText_var.vue
@@ -1,0 +1,46 @@
+<template>
+	<div class="wmde-banner-message">
+		<div>
+			<p>
+				<strong>
+					<InfoIcon fill="#990a00"/>
+					{{ liveDateAndTime.currentDate }}, {{ liveDateAndTime.currentTime }}: &#8220;Wikipedia is not for
+					sale.&#8221; - A personal appeal from Wikipedia founder Jimmy Wales.
+				</strong>
+			</p>
+			<p>
+				Please don't ignore this 1-minute read. This {{ currentDayName }}, {{ currentDate }}, I ask you to
+				reflect on the number of times you visited Wikipedia in the past year, the value you got from it,
+				and whether you're able to give €5 back. If you can, please join the 1% of readers who
+				give. <AnimatedText content="If everyone reading this right now gave just €5, we'd hit our goal in a couple of hours."/>
+			</p>
+
+			<p>
+				It's hard to know what to trust online these days. Disinformation and scammers are everywhere.
+				Wikipedia is different. It's not perfect, but it's not here to make a profit or to push a particular
+				perspective. It's written by everyone, together. Wikipedia is something we all share, like a library
+				or a public park. We are passionate about our model because we want everyone to have equal access to
+				quality information - something that is becoming harder and harder to find online.
+			</p>
+
+			<p>
+				If Wikipedia has given you €5 worth of knowledge this year, please give back. There are no small
+				contributions: every edit counts, every donation counts. Thank you.
+			</p>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { inject, onMounted, onUnmounted } from 'vue';
+import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import InfoIcon from '@src/components/Icons/InfoIcon.vue';
+import AnimatedText from '@src/components/AnimatedText/AnimatedText.vue';
+import { useLiveDateAndTime } from '@src/components/composables/useLiveDateAndTime';
+
+const { currentDayName, currentDate, getCurrentDateAndTime }: DynamicContent = inject( 'dynamicCampaignText' );
+const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );
+onMounted( startTimer );
+onUnmounted( stopTimer );
+
+</script>

--- a/banners/english/C24_WMDE_Desktop_EN_02/content/BannerText_var.vue
+++ b/banners/english/C24_WMDE_Desktop_EN_02/content/BannerText_var.vue
@@ -4,28 +4,26 @@
 			<p>
 				<strong>
 					<InfoIcon fill="#990a00"/>
-					{{ liveDateAndTime.currentDate }}, {{ liveDateAndTime.currentTime }}: &#8220;Wikipedia is not for
-					sale.&#8221; - A personal appeal from Wikipedia founder Jimmy Wales.
+					{{ liveDateAndTime.currentDate }}, {{ liveDateAndTime.currentTime }}: &#8220;Wikipedia still
+					can't be sold.&#8221; - An important update for readers in Germany.
 				</strong>
 			</p>
 			<p>
-				Please don't ignore this 1-minute read. This {{ currentDayName }}, {{ currentDate }}, I ask you to
-				reflect on the number of times you visited Wikipedia in the past year, the value you got from it,
-				and whether you're able to give €5 back. If you can, please join the 1% of readers who
-				give. <AnimatedText content="If everyone reading this right now gave just €5, we'd hit our goal in a couple of hours."/>
+				Today is the day. We're sorry to interrupt, but it's {{ currentDayName }}, {{ currentDate }}, and this
+				message will be up for only a few hours.
+				We ask you to reflect on the number of times you visited
+				Wikipedia in the past year and if you're able to give €5 back.
+				<AnimatedText content="If everyone reading this gave just €5, we'd hit our goal in a few hours."/>
 			</p>
-
 			<p>
-				It's hard to know what to trust online these days. Disinformation and scammers are everywhere.
-				Wikipedia is different. It's not perfect, but it's not here to make a profit or to push a particular
-				perspective. It's written by everyone, together. Wikipedia is something we all share, like a library
-				or a public park. We are passionate about our model because we want everyone to have equal access to
-				quality information - something that is becoming harder and harder to find online.
+				In the age of AI, access to verifiable facts is crucial. Wikipedia is at the heart of online
+				information, powering everything from your personal searches to emerging AI technologies. Your gift
+				strengthens the knowledge of today and tomorrow.
 			</p>
-
 			<p>
-				If Wikipedia has given you €5 worth of knowledge this year, please give back. There are no small
-				contributions: every edit counts, every donation counts. Thank you.
+				Just 1&nbsp;% of our readers donate, so if you have
+				given in the past and Wikipedia still provides you with €5 worth of knowledge, kindly donate today. If
+				you are undecided, remember that any contribution helps, whether it's €5 or €25. Thank you.
 			</p>
 		</div>
 	</div>

--- a/banners/english/C24_WMDE_Desktop_EN_02/content/FallbackSlides.vue
+++ b/banners/english/C24_WMDE_Desktop_EN_02/content/FallbackSlides.vue
@@ -1,0 +1,27 @@
+<template>
+	<KeenSliderSlide :is-current="currentSlide === 0">
+		<p>
+			If Wikipedia has given you €5 worth of knowledge this year, please give back.
+		</p>
+	</KeenSliderSlide>
+	<KeenSliderSlide :is-current="currentSlide === 1">
+		<p>
+			If you can, please join the 1% of readers who give. <em>Thank you.</em>
+		</p>
+	</KeenSliderSlide>
+	<KeenSliderSlide :is-current="currentSlide === 2">
+		<FallbackBank/>
+	</KeenSliderSlide>
+</template>
+
+<script setup lang="ts">
+import KeenSliderSlide from '@src/components/Slider/KeenSliderSlide.vue';
+import FallbackBank from '@src/components/FallbackBanner/FallbackBank.vue';
+
+interface Props {
+	currentSlide: number
+}
+
+defineProps<Props>();
+
+</script>

--- a/banners/english/C24_WMDE_Desktop_EN_02/content/FallbackText.vue
+++ b/banners/english/C24_WMDE_Desktop_EN_02/content/FallbackText.vue
@@ -1,0 +1,32 @@
+<template>
+	<div class="wmde-banner-message">
+		<div>
+			<p>
+				<InfoIcon fill="#990a00"/> <strong>Please don't ignore this 1-minute read</strong>
+			</p>
+			<p>
+				This {{ currentDayName }}, {{ liveDateAndTime.currentDate }} at {{ liveDateAndTime.currentTime }}, please
+				reflect on the number of times you visited
+				Wikipedia in the past year, the value you got from it, and whether you're able to give €5 back. If you
+				can, please join the 1% of readers who give. <em>Thank you.</em>
+			</p>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { inject, onMounted, onUnmounted } from 'vue';
+import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import InfoIcon from '@src/components/Icons/InfoIcon.vue';
+import { useLiveDateAndTime } from '@src/components/composables/useLiveDateAndTime';
+
+const {
+	currentDayName,
+	getCurrentDateAndTime
+}: DynamicContent = inject( 'dynamicCampaignText' );
+
+const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );
+onMounted( startTimer );
+onUnmounted( stopTimer );
+
+</script>

--- a/banners/english/C24_WMDE_Desktop_EN_02/event_map.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_02/event_map.ts
@@ -1,0 +1,38 @@
+import { TrackingEventConverterFactory } from '@src/tracking/LegacyTrackerWPORG';
+import { WMDELegacyBannerEvent } from '@src/tracking/WPORG/WMDELegacyBannerEvent';
+import { FormStepShownEvent } from '@src/tracking/events/FormStepShownEvent';
+import { mapFormStepShownEvent } from '@src/tracking/LegacyEventTracking/mapFormStepShownEvent';
+import { CustomAmountChangedEvent } from '@src/tracking/events/CustomAmountChangedEvent';
+import { CloseEvent } from '@src/tracking/events/CloseEvent';
+import { mapCloseEvent } from '@src/tracking/LegacyEventTracking/mapCloseEvent';
+import { NotShownEvent } from '@src/tracking/events/NotShownEvent';
+import { mapNotShownEvent } from '@src/tracking/LegacyEventTracking/mapNotShownEvent';
+import { BannerSubmitEvent } from '@src/tracking/events/BannerSubmitEvent';
+import { WMDESizeIssueEvent } from '@src/tracking/WPORG/WMDEBannerSizeIssue';
+import { createViewportInfo } from '@src/tracking/LegacyEventTracking/createViewportInfo';
+import { FallbackBannerSubmitEvent } from '@src/tracking/events/FallbackBannerSubmitEvent';
+import { ShownEvent } from '@src/tracking/events/ShownEvent';
+import { mapShownEvent } from '@src/tracking/LegacyEventTracking/mapShownEvent';
+
+export default new Map<string, TrackingEventConverterFactory>( [
+	[ ShownEvent.EVENT_NAME, mapShownEvent ],
+	[ CloseEvent.EVENT_NAME, mapCloseEvent ],
+
+	[ FormStepShownEvent.EVENT_NAME, mapFormStepShownEvent ],
+	[ CustomAmountChangedEvent.EVENT_NAME,
+		( e: CustomAmountChangedEvent ): WMDELegacyBannerEvent =>
+			new WMDELegacyBannerEvent( e.userChoice + '-amount', 1 )
+	],
+	[ NotShownEvent.EVENT_NAME, mapNotShownEvent ],
+	[ BannerSubmitEvent.EVENT_NAME, ( e: BannerSubmitEvent ): WMDESizeIssueEvent => {
+		switch ( e.feature ) {
+			case 'UpgradeToYearlyForm':
+				return new WMDESizeIssueEvent( `submit-${e.userChoice}`, createViewportInfo(), 1 );
+			case 'CustomAmountForm':
+				return new WMDESizeIssueEvent( `submit-different-amount`, createViewportInfo(), 1 );
+			default:
+				return new WMDESizeIssueEvent( `submit`, createViewportInfo(), 1 );
+		}
+	} ],
+	[ FallbackBannerSubmitEvent.EVENT_NAME, ( e: FallbackBannerSubmitEvent ): WMDESizeIssueEvent => new WMDESizeIssueEvent( e.eventName, createViewportInfo(), 1 ) ]
+] );

--- a/banners/english/C24_WMDE_Desktop_EN_02/form_items.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_02/form_items.ts
@@ -1,0 +1,21 @@
+import FormItemsBuilder from '@src/utils/FormItemsBuilder/FormItemsBuilder';
+import { Translator } from '@src/Translator';
+import { DonationFormItems } from '@src/utils/FormItemsBuilder/DonationFormItems';
+import { Intervals } from '@src/utils/FormItemsBuilder/fields/Intervals';
+import { PaymentMethods } from '@src/utils/FormItemsBuilder/fields/PaymentMethods';
+import { NumberFormatter } from '@src/utils/DynamicContent/formatters/NumberFormatter';
+
+export function createFormItems( translations: Translator, amountFormatter: NumberFormatter ): DonationFormItems {
+	return new FormItemsBuilder( translations, amountFormatter )
+		.setIntervals(
+			Intervals.ONCE,
+			Intervals.MONTHLY,
+			Intervals.QUARTERLY,
+			Intervals.YEARLY
+		)
+		.setAmounts( 5, 10, 20, 25, 50, 100 )
+		.setPaymentMethods(
+			PaymentMethods.PAYPAL,
+			PaymentMethods.CREDIT_CARD
+		).getItems();
+}

--- a/banners/english/C24_WMDE_Desktop_EN_02/messages.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_02/messages.ts
@@ -1,0 +1,24 @@
+import CustomAmountFormEn from '@src/components/DonationForm/Forms/messages/CustomAmountForm.en';
+import DynamicCampaignTextEn from '@src/utils/DynamicContent/messages/DynamicCampaignText.en';
+import { TranslationMessages } from '@src/Translator';
+import UpgradeToYearlyEn from '@src/components/DonationForm/Forms/messages/UpgradeToYearly.en';
+import SoftCloseEn from '@src/components/SoftClose/messages/SoftClose.en';
+import AddressFormEn from '@src/components/DonationForm/Forms/messages/AddressForm.en';
+import FooterEn from '@src/components/Footer/messages/Footer.en';
+import MainDonationFormEn from '@src/components/DonationForm/Forms/messages/MainDonationForm.en';
+import AlreadyDonatedModalEn from '@src/components/AlreadyDonatedModal/translations/AlreadyDonatedModal.en';
+import FallbackBanner from '@src/components/FallbackBanner/messages/FallbackBanner.en';
+
+const messages: TranslationMessages = {
+	...CustomAmountFormEn,
+	...DynamicCampaignTextEn,
+	...UpgradeToYearlyEn,
+	...SoftCloseEn,
+	...AddressFormEn,
+	...FooterEn,
+	...MainDonationFormEn,
+	...AlreadyDonatedModalEn,
+	...FallbackBanner
+};
+
+export default messages;

--- a/banners/english/C24_WMDE_Desktop_EN_02/styles/Banner.scss
+++ b/banners/english/C24_WMDE_Desktop_EN_02/styles/Banner.scss
@@ -1,0 +1,17 @@
+@use 'src/themes/Treedip/variables/fonts';
+
+.wmde-banner {
+	&-wrapper {
+		font-size: 14px;
+		font-family: fonts.$ui;
+		box-shadow: var( --main-box-shadow );
+		background-color: var( --main-background );
+		color: var( --main-color );
+	}
+
+	&--closed {
+		.wmde-banner-wrapper {
+			display: none;
+		}
+	}
+}

--- a/banners/english/C24_WMDE_Desktop_EN_02/styles/FallbackBanner.scss
+++ b/banners/english/C24_WMDE_Desktop_EN_02/styles/FallbackBanner.scss
@@ -1,0 +1,135 @@
+@use 'src/themes/Treedip/variables/globals';
+@use 'src/themes/Treedip/variables/fonts';
+@use 'sass:color';
+
+$breakpoint: 800px;
+
+.wmde-banner {
+	&-fallback {
+		width: 100%;
+		height: 150px;
+		display: flex;
+		flex-direction: column;
+		background: var( --fallback-background );
+		box-shadow: var( --main-box-shadow );
+
+		@media ( min-width: $breakpoint ) {
+			height: auto;
+			min-height: 250px;
+			padding: 4px;
+		}
+
+		&-small,
+		&-large {
+			display: flex;
+			flex-direction: column;
+			flex: 1 1 auto;
+		}
+
+		&-small {
+			align-items: center;
+			border: 4px solid var( --fallback-border );
+			border-radius: 4px;
+			padding: 8px;
+
+			.wmde-banner-progress-bar {
+				height: 25px;
+				line-height: 25px;
+			}
+
+			.wmde-banner-progress-bar-text,
+			.wmde-banner-progress-bar-fill-wrapper {
+				height: 25px;
+			}
+
+			.wmde-banner-progress-bar-fill {
+				line-height: 20px;
+			}
+
+			.wmde-banner-fallback-button {
+				margin: 0 0 8px;
+			}
+
+			.wmde-banner-selection-input-text,
+			.wmde-banner-selection-input-input {
+				font-family: fonts.$content;
+				font-size: 14px;
+				font-weight: normal;
+			}
+		}
+
+		&-large {
+			align-items: stretch;
+		}
+
+		&-usage-link {
+			color: var( --fallback-uof-link );
+		}
+
+		&-message {
+			flex: 1 1 auto;
+			display: flex;
+			flex-direction: column;
+			background: var( --fallback-message-background );
+			border: 4px solid var( --fallback-message-border );
+			border-radius: 4px;
+			padding: 8px 0;
+		}
+
+		&-bank-item {
+			display: block;
+
+			&-label {
+				font-weight: bold;
+			}
+		}
+
+		.wmde-banner-close {
+			height: 16px;
+			width: 16px;
+			top: 8px;
+			right: 8px;
+
+			@media ( min-width: $breakpoint ) {
+				height: 30px;
+				width: 30px;
+				top: 12px;
+				right: 12px;
+			}
+		}
+
+		.wmde-banner-slider-container {
+			padding: 0 0 8px;
+		}
+
+		.wmde-banner-slide-content {
+			font-size: 14px;
+			p {
+				margin-bottom: 8px;
+			}
+		}
+
+		.wmde-banner-slider-navigation-previous,
+		.wmde-banner-slider-navigation-next {
+			align-items: end;
+		}
+
+		.wmde-banner-slider-pagination-dot {
+			cursor: default;
+		}
+
+		.wmde-banner-message {
+			flex: 1 1 auto;
+
+			p {
+				margin-bottom: 0;
+			}
+		}
+	}
+
+	&--pending {
+		.wmde-banner-fallback {
+			box-shadow: none;
+		}
+	}
+}

--- a/banners/english/C24_WMDE_Desktop_EN_02/styles/MainBanner.scss
+++ b/banners/english/C24_WMDE_Desktop_EN_02/styles/MainBanner.scss
@@ -1,0 +1,44 @@
+$banner-height: 357px !default;
+$form-width: 300px !default;
+
+.wmde-banner {
+	&-main {
+		min-height: $banner-height;
+		display: flex;
+		flex-direction: column;
+		padding: 12px 24px 0;
+	}
+
+	&-content {
+		display: flex;
+		flex-direction: row;
+		flex-grow: 1;
+	}
+
+	&-message {
+		padding: 0 15px;
+	}
+
+	&-column-left {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		flex: 1 1 auto;
+		margin-bottom: 0;
+		overflow-y: hidden;
+		margin-right: 30px;
+		padding: 0 0 10px;
+		background: var( --message-background );
+		border: 5px solid var( --message-border );
+		border-radius: 9px;
+	}
+
+	&-column-right {
+		order: 2;
+		flex: 0 0 $form-width;
+		display: flex;
+		flex-direction: column;
+		width: $form-width;
+		padding: 10px 0;
+	}
+}

--- a/banners/english/C24_WMDE_Desktop_EN_02/styles/styles.scss
+++ b/banners/english/C24_WMDE_Desktop_EN_02/styles/styles.scss
@@ -4,6 +4,7 @@
 	$select-group-bubble: true,
 	$upgrade-to-yearly: true,
 	$fallback-banner: true,
+	$select-group-image-label: true,
 );
 @use 'src/themes/Treedip/variables/breakpoints';
 @use 'src/components/BannerConductor/banner-transition';

--- a/banners/english/C24_WMDE_Desktop_EN_02/styles/styles.scss
+++ b/banners/english/C24_WMDE_Desktop_EN_02/styles/styles.scss
@@ -1,0 +1,57 @@
+// This is the file where we import the theme-specific component styles
+@use 'src/themes/Treedip/swatches/skin_vector-2022' with (
+	$slider: true,
+	$select-group-bubble: true,
+	$upgrade-to-yearly: true,
+	$fallback-banner: true,
+);
+@use 'src/themes/Treedip/variables/breakpoints';
+@use 'src/components/BannerConductor/banner-transition';
+@use 'Banner';
+@use 'MainBanner' with (
+	$banner-height: 355px,
+	$form-width: 300px
+);
+@use 'src/themes/UseOfFunds/swatches/skin_vector-2022' as uof-vector-2022;
+@use 'src/themes/UseOfFunds/UseOfFunds';
+@use 'src/themes/Treedip/defaults';
+@use 'src/themes/Treedip/ButtonClose/ButtonClose' with (
+	$padding: 4px,
+	$top: 12px,
+	$right: 8px,
+	$margin: -4.5px
+);
+@use 'src/themes/Treedip/ProgressBar/ProgressBarAlternative' with (
+	$progress-bar-margin: 0 15px
+);
+@use 'src/themes/Treedip/DonationForm/DonationForm';
+@use 'src/themes/Treedip/DonationForm/MultiStepDonation';
+@use 'src/themes/Treedip/DonationForm/BubbleForm/SelectGroupBubble';
+@use 'src/themes/Treedip/DonationForm/BubbleForm/SelectGroupRadioBubbles' with (
+	$height: 34px
+);
+@use 'src/themes/Treedip/DonationForm/BubbleForm/SelectCustomAmountRadioBubble' with (
+	$height: 34px
+);
+@use 'src/themes/Treedip/DonationForm/BubbleForm/SelectGroupBubbleImageLabel';
+@use 'src/themes/Treedip/DonationForm/BubbleForm/SelectGroupBubbleImageLabel_dark';
+@use 'src/themes/Treedip/DonationForm/SubComponents/SmsBox';
+@use 'src/themes/Treedip/DonationForm/Forms/MainDonationForm' with (
+	$padding: 14px 0 0
+);
+@use 'src/themes/Treedip/DonationForm/Forms/UpgradeToYearlyButtonForm';
+@use 'src/themes/Treedip/DonationForm/Forms/CustomAmountForm';
+@use 'src/themes/Treedip/Footer/BannerFooter' with (
+	$right-column-width: 300px
+);
+@use 'src/themes/Treedip/Footer/SelectionInput';
+@use 'src/themes/Treedip/Message/Message' with (
+	$font-sizes: ( 1400px: 15px, 1600px: 16px, 1800px: 18px )
+);
+@use 'src/themes/Treedip/Slider/KeenSlider';
+@use 'src/themes/Treedip/SoftClose/SoftClose';
+@use 'src/themes/Treedip/AlreadyDonatedModal/AlreadyDonatedModal';
+@use 'FallbackBanner';
+@use 'src/themes/Fijitiv/FallbackBanner/FallbackButton';
+@use 'src/themes/Fijitiv/FallbackBanner/LargeFooter';
+@use 'src/themes/Fijitiv/FallbackBanner/SmallFooter';

--- a/campaign_info.toml
+++ b/campaign_info.toml
@@ -137,9 +137,9 @@ tracking = "wpde-mob00-240619-var"
 [english]
 name = "English Desktop"
 icon = "desktop"
-campaign = "C24_WMDE_Desktop_EN_01"
-description = "Based on C23_WMDE_Desktop_EN_05"
-campaign_tracking = "en01-ba-090324"
+campaign = "C24_WMDE_Desktop_EN_02"
+description = "Based on desktop EN 01"
+campaign_tracking = "en02-ba-241015"
 preview_link = "/wiki/Main_Page?devbanner={{banner}}&banner=B22_WMDE_local_prototype"
 preview_link_darkmode = "/wiki/Main_Page?devbanner={{banner}}&banner=B22_WMDE_local_prototype&vectornightmode=1"
 preview_url = 'https://en.wikipedia.org/wiki/Main_Page?banner={{banner}}&devMode'
@@ -147,14 +147,14 @@ wrapper_template = "wikipedia_org"
 use_of_funds_source = "MediaWiki:WMDE_Fundraising/UseOfFunds_2024_EN"
 
 [english.banners.ctrl]
-filename = "./banners/english/C24_WMDE_Desktop_EN_01/banner_ctrl.ts"
-pagename = "B24_WMDE_Desktop_EN_01_ctrl"
-tracking = "org-en01-090324-ctrl"
+filename = "./banners/english/C24_WMDE_Desktop_EN_02/banner_ctrl.ts"
+pagename = "B24_WMDE_Desktop_EN_02_ctrl"
+tracking = "org-en02-241015-ctrl"
 
 [english.banners.var]
-filename = "./banners/english/C24_WMDE_Desktop_EN_01/banner_var.ts"
-pagename = "B24_WMDE_Desktop_EN_01_var"
-tracking = "org-en01-090324-var"
+filename = "./banners/english/C24_WMDE_Desktop_EN_02/banner_var.ts"
+pagename = "B24_WMDE_Desktop_EN_02_var"
+tracking = "org-en02-241015-var"
 
 [english.test_matrix]
 platform = ["edge", "firefox_win10", "chrome_win10", "safari", "firefox_macos", "chrome_macos", "firefox_linux", "chrome_linux"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -6411,7 +6411,7 @@
     },
     "node_modules/fundraising-frontend-content": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/wmde/fundraising-frontend-content.git#1997467cf3a43583b72fae0cfb8ff7346936322a",
+      "resolved": "git+ssh://git@github.com/wmde/fundraising-frontend-content.git#d67810d4840135bfcf7741004526b2a189e2b7ec",
       "license": "CC0-1.0"
     },
     "node_modules/get-intrinsic": {

--- a/test/banners/english/components/BannerCtrl.spec.ts
+++ b/test/banners/english/components/BannerCtrl.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, test, vi } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
-import Banner from '@banners/english/C24_WMDE_Desktop_EN_01/components/BannerCtrl.vue';
+import Banner from '@banners/english/C24_WMDE_Desktop_EN_02/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
 import { newDynamicContent } from '@test/banners/dynamicCampaignContent';
 import { useOfFundsContent } from '@test/banners/useOfFundsContent';

--- a/test/banners/english/components/FallbackBanner.spec.ts
+++ b/test/banners/english/components/FallbackBanner.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, test, vi } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
-import FallbackBanner from '@banners/english/C24_WMDE_Desktop_EN_01/components/FallbackBanner.vue';
+import FallbackBanner from '@banners/english/C24_WMDE_Desktop_EN_02/components/FallbackBanner.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
 import { useOfFundsContent } from '@test/banners/useOfFundsContent';
 import { newDynamicContent } from '@test/banners/dynamicCampaignContent';


### PR DESCRIPTION
- based on en 01
- var: text change
- round 1, went live on 15th of October

- round 2 of this banner: https://github.com/wmde/fundraising-banners/pull/582

Ticket: https://phabricator.wikimedia.org/T374101