### PR TITLE
Expose average donation to banner content

### DIFF
--- a/banners/desktop/C24_WMDE_Desktop_DE_07/content/BannerSlides.vue
+++ b/banners/desktop/C24_WMDE_Desktop_DE_07/content/BannerSlides.vue
@@ -18,7 +18,7 @@
 	</KeenSliderSlide>
 	<KeenSliderSlide :is-current="currentSlide === 2">
 		<p>
-			Die durchschnittliche Spende beträgt 22,49&nbsp;€, doch bereits 5&nbsp;€ helfen uns weiter. Hat Wikipedia
+			Die durchschnittliche Spende beträgt {{ averageDonation }}, doch bereits 5&nbsp;€ helfen uns weiter. Hat Wikipedia
 			Ihnen in diesem Jahr Wissen im Wert einer Tasse Kaffee geschenkt?
 		</p>
 	</KeenSliderSlide>
@@ -45,7 +45,8 @@ defineProps<Props>();
 
 const {
 	currentDayName,
-	getCurrentDateAndTime
+	getCurrentDateAndTime,
+	averageDonation
 } = inject<DynamicContent>( 'dynamicCampaignText' );
 
 const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );

--- a/banners/desktop/C24_WMDE_Desktop_DE_07/content/BannerSlidesVar.vue
+++ b/banners/desktop/C24_WMDE_Desktop_DE_07/content/BannerSlidesVar.vue
@@ -21,7 +21,7 @@
 	</KeenSliderSlide>
 	<KeenSliderSlide :is-current="currentSlide === 2">
 		<p>
-			Die durchschnittliche Spende beträgt 22,49&nbsp;€, doch bereits 5&nbsp;€ helfen uns weiter. Hat Wikipedia
+			Die durchschnittliche Spende beträgt {{ averageDonation }}, doch bereits 5&nbsp;€ helfen uns weiter. Hat Wikipedia
 			Ihnen in diesem Jahr Wissen im Wert einer Tasse Kaffee geschenkt?
 		</p>
 	</KeenSliderSlide>
@@ -48,7 +48,8 @@ defineProps<Props>();
 
 const {
 	currentDayName,
-	getCurrentDateAndTime
+	getCurrentDateAndTime,
+	averageDonation
 } = inject<DynamicContent>( 'dynamicCampaignText' );
 
 const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );

--- a/banners/desktop/C24_WMDE_Desktop_DE_07/content/BannerText.vue
+++ b/banners/desktop/C24_WMDE_Desktop_DE_07/content/BannerText.vue
@@ -11,7 +11,7 @@
 				{{ currentDayName }} bitten wir Sie, die Unabhängigkeit von Wikipedia zu unterstützen.
 				<AnimatedText content="Millionen Menschen nutzen Wikipedia, aber 99&nbsp;% spenden nicht – sie übergehen
 				diesen Aufruf."/> Die meisten Menschen spenden, weil sie Wikipedia nützlich finden. Die
-				durchschnittliche Spende beträgt 22,49&nbsp;€, doch bereits 5&nbsp;€ helfen uns weiter. Hat Wikipedia
+				durchschnittliche Spende beträgt {{ averageDonation }}, doch bereits 5&nbsp;€ helfen uns weiter. Hat Wikipedia
 				Ihnen in diesem Jahr Wissen im Wert einer Tasse Kaffee geschenkt? Dann entscheiden Sie sich, eine der
 				seltenen Ausnahmen zu sein, und geben Sie etwas zurück. Vielen Dank!
 			</p>
@@ -28,7 +28,8 @@ import InfoIcon from '@src/components/Icons/InfoIcon.vue';
 
 const {
 	currentDayName,
-	getCurrentDateAndTime
+	getCurrentDateAndTime,
+	averageDonation
 } = inject<DynamicContent>( 'dynamicCampaignText' );
 
 const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );

--- a/banners/desktop/C24_WMDE_Desktop_DE_07/content/BannerTextVar.vue
+++ b/banners/desktop/C24_WMDE_Desktop_DE_07/content/BannerTextVar.vue
@@ -14,7 +14,7 @@
 				{{ currentDayName }} bitten wir Sie, die Unabhängigkeit von Wikipedia zu unterstützen.
 				<AnimatedText content="Millionen Menschen nutzen Wikipedia, aber 99&nbsp;% spenden nicht – sie übergehen diesen
 				Aufruf."/> Die meisten Menschen spenden, weil sie Wikipedia nützlich finden. Die
-				durchschnittliche Spende beträgt 22,49&nbsp;€, doch bereits 5&nbsp;€ helfen uns weiter. Hat Wikipedia
+				durchschnittliche Spende beträgt {{ averageDonation }}, doch bereits 5&nbsp;€ helfen uns weiter. Hat Wikipedia
 				Ihnen in diesem Jahr Wissen im Wert einer Tasse Kaffee geschenkt? Dann entscheiden Sie sich, eine der
 				seltenen Ausnahmen zu sein, und geben Sie etwas zurück. Vielen Dank!
 			</p>
@@ -31,7 +31,8 @@ import InfoIcon from '@src/components/Icons/InfoIcon.vue';
 
 const {
 	currentDayName,
-	getCurrentDateAndTime
+	getCurrentDateAndTime,
+	averageDonation
 } = inject<DynamicContent>( 'dynamicCampaignText' );
 
 const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );

--- a/banners/desktop/C24_WMDE_Desktop_DE_08/content/BannerSlides.vue
+++ b/banners/desktop/C24_WMDE_Desktop_DE_08/content/BannerSlides.vue
@@ -22,7 +22,7 @@
 	</KeenSliderSlide>
 	<KeenSliderSlide :is-current="currentSlide === 2">
 		<p>
-			Die durchschnittliche Spende beträgt 22,49&nbsp;€, doch bereits 5&nbsp;€ helfen uns weiter. Hat Wikipedia
+			Die durchschnittliche Spende beträgt {{ averageDonation }}, doch bereits 5&nbsp;€ helfen uns weiter. Hat Wikipedia
 			Ihnen in diesem Jahr Wissen im Wert einer Tasse Kaffee geschenkt?
 		</p>
 	</KeenSliderSlide>
@@ -52,7 +52,8 @@ const {
 	getCurrentDateAndTime,
 	currentDate,
 	campaignDaySentence,
-	visitorsVsDonorsSentence
+	visitorsVsDonorsSentence,
+	averageDonation
 } = inject<DynamicContent>( 'dynamicCampaignText' );
 
 const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );

--- a/banners/desktop/C24_WMDE_Desktop_DE_08/content/BannerText.vue
+++ b/banners/desktop/C24_WMDE_Desktop_DE_08/content/BannerText.vue
@@ -15,7 +15,7 @@
 				{{campaignDaySentence}}
 				<AnimatedText :content="visitorsVsDonorsSentence"/>
 				Die meisten Menschen spenden, weil sie Wikipedia nützlich finden.
-				Die durchschnittliche Spende beträgt 22,49&nbsp;€, doch bereits 5&nbsp;€ helfen uns weiter.
+				Die durchschnittliche Spende beträgt {{ averageDonation }}, doch bereits 5&nbsp;€ helfen uns weiter.
 				Hat Wikipedia Ihnen in diesem Jahr Wissen im Wert einer Tasse Kaffee geschenkt?
 				Dann entscheiden Sie sich, eine der seltenen Ausnahmen zu sein, und geben Sie etwas zurück.
 				Vielen Dank!
@@ -36,7 +36,8 @@ const {
 	getCurrentDateAndTime,
 	currentDate,
 	campaignDaySentence,
-	visitorsVsDonorsSentence
+	visitorsVsDonorsSentence,
+	averageDonation
 } = inject<DynamicContent>( 'dynamicCampaignText' );
 
 const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );

--- a/docs/2025PostCampaignCleanUp.md
+++ b/docs/2025PostCampaignCleanUp.md
@@ -19,8 +19,8 @@ but actually it was `Euros and Cents`. We are used to the amount being `Cents` f
 using this best practice. See https://stackoverflow.com/questions/3730019/why-not-use-double-or-float-to-represent-currency
 
 ### Files to look at:
-../src/utils/FormModel/FormModel.ts
-../src/components/composables/useAmountBasedFormAction.ts
+- `../src/utils/FormModel/FormModel.ts`
+- `../src/components/composables/useAmountBasedFormAction.ts`
 
 
 ## Create parameters for 2025 campaign and adapt dev banner
@@ -39,7 +39,15 @@ a Webpack warning. The current "solution" was to set the limit to 310KB (from 25
 solution would be to remove features. When that can be done, please check with lower limits.
 
 ### Files to look at:
-../webpack/webpack.production.js
+- `../webpack/webpack.production.js`
+
+## Average Donation
+This value is in the dynamic content and was previously only used for calculating part of the projection. It's now exposed to the banner content so we should decide if we need to move it out of the campaignProjection part of the CampaignParameters and inject it into the CampaignProjection class separately.
+
+### Files to look at
+- `src/page/PageWPORG.ts`
+- `src/utils/DynamicContent/CampaignProjection.ts`
+- `src/utils/DynamicContent/DynamicCampaignText.ts`
 
 ## UpgradeToYearly form
 

--- a/src/utils/DynamicContent/DynamicCampaignText.ts
+++ b/src/utils/DynamicContent/DynamicCampaignText.ts
@@ -182,4 +182,8 @@ export default class DynamicCampaignText implements DynamicContent {
 		}
 		return this._progressBarContent;
 	}
+
+	public get averageDonation(): string {
+		return this._formatters.currency.euroAmount( this._campaignParameters.campaignProjection.averageAmountPerDonation );
+	}
 }

--- a/src/utils/DynamicContent/DynamicContent.ts
+++ b/src/utils/DynamicContent/DynamicContent.ts
@@ -17,4 +17,5 @@ export interface DynamicContent {
 	remainingDonationSum: string;
 	overallImpressionCount: number;
 	progressBarContent: DynamicProgressBarContent;
+	averageDonation: string;
 }

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_08/components/BannerCtrl.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_08/components/BannerCtrl.spec.ts
@@ -8,7 +8,7 @@ import { formItems } from '@test/banners/formItems';
 import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
 import {
-	bannerContentAnimatedTextFeatures,
+	bannerContentAnimatedTextFeatures, bannerContentAverageDonationFeatures,
 	bannerContentDateAndTimeFeatures,
 	bannerContentDisplaySwitchFeatures,
 	bannerContentFeatures
@@ -110,6 +110,13 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectShowsLiveDateAndTimeInSlideshow' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerContentDateAndTimeFeatures[ testName ]( getWrapper );
+		} );
+
+		test.each( [
+			[ 'expectShowsAverageDonationInMessage' ],
+			[ 'expectShowsAverageDonationInSlideshow' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerContentAverageDonationFeatures[ testName ]( getWrapper );
 		} );
 	} );
 

--- a/test/banners/dynamicCampaignContent.ts
+++ b/test/banners/dynamicCampaignContent.ts
@@ -22,6 +22,7 @@ export function newDynamicContent(): DynamicContent {
 			amountNeeded: 'amountNeeded',
 			isLateProgress: false
 		},
-		visitorsVsDonorsSentence: ''
+		visitorsVsDonorsSentence: '',
+		averageDonation: ''
 	};
 }

--- a/test/banners/english/C24_WMDE_Desktop_EN_02b/components/BannerCtrl.spec.ts
+++ b/test/banners/english/C24_WMDE_Desktop_EN_02b/components/BannerCtrl.spec.ts
@@ -8,7 +8,8 @@ import { formItems } from '@test/banners/formItems';
 import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
 import {
-	bannerContentAnimatedTextFeatures, bannerContentDateAndTimeFeatures,
+	bannerContentAnimatedTextFeatures,
+	bannerContentDateAndTimeFeatures,
 	bannerContentDisplaySwitchFeatures,
 	bannerContentFeatures
 } from '@test/features/BannerContent';

--- a/test/components/ProgressBar/DoubleProgressBar.spec.ts
+++ b/test/components/ProgressBar/DoubleProgressBar.spec.ts
@@ -28,7 +28,8 @@ describe( 'DoubleProgressBar.vue', () => {
 				amountNeeded: 'amountNeeded',
 				isLateProgress: false
 			},
-			visitorsVsDonorsSentence: ''
+			visitorsVsDonorsSentence: '',
+			averageDonation: ''
 		};
 	} );
 

--- a/test/components/ProgressBar/ProgressBar.spec.ts
+++ b/test/components/ProgressBar/ProgressBar.spec.ts
@@ -28,7 +28,8 @@ describe( 'ProgressBar.vue', () => {
 				amountNeeded: 'amountNeeded',
 				isLateProgress: false
 			},
-			visitorsVsDonorsSentence: ''
+			visitorsVsDonorsSentence: '',
+			averageDonation: ''
 		};
 	} );
 

--- a/test/features/BannerContent.ts
+++ b/test/features/BannerContent.ts
@@ -111,6 +111,26 @@ const expectShowsLiveDateAndTimeInSlideshow = async ( getWrapper: ( dynamicConte
 	expect( wrapper.find( '.wmde-banner-slider' ).text() ).toContain( 'Third Time' );
 };
 
+const expectShowsAverageDonationInMessage = async ( getWrapper: ( dynamicContent: DynamicContent ) => VueWrapper<any> ): Promise<any> => {
+	Object.defineProperty( window, 'innerWidth', { writable: true, configurable: true, value: 1301 } );
+	const dynamicContent = newDynamicContent();
+	dynamicContent.averageDonation = '== Average Donation ==';
+
+	const wrapper = getWrapper( dynamicContent );
+
+	expect( wrapper.find( '.wmde-banner-message' ).text() ).toContain( '== Average Donation ==' );
+};
+
+const expectShowsAverageDonationInSlideshow = async ( getWrapper: ( dynamicContent: DynamicContent ) => VueWrapper<any> ): Promise<any> => {
+	Object.defineProperty( window, 'innerWidth', { writable: true, configurable: true, value: 1300 } );
+	const dynamicContent = newDynamicContent();
+	dynamicContent.averageDonation = '== Average Donation ==';
+
+	const wrapper = getWrapper( dynamicContent );
+
+	expect( wrapper.find( '.wmde-banner-slider' ).text() ).toContain( '== Average Donation ==' );
+};
+
 const expectShowsLiveDateAndTimeInMiniBanner = async ( getWrapper: ( dynamicContent: DynamicContent ) => VueWrapper<any> ): Promise<any> => {
 	const dynamicContent = newDynamicContent();
 	// There are 2 live text elements mounted at the same time in the mobile banners meaning it will be initialised twice
@@ -169,6 +189,11 @@ export const bannerContentFeatures: Record<string, ( wrapper: VueWrapper<any> ) 
 export const bannerContentDisplaySwitchFeatures: Record<string, ( getWrapper: () => VueWrapper<any>, minWidthForLargeScreen: number ) => Promise<any>> = {
 	expectShowsSlideShowOnSmallSizes,
 	expectShowsMessageOnLargeSizes
+};
+
+export const bannerContentAverageDonationFeatures: Record<string, ( getWrapper: () => VueWrapper<any> ) => Promise<any>> = {
+	expectShowsAverageDonationInMessage,
+	expectShowsAverageDonationInSlideshow
 };
 
 export const bannerContentAnimatedTextFeatures: Record<string, ( getWrapper: () => VueWrapper<any> ) => Promise<any>> = {

--- a/test/unit/utils/DynamicContent/DynamicCampaignText.spec.ts
+++ b/test/unit/utils/DynamicContent/DynamicCampaignText.spec.ts
@@ -127,4 +127,8 @@ describe( 'DynamicCampaignText', () => {
 		expect( dynamicCampaignText.progressBarContent.amountDonated ).toBe( '€0.1M' );
 		expect( dynamicCampaignText.progressBarContent.amountNeeded ).toBe( 'Progress missing 8,900,000 euro' );
 	} );
+
+	it( 'Gets the average donation', () => {
+		expect( dynamicCampaignText.averageDonation ).toBe( '€20' );
+	} );
 } );


### PR DESCRIPTION
We use the average donation to do the campaign projection.
This exposes it so it can be used in the content.

Also adds a banner test to make sure it works.

Ticket: https://phabricator.wikimedia.org/T378212