### PR TITLE
Make page scroller scroll to top of element 

### DIFF
--- a/src/utils/PageScroller/WindowPageScroller.ts
+++ b/src/utils/PageScroller/WindowPageScroller.ts
@@ -3,7 +3,7 @@ import { PageScroller } from '@src/utils/PageScroller/PageScroller';
 export class WindowPageScroller implements PageScroller {
 	public scrollIntoView( classSelector: string ): void {
 		document.querySelector( classSelector )?.scrollIntoView(
-			{ behavior: 'smooth', block: 'center', inline: 'nearest' }
+			{ behavior: 'smooth', block: 'start', inline: 'start' }
 		);
 	}
 


### PR DESCRIPTION
We use the page scroller to show the donation form
but this doesn't always align to the top. This modifies
the behavior to make that happen.