### PR TITLE
Simplify layout of small print footer

### DIFF
--- a/src/components/Footer/SmallPrintFooter.scss
+++ b/src/components/Footer/SmallPrintFooter.scss
@@ -5,16 +5,8 @@
 		justify-content: space-between;
 		width: 100%;
 
-		.first-row-items,
-		.second-row-items {
-			display: flex;
-			flex-direction: row;
-		}
-
 		&-usage {
 			padding: 10px 0;
-			display: flex;
-			flex-direction: column;
 			flex-grow: 1;
 		}
 

--- a/src/components/Footer/SmallPrintFooter.vue
+++ b/src/components/Footer/SmallPrintFooter.vue
@@ -1,18 +1,16 @@
 <template>
 	<div class="wmde-banner-footer">
 		<div v-if="showFundsLink" class="wmde-banner-footer-usage">
-			<div class="first-row-items">
-				<div class="wmde-banner-footer-item">
-					<a
-						id="application-of-funds-link"
-						class="wmde-banner-footer-usage-link t-use-of-funds-link"
-						@click.prevent="$emit( 'showFundsModal' )"
-						:title="$translate( 'use-of-funds-link-description' )"
-					>
-						{{ $translate( 'use-of-funds-link' ) }}
-					</a>
-				</div>
-				<div class="wmde-banner-footer-item wmde-banner-footer-faq-link-item">
+			<p class="first-row-items">
+				<a
+					id="application-of-funds-link"
+					class="wmde-banner-footer-usage-link t-use-of-funds-link"
+					@click.prevent="$emit( 'showFundsModal' )"
+					:title="$translate( 'use-of-funds-link-description' )"
+				>
+					{{ $translate( 'use-of-funds-link' ) }}
+				</a>
+				<span class="wmde-banner-footer-faq-link-item">
 					<span class="link-separator"> | </span>
 					<a
 						id="faq-page-link"
@@ -23,18 +21,14 @@
 					>
 						{{ $translate( 'faq-page-link' ) }}
 					</a>
-				</div>
-				<div class="wmde-banner-footer-item bold text-explanation">
-					<span class="link-separator "> | </span>
-					Eine Dauerspende ist jederzeit formlos kündbar. Sie gehen kein Risiko ein.
-				</div>
-			</div>
-			<div class="second-row-items">
-				<div class="wmde-banner-footer-item">
-					<span>Wikimedia Deutschland ist der gemeinnützige Verein hinter Wikipedia. Jede Spende ist steuerlich
-						absetzbar. Auf Wunsch erhalten Sie von uns eine Spendenquittung.</span>
-				</div>
-			</div>
+				</span>
+				<span class="link-separator "> | </span>
+				Eine Dauerspende ist jederzeit formlos kündbar. Sie gehen kein Risiko ein.
+			</p>
+			<p class="second-row-items">
+				Wikimedia Deutschland ist der gemeinnützige Verein hinter Wikipedia. Jede Spende ist steuerlich
+					absetzbar. Auf Wunsch erhalten Sie von uns eine Spendenquittung.
+			</p>
 		</div>
 
 		<div class="wmde-banner-footer-bank">

--- a/src/themes/Svingle/Footer/SmallPrintFooter.scss
+++ b/src/themes/Svingle/Footer/SmallPrintFooter.scss
@@ -15,6 +15,8 @@ $left-column-margin: 0 30px 0 0 !default;
 		margin-top: 0;
 
 		&-bank {
+			flex: 0 0 $right-column-width;
+			width: $right-column-width;
 			padding: 5px 10px 5px 0;
 			text-align: right;
 			&-item {
@@ -43,11 +45,16 @@ $left-column-margin: 0 30px 0 0 !default;
 			margin-right: 3px;
 		}
 
+		.first-row-items,
+		.second-row-items {
+			margin: 0;
+		}
+
 		.second-row-items {
 			display: none;
 
 			@include breakpoints.large-up {
-				display: flex;
+				display: block;
 			}
 		}
 
@@ -55,7 +62,7 @@ $left-column-margin: 0 30px 0 0 !default;
 			display: none;
 
 			@include breakpoints.bigger-medium-up {
-				display: flex;
+				display: inline;
 			}
 		}
 	}


### PR DESCRIPTION
This removes flex styles and block level elements from
the small print footer which makes the line wrap a
little better on small sizes.

Ticket: https://phabricator.wikimedia.org/T375599