### PR TITLE
Increase Webpack maximum sizes

### DIFF
--- a/docs/2025PostCampaignCleanUp.md
+++ b/docs/2025PostCampaignCleanUp.md
@@ -21,3 +21,12 @@ using this best practice. See https://stackoverflow.com/questions/3730019/why-no
 ### Files to look at:
 ../src/utils/FormModel/FormModel.ts
 ../src/components/composables/useAmountBasedFormAction.ts
+
+## Try lowering the maximum asset and entry point size
+
+Some features (SVG payment icons, fallback banners, slider) make the size of the compiled banner bigger, which triggers
+a Webpack warning. The current "solution" was to set the limit to 310KB (from 250KB) to avoid the warning, but a better
+solution would be to remove features. When that can be done, please check with lower limits.
+
+### Files to look at:
+../webpack/webpack.production.js

--- a/webpack.production.js
+++ b/webpack.production.js
@@ -85,7 +85,13 @@ module.exports = ( env ) => {
 					}
 					callback();
 				}
-			]
+			],
+			performance: {
+				// Size limit in Bytes for the generated JS files
+				maxAssetSize: 310_000,
+				// Size limit in Bytes for the combined code of entry points
+				maxEntrypointSize: 310_000
+			}
 		},
 		entrypointRules
 	);


### PR DESCRIPTION
To avoid warnings that we can't do anything about at the moment,
increase the maximum sizes in the Webpack configuration.
