### PR TITLE
Change evaluation of is-late-progress

### DIFF
--- a/src/page/PageWPORG.ts
+++ b/src/page/PageWPORG.ts
@@ -162,7 +162,7 @@ class PageWPORG implements Page {
 			startDate: data.startDate,
 			endDate: data.endDate,
 			numberOfMembers: Number( data.numberOfMembers ),
-			isLateProgress: Boolean( data.isLateProgress ),
+			isLateProgress: data.isLateProgress === 'true',
 			thankYouCampaign: {
 				numberOfDonors: Number( data.tyNumberOfDonors ),
 				progressBarPercentage: Number( data.tyProgressBarPercentage )


### PR DESCRIPTION
We evaluate if the campaigns are in late progress by
looking at a html data attribute that we store in a
mediawiki template included with our banners.

If this attribute contains any string it was being
evaluated as true. This change makes it check that
the attribute value is explicitly the string `true`.