### PR TITLE
Fix tracking parameters for WPDE banners

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -21,8 +21,10 @@ module.exports = ( env ) => {
 						appendTsSuffixTo: [ /\.vue$/ ]
 					}
 				},
+				// This is a "special" rule for all wikipedia.de banner entry points. It should be in sync with the rules for `.ts` files.
+				// It replaces tracking parameter placeholders with tracking parameters read from the campaign configuration.
 				{
-					test: /(wpde_desktop|wpde_mobile)\/banner(_ctrl|_var)\.ts/,
+					test: /(wpde_desktop|wpde_mobile)\/\w+\/banner(_ctrl|_var)\.ts/,
 					use: [
 						{
 							loader: 'ts-loader',


### PR DESCRIPTION
While restructuring the banners (see ADR 005), we broke the Webpack
configuration that replaces the placeholders in the entry points with
actual campaign parameters. This commit fixes the webpack path check.
