### PR TITLE
Replace window timer with injected timer

### DIFF
--- a/banners/desktop/C24_WMDE_Desktop_DE_00/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_00/banner_ctrl.ts
@@ -27,6 +27,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { currentCampaignTimePercentage } from './currentCampaignTimePercentage';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -72,5 +73,6 @@ app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmo
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
 app.provide( 'currentCampaignTimePercentage', currentCampaignTimePercentage( date, page.getCampaignParameters() ) );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_00/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_00/banner_ctrl.ts
@@ -18,12 +18,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { currentCampaignTimePercentage } from './currentCampaignTimePercentage';

--- a/banners/desktop/C24_WMDE_Desktop_DE_00/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_00/banner_var.ts
@@ -27,6 +27,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { currentCampaignTimePercentage } from './currentCampaignTimePercentage';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -72,5 +73,6 @@ app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmo
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
 app.provide( 'currentCampaignTimePercentage', currentCampaignTimePercentage( date, page.getCampaignParameters() ) );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_00/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_00/banner_var.ts
@@ -18,12 +18,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { currentCampaignTimePercentage } from './currentCampaignTimePercentage';

--- a/banners/desktop/C24_WMDE_Desktop_DE_01/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_01/banner_ctrl.ts
@@ -27,6 +27,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { currentCampaignTimePercentage } from './currentCampaignTimePercentage';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -72,5 +73,6 @@ app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmo
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { ap: '0' } ) );
 app.provide( 'tracker', tracker );
 app.provide( 'currentCampaignTimePercentage', currentCampaignTimePercentage( date, page.getCampaignParameters() ) );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_01/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_01/banner_ctrl.ts
@@ -18,12 +18,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { currentCampaignTimePercentage } from './currentCampaignTimePercentage';

--- a/banners/desktop/C24_WMDE_Desktop_DE_01/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_01/banner_var.ts
@@ -18,12 +18,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { currentCampaignTimePercentage } from './currentCampaignTimePercentage';

--- a/banners/desktop/C24_WMDE_Desktop_DE_01/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_01/banner_var.ts
@@ -27,6 +27,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { currentCampaignTimePercentage } from './currentCampaignTimePercentage';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -72,5 +73,6 @@ app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmo
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { ap: '1' } ) );
 app.provide( 'tracker', tracker );
 app.provide( 'currentCampaignTimePercentage', currentCampaignTimePercentage( date, page.getCampaignParameters() ) );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_02/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_02/banner_ctrl.ts
@@ -27,6 +27,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { currentCampaignTimePercentage } from './currentCampaignTimePercentage';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -72,5 +73,6 @@ app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmo
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
 app.provide( 'currentCampaignTimePercentage', currentCampaignTimePercentage( date, page.getCampaignParameters() ) );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_02/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_02/banner_ctrl.ts
@@ -18,12 +18,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { currentCampaignTimePercentage } from './currentCampaignTimePercentage';

--- a/banners/desktop/C24_WMDE_Desktop_DE_02/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_02/banner_var.ts
@@ -27,6 +27,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { currentCampaignTimePercentage } from './currentCampaignTimePercentage';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -72,5 +73,6 @@ app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmo
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
 app.provide( 'currentCampaignTimePercentage', currentCampaignTimePercentage( date, page.getCampaignParameters() ) );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_02/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_02/banner_var.ts
@@ -18,12 +18,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { currentCampaignTimePercentage } from './currentCampaignTimePercentage';

--- a/banners/desktop/C24_WMDE_Desktop_DE_03/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_03/banner_ctrl.ts
@@ -26,6 +26,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -70,5 +71,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_03/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_03/banner_ctrl.ts
@@ -18,12 +18,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/desktop/C24_WMDE_Desktop_DE_03/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_03/banner_var.ts
@@ -26,6 +26,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -70,5 +71,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_03/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_03/banner_var.ts
@@ -18,12 +18,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/desktop/C24_WMDE_Desktop_DE_04/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_04/banner_ctrl.ts
@@ -26,6 +26,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -70,5 +71,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { afo: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_04/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_04/banner_ctrl.ts
@@ -18,12 +18,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/desktop/C24_WMDE_Desktop_DE_04/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_04/banner_var.ts
@@ -26,6 +26,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -70,5 +71,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { afo: '1' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_04/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_04/banner_var.ts
@@ -18,12 +18,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/desktop/C24_WMDE_Desktop_DE_05/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_05/banner_ctrl.ts
@@ -26,6 +26,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -70,5 +71,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { afo: '1', ap: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_05/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_05/banner_ctrl.ts
@@ -18,12 +18,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/desktop/C24_WMDE_Desktop_DE_05/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_05/banner_var.ts
@@ -26,6 +26,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -70,5 +71,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { afo: '1' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_05/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_05/banner_var.ts
@@ -18,12 +18,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/desktop/C24_WMDE_Desktop_DE_06/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_06/banner_ctrl.ts
@@ -26,6 +26,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -70,5 +71,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { afo: '1', ap: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_06/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_06/banner_ctrl.ts
@@ -18,12 +18,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/desktop/C24_WMDE_Desktop_DE_06/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_06/banner_var.ts
@@ -27,6 +27,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { createFAQPageURL } from '@src/createFAQPageURL';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -72,5 +73,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { afo: '1', ap: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_06/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_06/banner_var.ts
@@ -18,12 +18,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { createFAQPageURL } from '@src/createFAQPageURL';

--- a/banners/desktop/C24_WMDE_Desktop_DE_07/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_07/banner_ctrl.ts
@@ -26,6 +26,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -70,5 +71,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { afo: '1', ap: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_07/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_07/banner_ctrl.ts
@@ -18,12 +18,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/desktop/C24_WMDE_Desktop_DE_07/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_07/banner_var.ts
@@ -26,6 +26,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -70,5 +71,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { afo: '1', ap: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_07/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_07/banner_var.ts
@@ -18,12 +18,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/desktop/C24_WMDE_Desktop_DE_08/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_08/banner_ctrl.ts
@@ -27,6 +27,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -72,5 +73,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { afo: '1', ap: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_08/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_08/banner_ctrl.ts
@@ -19,12 +19,8 @@ import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
 import { LocalStorageCloseTracker } from '@src/utils/LocalCloseTracker';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/desktop/C24_WMDE_Desktop_DE_08/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_08/banner_var.ts
@@ -19,12 +19,8 @@ import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
 import { LocalStorageCloseTracker } from '@src/utils/LocalCloseTracker';
-
-// Locale-specific imports
 import messages from './messages_var';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/desktop/C24_WMDE_Desktop_DE_08/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_08/banner_var.ts
@@ -27,6 +27,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -72,5 +73,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { afo: '1', ap: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_09/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_09/banner_ctrl.ts
@@ -27,6 +27,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -72,5 +73,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { afo: '1', ap: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_09/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_09/banner_ctrl.ts
@@ -19,12 +19,8 @@ import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
 import { LocalStorageCloseTracker } from '@src/utils/LocalCloseTracker';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/desktop/C24_WMDE_Desktop_DE_09/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_09/banner_var.ts
@@ -27,6 +27,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -72,5 +73,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { afo: '1', ap: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_09/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_09/banner_var.ts
@@ -19,12 +19,8 @@ import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
 import { LocalStorageCloseTracker } from '@src/utils/LocalCloseTracker';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/desktop/C24_WMDE_Desktop_DE_10/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_10/banner_ctrl.ts
@@ -27,6 +27,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -72,5 +73,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { afo: '1', ap: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_10/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_10/banner_ctrl.ts
@@ -19,12 +19,8 @@ import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
 import { LocalStorageCloseTracker } from '@src/utils/LocalCloseTracker';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/desktop/C24_WMDE_Desktop_DE_10/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_10/banner_var.ts
@@ -27,6 +27,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items_var';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const date = new Date();
 const localeFactory = new LocaleFactoryDe();
@@ -72,5 +73,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { afo: '1', ap: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/desktop/C24_WMDE_Desktop_DE_10/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_10/banner_var.ts
@@ -19,12 +19,8 @@ import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
 import { LocalStorageCloseTracker } from '@src/utils/LocalCloseTracker';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items_var';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/english/C24_WMDE_Desktop_EN_00/banner_ctrl.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_00/banner_ctrl.ts
@@ -27,6 +27,7 @@ import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryEn();
 const translator = new Translator( messages );
@@ -69,5 +70,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { locale: Locales.EN } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/english/C24_WMDE_Desktop_EN_00/banner_ctrl.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_00/banner_ctrl.ts
@@ -17,12 +17,8 @@ import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import { Locales } from '@src/domain/Locales';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryEn } from '@src/utils/LocaleFactory/LocaleFactoryEn';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import eventMappings from './event_map';

--- a/banners/english/C24_WMDE_Desktop_EN_00/banner_var.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_00/banner_var.ts
@@ -27,6 +27,7 @@ import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryEn();
 const translator = new Translator( messages );
@@ -69,5 +70,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { locale: Locales.EN } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/english/C24_WMDE_Desktop_EN_00/banner_var.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_00/banner_var.ts
@@ -17,12 +17,8 @@ import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import { Locales } from '@src/domain/Locales';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryEn } from '@src/utils/LocaleFactory/LocaleFactoryEn';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import eventMappings from './event_map';

--- a/banners/english/C24_WMDE_Desktop_EN_01/banner_ctrl.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_01/banner_ctrl.ts
@@ -27,6 +27,7 @@ import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryEn();
 const translator = new Translator( messages );
@@ -69,5 +70,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { locale: Locales.EN, ap: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/english/C24_WMDE_Desktop_EN_01/banner_ctrl.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_01/banner_ctrl.ts
@@ -17,12 +17,8 @@ import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import { Locales } from '@src/domain/Locales';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryEn } from '@src/utils/LocaleFactory/LocaleFactoryEn';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import eventMappings from './event_map';

--- a/banners/english/C24_WMDE_Desktop_EN_01/banner_var.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_01/banner_var.ts
@@ -27,6 +27,7 @@ import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryEn();
 const translator = new Translator( messages );
@@ -69,5 +70,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { locale: Locales.EN, ap: '1' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/english/C24_WMDE_Desktop_EN_01/banner_var.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_01/banner_var.ts
@@ -17,12 +17,8 @@ import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import { Locales } from '@src/domain/Locales';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryEn } from '@src/utils/LocaleFactory/LocaleFactoryEn';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import eventMappings from './event_map';

--- a/banners/english/C24_WMDE_Desktop_EN_02/banner_ctrl.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_02/banner_ctrl.ts
@@ -27,6 +27,7 @@ import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryEn();
 const translator = new Translator( messages );
@@ -69,5 +70,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { locale: Locales.EN, ap: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/english/C24_WMDE_Desktop_EN_02/banner_ctrl.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_02/banner_ctrl.ts
@@ -17,12 +17,8 @@ import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import { Locales } from '@src/domain/Locales';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryEn } from '@src/utils/LocaleFactory/LocaleFactoryEn';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import eventMappings from './event_map';

--- a/banners/english/C24_WMDE_Desktop_EN_02/banner_var.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_02/banner_var.ts
@@ -27,6 +27,7 @@ import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryEn();
 const translator = new Translator( messages );
@@ -69,5 +70,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { locale: Locales.EN, ap: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/english/C24_WMDE_Desktop_EN_02/banner_var.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_02/banner_var.ts
@@ -17,12 +17,8 @@ import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import { Locales } from '@src/domain/Locales';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryEn } from '@src/utils/LocaleFactory/LocaleFactoryEn';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import eventMappings from './event_map';

--- a/banners/english/C24_WMDE_Desktop_EN_02b/banner_ctrl.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_02b/banner_ctrl.ts
@@ -27,6 +27,7 @@ import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryEn();
 const translator = new Translator( messages );
@@ -69,5 +70,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { locale: Locales.EN, ap: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/english/C24_WMDE_Desktop_EN_02b/banner_ctrl.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_02b/banner_ctrl.ts
@@ -17,12 +17,8 @@ import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import { Locales } from '@src/domain/Locales';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryEn } from '@src/utils/LocaleFactory/LocaleFactoryEn';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import eventMappings from './event_map';

--- a/banners/english/C24_WMDE_Desktop_EN_02b/banner_var.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_02b/banner_var.ts
@@ -27,6 +27,7 @@ import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryEn();
 const translator = new Translator( messages );
@@ -69,5 +70,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { locale: Locales.EN, ap: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/english/C24_WMDE_Desktop_EN_02b/banner_var.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_02b/banner_var.ts
@@ -17,12 +17,8 @@ import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import { Locales } from '@src/domain/Locales';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryEn } from '@src/utils/LocaleFactory/LocaleFactoryEn';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import eventMappings from './event_map';

--- a/banners/english/C24_WMDE_Desktop_EN_03/banner_ctrl.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_03/banner_ctrl.ts
@@ -27,6 +27,7 @@ import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import eventMappings from './event_map';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryEn();
 const translator = new Translator( messages );
@@ -69,5 +70,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { locale: Locales.EN, afo: '1' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/english/C24_WMDE_Desktop_EN_03/banner_ctrl.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_03/banner_ctrl.ts
@@ -17,12 +17,8 @@ import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import { Locales } from '@src/domain/Locales';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryEn } from '@src/utils/LocaleFactory/LocaleFactoryEn';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import eventMappings from './event_map';

--- a/banners/english/C24_WMDE_Desktop_EN_03/banner_var.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_03/banner_var.ts
@@ -17,12 +17,8 @@ import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import { Locales } from '@src/domain/Locales';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryEn } from '@src/utils/LocaleFactory/LocaleFactoryEn';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import eventMappings from './event_map_var';

--- a/banners/english/C24_WMDE_Desktop_EN_03/banner_var.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_03/banner_var.ts
@@ -27,6 +27,7 @@ import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import eventMappings from './event_map_var';
 import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryEn();
 const translator = new Translator( messages );
@@ -69,5 +70,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { locale: Locales.EN, afo: '1' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/mobile/C24_WMDE_Mobile_DE_00/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_00/banner_ctrl.ts
@@ -25,6 +25,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryDe();
 const translator = new Translator( messages );
@@ -65,5 +66,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/mobile/C24_WMDE_Mobile_DE_00/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_00/banner_ctrl.ts
@@ -17,12 +17,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { WindowPageScroller } from '@src/utils/PageScroller/WindowPageScroller';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/mobile/C24_WMDE_Mobile_DE_00/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_00/banner_var.ts
@@ -25,6 +25,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items_var';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryDe();
 const translator = new Translator( messages );
@@ -65,5 +66,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/mobile/C24_WMDE_Mobile_DE_00/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_00/banner_var.ts
@@ -17,12 +17,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { WindowPageScroller } from '@src/utils/PageScroller/WindowPageScroller';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items_var';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/mobile/C24_WMDE_Mobile_DE_01/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_01/banner_ctrl.ts
@@ -25,6 +25,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryDe();
 const translator = new Translator( messages );
@@ -65,5 +66,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/mobile/C24_WMDE_Mobile_DE_01/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_01/banner_ctrl.ts
@@ -17,12 +17,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { WindowPageScroller } from '@src/utils/PageScroller/WindowPageScroller';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/mobile/C24_WMDE_Mobile_DE_01/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_01/banner_var.ts
@@ -25,6 +25,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryDe();
 const translator = new Translator( messages );
@@ -65,5 +66,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/mobile/C24_WMDE_Mobile_DE_01/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_01/banner_var.ts
@@ -17,12 +17,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { WindowPageScroller } from '@src/utils/PageScroller/WindowPageScroller';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/mobile/C24_WMDE_Mobile_DE_02/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_02/banner_ctrl.ts
@@ -25,6 +25,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryDe();
 const translator = new Translator( messages );
@@ -65,5 +66,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/mobile/C24_WMDE_Mobile_DE_02/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_02/banner_ctrl.ts
@@ -17,12 +17,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { WindowPageScroller } from '@src/utils/PageScroller/WindowPageScroller';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/mobile/C24_WMDE_Mobile_DE_02/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_02/banner_var.ts
@@ -25,6 +25,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryDe();
 const translator = new Translator( messages );
@@ -65,5 +66,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { ap: '1' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/mobile/C24_WMDE_Mobile_DE_02/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_02/banner_var.ts
@@ -17,12 +17,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { WindowPageScroller } from '@src/utils/PageScroller/WindowPageScroller';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/mobile/C24_WMDE_Mobile_DE_03/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_03/banner_ctrl.ts
@@ -25,6 +25,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryDe();
 const translator = new Translator( messages );
@@ -65,5 +66,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/mobile/C24_WMDE_Mobile_DE_03/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_03/banner_ctrl.ts
@@ -17,12 +17,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { WindowPageScroller } from '@src/utils/PageScroller/WindowPageScroller';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/mobile/C24_WMDE_Mobile_DE_03/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_03/banner_var.ts
@@ -25,6 +25,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryDe();
 const translator = new Translator( messages );
@@ -65,5 +66,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { afo: '1' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/mobile/C24_WMDE_Mobile_DE_03/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_03/banner_var.ts
@@ -17,12 +17,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { WindowPageScroller } from '@src/utils/PageScroller/WindowPageScroller';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/mobile/C24_WMDE_Mobile_DE_04/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_04/banner_ctrl.ts
@@ -25,6 +25,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryDe();
 const translator = new Translator( messages );
@@ -65,5 +66,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { afo: '1', ap: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/mobile/C24_WMDE_Mobile_DE_04/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_04/banner_ctrl.ts
@@ -17,12 +17,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { WindowPageScroller } from '@src/utils/PageScroller/WindowPageScroller';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/mobile/C24_WMDE_Mobile_DE_04/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_04/banner_var.ts
@@ -25,6 +25,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryDe();
 const translator = new Translator( messages );
@@ -65,5 +66,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { afo: '1' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/mobile/C24_WMDE_Mobile_DE_04/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_04/banner_var.ts
@@ -17,12 +17,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { WindowPageScroller } from '@src/utils/PageScroller/WindowPageScroller';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/mobile/C24_WMDE_Mobile_DE_05/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_05/banner_ctrl.ts
@@ -25,6 +25,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryDe();
 const translator = new Translator( messages );
@@ -65,5 +66,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { afo: '1', ap: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/mobile/C24_WMDE_Mobile_DE_05/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_05/banner_ctrl.ts
@@ -17,12 +17,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { WindowPageScroller } from '@src/utils/PageScroller/WindowPageScroller';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/mobile/C24_WMDE_Mobile_DE_05/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_05/banner_var.ts
@@ -25,6 +25,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 // Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryDe();
 const translator = new Translator( messages );
@@ -65,5 +66,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { afo: '1', ap: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/mobile/C24_WMDE_Mobile_DE_05/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_05/banner_var.ts
@@ -17,12 +17,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { WindowPageScroller } from '@src/utils/PageScroller/WindowPageScroller';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/mobile/C24_WMDE_Mobile_DE_06/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_06/banner_ctrl.ts
@@ -26,6 +26,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { LocalStorageCloseTracker } from '@src/utils/LocalCloseTracker';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryDe();
 const translator = new Translator( messages );
@@ -67,5 +68,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { afo: '1', ap: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/mobile/C24_WMDE_Mobile_DE_06/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_06/banner_ctrl.ts
@@ -17,12 +17,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { WindowPageScroller } from '@src/utils/PageScroller/WindowPageScroller';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
-
-// Locale-specific imports
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { LocalStorageCloseTracker } from '@src/utils/LocalCloseTracker';

--- a/banners/mobile/C24_WMDE_Mobile_DE_06/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_06/banner_var.ts
@@ -17,12 +17,8 @@ import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { WindowPageScroller } from '@src/utils/PageScroller/WindowPageScroller';
 import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
 import eventMappings from './event_map';
-
-// Locale-specific imports
 import messages from './messages_var';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { LocalStorageCloseTracker } from '@src/utils/LocalCloseTracker';

--- a/banners/mobile/C24_WMDE_Mobile_DE_06/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_06/banner_var.ts
@@ -26,6 +26,7 @@ import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
 import { LocalStorageCloseTracker } from '@src/utils/LocalCloseTracker';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryDe();
 const translator = new Translator( messages );
@@ -67,5 +68,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { afo: '1', ap: '0' } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/mobile_english/C24_WMDE_Mobile_EN_00/banner_ctrl.ts
+++ b/banners/mobile_english/C24_WMDE_Mobile_EN_00/banner_ctrl.ts
@@ -26,6 +26,7 @@ import { createFormActions } from '@src/createFormActions';
 // Content for EN banners
 import messages from './messages';
 import { LocaleFactoryEn } from '@src/utils/LocaleFactory/LocaleFactoryEn';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryEn();
 const translator = new Translator( messages );
@@ -65,5 +66,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { locale: Locales.EN } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/mobile_english/C24_WMDE_Mobile_EN_00/banner_ctrl.ts
+++ b/banners/mobile_english/C24_WMDE_Mobile_EN_00/banner_ctrl.ts
@@ -18,12 +18,8 @@ import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { WindowPageScroller } from '@src/utils/PageScroller/WindowPageScroller';
 import { Locales } from '@src/domain/Locales';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
-
-// Content for EN banners
 import messages from './messages';
 import { LocaleFactoryEn } from '@src/utils/LocaleFactory/LocaleFactoryEn';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/mobile_english/C24_WMDE_Mobile_EN_00/banner_var.ts
+++ b/banners/mobile_english/C24_WMDE_Mobile_EN_00/banner_var.ts
@@ -26,6 +26,7 @@ import { createFormActions } from '@src/createFormActions';
 // Content for EN banners
 import messages from './messages';
 import { LocaleFactoryEn } from '@src/utils/LocaleFactory/LocaleFactoryEn';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryEn();
 const translator = new Translator( messages );
@@ -65,5 +66,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { locale: Locales.EN } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/mobile_english/C24_WMDE_Mobile_EN_00/banner_var.ts
+++ b/banners/mobile_english/C24_WMDE_Mobile_EN_00/banner_var.ts
@@ -18,12 +18,8 @@ import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { WindowPageScroller } from '@src/utils/PageScroller/WindowPageScroller';
 import { Locales } from '@src/domain/Locales';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
-
-// Content for EN banners
 import messages from './messages';
 import { LocaleFactoryEn } from '@src/utils/LocaleFactory/LocaleFactoryEn';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/mobile_english/C24_WMDE_Mobile_EN_01/banner_ctrl.ts
+++ b/banners/mobile_english/C24_WMDE_Mobile_EN_01/banner_ctrl.ts
@@ -26,6 +26,7 @@ import { createFormActions } from '@src/createFormActions';
 // Content for EN banners
 import messages from './messages';
 import { LocaleFactoryEn } from '@src/utils/LocaleFactory/LocaleFactoryEn';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryEn();
 const translator = new Translator( messages );
@@ -65,5 +66,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { locale: Locales.EN } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/mobile_english/C24_WMDE_Mobile_EN_01/banner_ctrl.ts
+++ b/banners/mobile_english/C24_WMDE_Mobile_EN_01/banner_ctrl.ts
@@ -18,12 +18,8 @@ import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { WindowPageScroller } from '@src/utils/PageScroller/WindowPageScroller';
 import { Locales } from '@src/domain/Locales';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
-
-// Content for EN banners
 import messages from './messages';
 import { LocaleFactoryEn } from '@src/utils/LocaleFactory/LocaleFactoryEn';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/mobile_english/C24_WMDE_Mobile_EN_01/banner_var.ts
+++ b/banners/mobile_english/C24_WMDE_Mobile_EN_01/banner_var.ts
@@ -26,6 +26,7 @@ import { createFormActions } from '@src/createFormActions';
 // Content for EN banners
 import messages from './messages';
 import { LocaleFactoryEn } from '@src/utils/LocaleFactory/LocaleFactoryEn';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryEn();
 const translator = new Translator( messages );
@@ -65,5 +66,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { locale: Locales.EN } ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/mobile_english/C24_WMDE_Mobile_EN_01/banner_var.ts
+++ b/banners/mobile_english/C24_WMDE_Mobile_EN_01/banner_var.ts
@@ -18,12 +18,8 @@ import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { WindowPageScroller } from '@src/utils/PageScroller/WindowPageScroller';
 import { Locales } from '@src/domain/Locales';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
-
-// Content for EN banners
 import messages from './messages';
 import { LocaleFactoryEn } from '@src/utils/LocaleFactory/LocaleFactoryEn';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/pad/C24_WMDE_iPad_00/banner_ctrl.ts
+++ b/banners/pad/C24_WMDE_iPad_00/banner_ctrl.ts
@@ -24,6 +24,7 @@ import { createFormActions } from '@src/createFormActions';
 // Content
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryDe();
 const translator = new Translator( messages );
@@ -63,5 +64,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/pad/C24_WMDE_iPad_00/banner_ctrl.ts
+++ b/banners/pad/C24_WMDE_iPad_00/banner_ctrl.ts
@@ -16,12 +16,8 @@ import eventMappings from './event_map';
 import { Translator } from '@src/Translator';
 import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
-
-// Content
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/pad/C24_WMDE_iPad_00/banner_var.ts
+++ b/banners/pad/C24_WMDE_iPad_00/banner_var.ts
@@ -24,6 +24,7 @@ import { createFormActions } from '@src/createFormActions';
 // Content
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryDe();
 const translator = new Translator( messages );
@@ -63,5 +64,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/pad/C24_WMDE_iPad_00/banner_var.ts
+++ b/banners/pad/C24_WMDE_iPad_00/banner_var.ts
@@ -16,12 +16,8 @@ import eventMappings from './event_map';
 import { Translator } from '@src/Translator';
 import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
-
-// Channel specific form setup
 import { createFormItems } from './form_items_var';
 import { createFormActions } from '@src/createFormActions';
-
-// Content
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/pad/C24_WMDE_iPad_DE_01/banner_ctrl.ts
+++ b/banners/pad/C24_WMDE_iPad_DE_01/banner_ctrl.ts
@@ -24,6 +24,7 @@ import { createFormActions } from '@src/createFormActions';
 // Content
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryDe();
 const translator = new Translator( messages );
@@ -63,5 +64,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/pad/C24_WMDE_iPad_DE_01/banner_ctrl.ts
+++ b/banners/pad/C24_WMDE_iPad_DE_01/banner_ctrl.ts
@@ -16,12 +16,8 @@ import eventMappings from './event_map';
 import { Translator } from '@src/Translator';
 import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
-
-// Content
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/pad/C24_WMDE_iPad_DE_01/banner_var.ts
+++ b/banners/pad/C24_WMDE_iPad_DE_01/banner_var.ts
@@ -24,6 +24,7 @@ import { createFormActions } from '@src/createFormActions';
 // Content
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryDe();
 const translator = new Translator( messages );
@@ -63,5 +64,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/pad/C24_WMDE_iPad_DE_01/banner_var.ts
+++ b/banners/pad/C24_WMDE_iPad_DE_01/banner_var.ts
@@ -16,12 +16,8 @@ import eventMappings from './event_map';
 import { Translator } from '@src/Translator';
 import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
-
-// Channel specific form setup
 import { createFormItems } from './form_items_var';
 import { createFormActions } from '@src/createFormActions';
-
-// Content
 import messages from './messages';
 import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/thank_you/banner_ctrl.de.ts
+++ b/banners/thank_you/banner_ctrl.de.ts
@@ -21,6 +21,7 @@ import { createTrackedURL, SUBSCRIBE_URL, USE_OF_FUNDS_URL } from './createTrack
 import { createThankYouSettings } from './settings';
 import { IntegerDe } from '@src/utils/DynamicContent/formatters/IntegerDe';
 import { Locales } from '@src/domain/Locales';
+import { WindowTimer } from '@src/utils/Timer';
 
 const translator = new Translator( messages );
 const mediaWiki = new WindowMediaWiki();
@@ -48,5 +49,6 @@ const app = createVueApp( BannerConductor, {
 app.use( TranslationPlugin, translator );
 app.provide( 'tracker', tracker );
 app.provide( 'formActions', new TrackingMembershipFormActions( page.getTracking(), impressionCount, Locales.DE ) );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/thank_you/banner_ctrl.en.ts
+++ b/banners/thank_you/banner_ctrl.en.ts
@@ -21,6 +21,7 @@ import { createTrackedURL, SUBSCRIBE_URL, USE_OF_FUNDS_URL } from './createTrack
 import { createThankYouSettings } from './settings';
 import { IntegerEn } from '@src/utils/DynamicContent/formatters/IntegerEn';
 import { Locales } from '@src/domain/Locales';
+import { WindowTimer } from '@src/utils/Timer';
 
 const translator = new Translator( messages );
 const mediaWiki = new WindowMediaWiki();
@@ -48,5 +49,6 @@ const app = createVueApp( BannerConductor, {
 app.use( TranslationPlugin, translator );
 app.provide( 'tracker', tracker );
 app.provide( 'formActions', new TrackingMembershipFormActions( page.getTracking(), impressionCount, Locales.EN ) );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/thank_you/banner_ctrl.wpde.ts
+++ b/banners/thank_you/banner_ctrl.wpde.ts
@@ -17,6 +17,7 @@ import eventMap from './event_map.wpde';
 import { createThankYouSettings } from './settings';
 import { IntegerDe } from '@src/utils/DynamicContent/formatters/IntegerDe';
 import { Locales } from '@src/domain/Locales';
+import { WindowTimer } from '@src/utils/Timer';
 
 // Tracking placeholders will be replaced by webpack string-replace-loader
 // using the campaign configuration ( campaign_info.toml ) for the correct values
@@ -50,5 +51,6 @@ const app = createVueApp( BannerConductor, {
 app.use( TranslationPlugin, translator );
 app.provide( 'tracker', tracker );
 app.provide( 'formActions', new TrackingMembershipFormActions( page.getTracking(), impressionCount, Locales.DE ) );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/thank_you/banner_var.de.ts
+++ b/banners/thank_you/banner_var.de.ts
@@ -21,6 +21,7 @@ import { createTrackedURL, SUBSCRIBE_URL, USE_OF_FUNDS_URL } from './createTrack
 import { createThankYouSettings } from './settings';
 import { IntegerDe } from '@src/utils/DynamicContent/formatters/IntegerDe';
 import { Locales } from '@src/domain/Locales';
+import { WindowTimer } from '@src/utils/Timer';
 
 const translator = new Translator( messages );
 const mediaWiki = new WindowMediaWiki();
@@ -48,5 +49,6 @@ const app = createVueApp( BannerConductor, {
 app.use( TranslationPlugin, translator );
 app.provide( 'tracker', tracker );
 app.provide( 'formActions', new TrackingMembershipFormActions( page.getTracking(), impressionCount, Locales.DE ) );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/thank_you/banner_var.en.ts
+++ b/banners/thank_you/banner_var.en.ts
@@ -21,6 +21,7 @@ import { createTrackedURL, SUBSCRIBE_URL, USE_OF_FUNDS_URL } from './createTrack
 import { createThankYouSettings } from './settings';
 import { IntegerEn } from '@src/utils/DynamicContent/formatters/IntegerEn';
 import { Locales } from '@src/domain/Locales';
+import { WindowTimer } from '@src/utils/Timer';
 
 const translator = new Translator( messages );
 const mediaWiki = new WindowMediaWiki();
@@ -48,5 +49,6 @@ const app = createVueApp( BannerConductor, {
 app.use( TranslationPlugin, translator );
 app.provide( 'tracker', tracker );
 app.provide( 'formActions', new TrackingMembershipFormActions( page.getTracking(), impressionCount, Locales.EN ) );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/thank_you/banner_var.wpde.ts
+++ b/banners/thank_you/banner_var.wpde.ts
@@ -17,6 +17,7 @@ import eventMap from './event_map.wpde';
 import { createThankYouSettings } from './settings';
 import { IntegerDe } from '@src/utils/DynamicContent/formatters/IntegerDe';
 import { Locales } from '@src/domain/Locales';
+import { WindowTimer } from '@src/utils/Timer';
 
 // Tracking placeholders will be replaced by webpack string-replace-loader
 // using the campaign configuration ( campaign_info.toml ) for the correct values
@@ -50,5 +51,6 @@ const app = createVueApp( BannerConductor, {
 app.use( TranslationPlugin, translator );
 app.provide( 'tracker', tracker );
 app.provide( 'formActions', new TrackingMembershipFormActions( page.getTracking(), impressionCount, Locales.DE ) );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/wpde_desktop/C24_WPDE_Desktop_00/banner_ctrl.ts
+++ b/banners/wpde_desktop/C24_WPDE_Desktop_00/banner_ctrl.ts
@@ -13,12 +13,8 @@ import eventMap from './event_map';
 import { Translator } from '@src/Translator';
 import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
-
-// Content
 import messages from './messages';
 import { LocaleFactoryWpDe } from '@src/utils/LocaleFactory/LocaleFactoryWpDe';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/wpde_desktop/C24_WPDE_Desktop_00/banner_ctrl.ts
+++ b/banners/wpde_desktop/C24_WPDE_Desktop_00/banner_ctrl.ts
@@ -21,6 +21,7 @@ import { createFormActions } from '@src/createFormActions';
 // Content
 import messages from './messages';
 import { LocaleFactoryWpDe } from '@src/utils/LocaleFactory/LocaleFactoryWpDe';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryWpDe();
 const translator = new Translator( messages );
@@ -67,5 +68,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/wpde_desktop/C24_WPDE_Desktop_00/banner_var.ts
+++ b/banners/wpde_desktop/C24_WPDE_Desktop_00/banner_var.ts
@@ -13,12 +13,8 @@ import eventMap from './event_map';
 import { Translator } from '@src/Translator';
 import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
-
-// Content
 import messages from './messages';
 import { LocaleFactoryWpDe } from '@src/utils/LocaleFactory/LocaleFactoryWpDe';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/wpde_desktop/C24_WPDE_Desktop_00/banner_var.ts
+++ b/banners/wpde_desktop/C24_WPDE_Desktop_00/banner_var.ts
@@ -21,6 +21,7 @@ import { createFormActions } from '@src/createFormActions';
 // Content
 import messages from './messages';
 import { LocaleFactoryWpDe } from '@src/utils/LocaleFactory/LocaleFactoryWpDe';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryWpDe();
 const translator = new Translator( messages );
@@ -67,5 +68,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/wpde_desktop/C24_WPDE_Desktop_01/banner_ctrl.ts
+++ b/banners/wpde_desktop/C24_WPDE_Desktop_01/banner_ctrl.ts
@@ -13,12 +13,8 @@ import eventMap from './event_map';
 import { Translator } from '@src/Translator';
 import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
-
-// Content
 import messages from './messages';
 import { LocaleFactoryWpDe } from '@src/utils/LocaleFactory/LocaleFactoryWpDe';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/wpde_desktop/C24_WPDE_Desktop_01/banner_ctrl.ts
+++ b/banners/wpde_desktop/C24_WPDE_Desktop_01/banner_ctrl.ts
@@ -21,6 +21,7 @@ import { createFormActions } from '@src/createFormActions';
 // Content
 import messages from './messages';
 import { LocaleFactoryWpDe } from '@src/utils/LocaleFactory/LocaleFactoryWpDe';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryWpDe();
 const translator = new Translator( messages );
@@ -67,5 +68,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/wpde_desktop/C24_WPDE_Desktop_01/banner_var.ts
+++ b/banners/wpde_desktop/C24_WPDE_Desktop_01/banner_var.ts
@@ -13,12 +13,8 @@ import eventMap from './event_map';
 import { Translator } from '@src/Translator';
 import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
-
-// Content
 import messages from './messages';
 import { LocaleFactoryWpDe } from '@src/utils/LocaleFactory/LocaleFactoryWpDe';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/wpde_desktop/C24_WPDE_Desktop_01/banner_var.ts
+++ b/banners/wpde_desktop/C24_WPDE_Desktop_01/banner_var.ts
@@ -21,6 +21,7 @@ import { createFormActions } from '@src/createFormActions';
 // Content
 import messages from './messages';
 import { LocaleFactoryWpDe } from '@src/utils/LocaleFactory/LocaleFactoryWpDe';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryWpDe();
 const translator = new Translator( messages );
@@ -67,5 +68,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/wpde_mobile/C24_WPDE_Mobile_00/banner_ctrl.ts
+++ b/banners/wpde_mobile/C24_WPDE_Mobile_00/banner_ctrl.ts
@@ -22,6 +22,7 @@ import { createFormActions } from '@src/createFormActions';
 // Content
 import messages from './messages';
 import { LocaleFactoryWpDe } from '@src/utils/LocaleFactory/LocaleFactoryWpDe';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryWpDe();
 const translator = new Translator( messages );
@@ -68,5 +69,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/wpde_mobile/C24_WPDE_Mobile_00/banner_ctrl.ts
+++ b/banners/wpde_mobile/C24_WPDE_Mobile_00/banner_ctrl.ts
@@ -14,12 +14,8 @@ import eventMap from './event_map';
 import { Translator } from '@src/Translator';
 import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
-
-// Content
 import messages from './messages';
 import { LocaleFactoryWpDe } from '@src/utils/LocaleFactory/LocaleFactoryWpDe';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/wpde_mobile/C24_WPDE_Mobile_00/banner_var.ts
+++ b/banners/wpde_mobile/C24_WPDE_Mobile_00/banner_var.ts
@@ -22,6 +22,7 @@ import { createFormActions } from '@src/createFormActions';
 // Content
 import messages from './messages';
 import { LocaleFactoryWpDe } from '@src/utils/LocaleFactory/LocaleFactoryWpDe';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryWpDe();
 const translator = new Translator( messages );
@@ -68,5 +69,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/wpde_mobile/C24_WPDE_Mobile_00/banner_var.ts
+++ b/banners/wpde_mobile/C24_WPDE_Mobile_00/banner_var.ts
@@ -14,12 +14,8 @@ import eventMap from './event_map';
 import { Translator } from '@src/Translator';
 import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
-
-// Content
 import messages from './messages';
 import { LocaleFactoryWpDe } from '@src/utils/LocaleFactory/LocaleFactoryWpDe';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/wpde_mobile/C24_WPDE_Mobile_01/banner_ctrl.ts
+++ b/banners/wpde_mobile/C24_WPDE_Mobile_01/banner_ctrl.ts
@@ -22,6 +22,7 @@ import { createFormActions } from '@src/createFormActions';
 // Content
 import messages from './messages';
 import { LocaleFactoryWpDe } from '@src/utils/LocaleFactory/LocaleFactoryWpDe';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryWpDe();
 const translator = new Translator( messages );
@@ -68,5 +69,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/wpde_mobile/C24_WPDE_Mobile_01/banner_ctrl.ts
+++ b/banners/wpde_mobile/C24_WPDE_Mobile_01/banner_ctrl.ts
@@ -14,12 +14,8 @@ import eventMap from './event_map';
 import { Translator } from '@src/Translator';
 import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
-
-// Content
 import messages from './messages';
 import { LocaleFactoryWpDe } from '@src/utils/LocaleFactory/LocaleFactoryWpDe';
 import { WindowTimer } from '@src/utils/Timer';

--- a/banners/wpde_mobile/C24_WPDE_Mobile_01/banner_var.ts
+++ b/banners/wpde_mobile/C24_WPDE_Mobile_01/banner_var.ts
@@ -22,6 +22,7 @@ import { createFormActions } from '@src/createFormActions';
 // Content
 import messages from './messages';
 import { LocaleFactoryWpDe } from '@src/utils/LocaleFactory/LocaleFactoryWpDe';
+import { WindowTimer } from '@src/utils/Timer';
 
 const localeFactory = new LocaleFactoryWpDe();
 const translator = new Translator( messages );
@@ -68,5 +69,6 @@ app.provide( 'currencyFormatter', currencyFormatter );
 app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
 app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
 app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
 
 app.mount( page.getBannerContainer() );

--- a/banners/wpde_mobile/C24_WPDE_Mobile_01/banner_var.ts
+++ b/banners/wpde_mobile/C24_WPDE_Mobile_01/banner_var.ts
@@ -14,12 +14,8 @@ import eventMap from './event_map';
 import { Translator } from '@src/Translator';
 import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
-
-// Channel specific form setup
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
-
-// Content
 import messages from './messages';
 import { LocaleFactoryWpDe } from '@src/utils/LocaleFactory/LocaleFactoryWpDe';
 import { WindowTimer } from '@src/utils/Timer';

--- a/package-lock.json
+++ b/package-lock.json
@@ -6637,7 +6637,8 @@
     },
     "node_modules/fundraising-frontend-content": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/wmde/fundraising-frontend-content.git#7885b65b3892c6e32ec94548a2f901e7323fe439"
+      "resolved": "git+ssh://git@github.com/wmde/fundraising-frontend-content.git#a15a417b75aba9b485df180e537047b4b47f065a",
+      "license": "CC0-1.0"
     },
     "node_modules/get-intrinsic": {
       "version": "1.2.4",

--- a/src/components/BannerConductor/BannerConductor.vue
+++ b/src/components/BannerConductor/BannerConductor.vue
@@ -31,6 +31,7 @@ import { Tracker } from '@src/tracking/Tracker';
 import { TrackingEvent } from '@src/tracking/TrackingEvent';
 import { CloseEvent } from '@src/tracking/events/CloseEvent';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+import { Timer } from '@src/utils/Timer';
 
 interface Props {
 	page: Page,
@@ -45,9 +46,10 @@ const props = withDefaults( defineProps<Props>(), {
 	bannerProps: (): any => {}
 } );
 const tracker = inject<Tracker>( 'tracker' );
+const timer = inject<Timer>( 'timer' );
 
 const bannerRef = ref( null );
-const stateFactory = newStateFactory( props.bannerConfig, props.page, tracker, props.resizeHandler, props.impressionCount );
+const stateFactory = newStateFactory( props.bannerConfig, props.page, tracker, props.resizeHandler, props.impressionCount, timer );
 const bannerState = ref<BannerState>( stateFactory.newInitialState() );
 const stateMachine = newBannerStateMachine( bannerState );
 

--- a/src/components/BannerConductor/FallbackBannerConductor.vue
+++ b/src/components/BannerConductor/FallbackBannerConductor.vue
@@ -32,6 +32,7 @@ import { TrackingEvent, TrackingFeatureName } from '@src/tracking/TrackingEvent'
 import { CloseEvent } from '@src/tracking/events/CloseEvent';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
 import { BannerNotShownReasons } from '@src/page/BannerNotShownReasons';
+import { Timer } from '@src/utils/Timer';
 
 interface Props {
 	page: Page,
@@ -48,10 +49,11 @@ const props = withDefaults( defineProps<Props>(), {
 	bannerProps: (): any => {}
 } );
 const tracker = inject<Tracker>( 'tracker' );
+const timer = inject<Timer>( 'timer' );
 
 const banner = shallowRef<Object>( props.banner );
 const bannerRef = ref( null );
-const stateFactory = newStateFactory( props.bannerConfig, props.page, tracker, props.resizeHandler, props.impressionCount );
+const stateFactory = newStateFactory( props.bannerConfig, props.page, tracker, props.resizeHandler, props.impressionCount, timer );
 const bannerState = ref<BannerState>( stateFactory.newInitialState() );
 const stateMachine = newBannerStateMachine( bannerState );
 

--- a/src/components/BannerConductor/StateMachine/states/ClosedState.ts
+++ b/src/components/BannerConductor/StateMachine/states/ClosedState.ts
@@ -4,6 +4,7 @@ import { Page } from '@src/page/Page';
 import { Tracker } from '@src/tracking/Tracker';
 import { ResizeHandler } from '@src/utils/ResizeHandler';
 import { TrackingEvent } from '@src/tracking/TrackingEvent';
+import { Timer } from '@src/utils/Timer';
 
 export class ClosedState extends BannerState {
 	public readonly stateName: BannerStates = BannerStates.Closed;
@@ -11,13 +12,21 @@ export class ClosedState extends BannerState {
 	private _page: Page;
 	private _tracker: Tracker;
 	private _resizeHandler: ResizeHandler;
+	private _timer: Timer;
 
-	public constructor( closeEvent: TrackingEvent<void>, page: Page, tracker: Tracker, resizeHandler: ResizeHandler ) {
+	public constructor(
+		closeEvent: TrackingEvent<void>,
+		page: Page,
+		tracker: Tracker,
+		resizeHandler: ResizeHandler,
+		timer: Timer
+	) {
 		super();
 		this._closeEvent = closeEvent;
 		this._page = page;
 		this._tracker = tracker;
 		this._resizeHandler = resizeHandler;
+		this._timer = timer;
 	}
 
 	public enter(): Promise<any> {
@@ -28,6 +37,7 @@ export class ClosedState extends BannerState {
 			.setCloseCookieIfNecessary( this._closeEvent )
 			.removePageEventListeners();
 		this._resizeHandler.onClose();
+		this._timer.clearAll();
 		return Promise.resolve();
 	}
 

--- a/src/components/BannerConductor/StateMachine/states/NotShownState.ts
+++ b/src/components/BannerConductor/StateMachine/states/NotShownState.ts
@@ -5,6 +5,7 @@ import { Page } from '@src/page/Page';
 import { Tracker } from '@src/tracking/Tracker';
 import { NotShownEvent } from '@src/tracking/events/NotShownEvent';
 import { ResizeHandler } from '@src/utils/ResizeHandler';
+import { Timer } from '@src/utils/Timer';
 
 export class NotShownState extends BannerState {
 	public readonly stateName: BannerStates = BannerStates.NotShown;
@@ -13,14 +14,23 @@ export class NotShownState extends BannerState {
 	private _tracker: Tracker;
 	private _resizeHandler: ResizeHandler;
 	private _bannerHeight: number;
+	private _timer: Timer;
 
-	public constructor( bannerNotShownReason: BannerNotShownReasons, page: Page, tracker: Tracker, resizeHandler: ResizeHandler, bannerHeight: number ) {
+	public constructor(
+		bannerNotShownReason: BannerNotShownReasons,
+		page: Page,
+		tracker: Tracker,
+		resizeHandler: ResizeHandler,
+		bannerHeight: number,
+		timer: Timer
+	) {
 		super();
 		this._bannerNotShownReason = bannerNotShownReason;
 		this._page = page;
 		this._tracker = tracker;
 		this._resizeHandler = resizeHandler;
 		this._bannerHeight = bannerHeight;
+		this._timer = timer;
 	}
 
 	public enter(): Promise<any> {
@@ -34,6 +44,7 @@ export class NotShownState extends BannerState {
 			.preventImpressionCountForHiddenBanner()
 			.removePageEventListeners();
 		this._resizeHandler.onClose();
+		this._timer.clearAll();
 		return Promise.resolve( true );
 	}
 

--- a/src/components/BannerConductor/StateMachine/states/PendingState.ts
+++ b/src/components/BannerConductor/StateMachine/states/PendingState.ts
@@ -1,20 +1,23 @@
 import { BannerState } from '@src/components/BannerConductor/StateMachine/states/BannerState';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
 import { Page } from '@src/page/Page';
+import { Timer } from '@src/utils/Timer';
 
 export class PendingState extends BannerState {
 	public readonly stateName: BannerStates = BannerStates.Pending;
-	private _timer: ReturnType<typeof setTimeout>;
+	private _timer: Timer;
+	private _timerId: number;
 	private _page: Page;
 	private readonly _bannerHeight: number;
 	private readonly _delay: number;
 
-	public constructor( page: Page, bannerHeight: number, delay: number ) {
+	public constructor( page: Page, bannerHeight: number, delay: number, timer: Timer ) {
 		super();
 
 		this._page = page;
 		this._bannerHeight = bannerHeight;
 		this._delay = delay;
+		this._timer = timer;
 
 		this.canMoveToStates.push( BannerStates.Showing );
 		this.canMoveToStates.push( BannerStates.Closed );
@@ -25,12 +28,12 @@ export class PendingState extends BannerState {
 		this._page.setSpace( this._bannerHeight );
 
 		return new Promise( ( resolve ) => {
-			this._timer = setTimeout( () => resolve( true ), this._delay );
+			this._timerId = this._timer.setTimeout( () => resolve( true ), this._delay );
 		} );
 	}
 
 	public exit(): Promise<any> {
-		clearTimeout( this._timer );
+		this._timer.clearTimeout( this._timerId );
 		return Promise.resolve();
 	}
 

--- a/src/components/BannerConductor/StateMachine/states/ShowingState.ts
+++ b/src/components/BannerConductor/StateMachine/states/ShowingState.ts
@@ -1,17 +1,20 @@
 import { BannerState } from '@src/components/BannerConductor/StateMachine/states/BannerState';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
 import { Page } from '@src/page/Page';
+import { Timer } from '@src/utils/Timer';
 
 export class ShowingState extends BannerState {
 	public readonly stateName: BannerStates = BannerStates.Showing;
-	private _timer: ReturnType<typeof setTimeout>;
+	private _timer: Timer;
+	private _timerId: number;
 	private _page: Page;
 	private readonly _transitionDuration: number;
 
-	public constructor( page: Page, transitionDuration: number ) {
+	public constructor( page: Page, transitionDuration: number, timer: Timer ) {
 		super();
 		this._page = page;
 		this._transitionDuration = transitionDuration;
+		this._timer = timer;
 
 		this.canMoveToStates.push( BannerStates.Visible );
 		this.canMoveToStates.push( BannerStates.Closed );
@@ -23,12 +26,12 @@ export class ShowingState extends BannerState {
 			.showBanner();
 
 		return new Promise( ( resolve ) => {
-			this._timer = setTimeout( () => resolve( true ), this._transitionDuration );
+			this._timerId = this._timer.setTimeout( () => resolve( true ), this._transitionDuration );
 		} );
 	}
 
 	public exit(): Promise<any> {
-		clearTimeout( this._timer );
+		this._timer.clearTimeout( this._timerId );
 		return Promise.resolve();
 	}
 

--- a/src/components/BannerConductor/StateMachine/states/StateFactory.ts
+++ b/src/components/BannerConductor/StateMachine/states/StateFactory.ts
@@ -12,6 +12,7 @@ import { ImpressionCount } from '@src/utils/ImpressionCount';
 import { ClosedState } from '@src/components/BannerConductor/StateMachine/states/ClosedState';
 import { InitialState } from '@src/components/BannerConductor/StateMachine/states/InitialState';
 import { TrackingEvent, TrackingFeatureName } from '@src/tracking/TrackingEvent';
+import { Timer } from '@src/utils/Timer';
 
 export class StateFactory {
 	private readonly _bannerConfig: BannerConfig;
@@ -19,13 +20,15 @@ export class StateFactory {
 	private readonly _tracker: Tracker;
 	private readonly _resizeHandler: ResizeHandler;
 	private readonly _impressionCount: ImpressionCount;
+	private readonly _timer: Timer;
 
-	public constructor( bannerConfig: BannerConfig, page: Page, tracker: Tracker, resizeHandler: ResizeHandler, impressionCount: ImpressionCount ) {
+	public constructor( bannerConfig: BannerConfig, page: Page, tracker: Tracker, resizeHandler: ResizeHandler, impressionCount: ImpressionCount, timer: Timer ) {
 		this._bannerConfig = bannerConfig;
 		this._page = page;
 		this._tracker = tracker;
 		this._resizeHandler = resizeHandler;
 		this._impressionCount = impressionCount;
+		this._timer = timer;
 	}
 
 	public newInitialState(): BannerState {
@@ -33,15 +36,15 @@ export class StateFactory {
 	}
 
 	public newPendingState( bannerHeight: number ): BannerState {
-		return new PendingState( this._page, bannerHeight, this._bannerConfig.delay );
+		return new PendingState( this._page, bannerHeight, this._bannerConfig.delay, this._timer );
 	}
 
 	public newNotShownState( bannerNotShownReason: BannerNotShownReasons, bannerHeight: number ): BannerState {
-		return new NotShownState( bannerNotShownReason, this._page, this._tracker, this._resizeHandler, bannerHeight );
+		return new NotShownState( bannerNotShownReason, this._page, this._tracker, this._resizeHandler, bannerHeight, this._timer );
 	}
 
 	public newShowingState(): BannerState {
-		return new ShowingState( this._page, this._bannerConfig.transitionDuration );
+		return new ShowingState( this._page, this._bannerConfig.transitionDuration, this._timer );
 	}
 
 	public newVisibleState( shownEventFeature: TrackingFeatureName ): BannerState {
@@ -49,16 +52,24 @@ export class StateFactory {
 	}
 
 	public newClosedState( closeEvent: TrackingEvent<void> ): BannerState {
-		return new ClosedState( closeEvent, this._page, this._tracker, this._resizeHandler );
+		return new ClosedState( closeEvent, this._page, this._tracker, this._resizeHandler, this._timer );
 	}
 }
 
-export function newStateFactory( bannerConfig: BannerConfig, page: Page, tracker: Tracker, resizeHandler: ResizeHandler, impressionCount: ImpressionCount ): StateFactory {
+export function newStateFactory(
+	bannerConfig: BannerConfig,
+	page: Page,
+	tracker: Tracker,
+	resizeHandler: ResizeHandler,
+	impressionCount: ImpressionCount,
+	timer: Timer
+): StateFactory {
 	return new StateFactory(
 		bannerConfig,
 		page,
 		tracker,
 		resizeHandler,
-		impressionCount
+		impressionCount,
+		timer
 	);
 }

--- a/src/components/DonationForm/MultiStepDonation.vue
+++ b/src/components/DonationForm/MultiStepDonation.vue
@@ -27,6 +27,7 @@ import { Tracker } from '@src/tracking/Tracker';
 import { TrackingEvent } from '@src/tracking/TrackingEvent';
 import { useFormAction } from '@src/components/composables/useFormAction';
 import { FormActions } from '@src/domain/FormActions';
+import { Timer } from '@src/utils/Timer';
 
 interface Props {
 	showErrorScrollLink?: boolean;
@@ -51,6 +52,7 @@ usedSlotNames.forEach( ( slotName: string, index: number ): void => {
 	slotNameIndices[ slotName ] = index;
 } );
 const tracker = inject<Tracker>( 'tracker' );
+const timer = inject<Timer>( 'timer' );
 const currentStepIndex = ref<number>( 0 );
 const defaultFormAction = useFormAction( inject<FormActions>( 'formActions' ) );
 const formAction = computed( (): string => {
@@ -70,7 +72,7 @@ const [ container, slider ] = useKeenSlider( {
 function onClick(): void {
 	// This is so the banner height is adjusted correctly if form errors change it when they appear
 	// We wait using setTimeout as nextTick() doesn't work here for some reason
-	setTimeout( () => {
+	timer.nextTick( () => {
 		emit( 'formInteraction' );
 	} );
 }
@@ -100,7 +102,7 @@ const onPrevious = async (): Promise<void> => {
 
 onMounted( () => {
 	// This fixes Keen Slider rendering a little early and not having the correct width
-	setTimeout( () => slider.value.update() );
+	timer.nextTick( () => slider.value.update() );
 } );
 
 </script>

--- a/src/components/Footer/SelectionInput.vue
+++ b/src/components/Footer/SelectionInput.vue
@@ -16,7 +16,8 @@
 
 <script setup lang="ts">
 
-import { ref } from 'vue';
+import { inject, ref } from 'vue';
+import { Timer } from '@src/utils/Timer';
 
 interface Props {
 	value: string;
@@ -27,9 +28,10 @@ defineProps<Props>();
 
 const inputRef = ref<HTMLInputElement>( null );
 const focused = ref<boolean>( false );
+const timer = inject<Timer>( 'timer' );
 
 const handleFocus = (): void => {
-	setTimeout( () => inputRef.value.setSelectionRange( 0, 9999 ), 1 );
+	timer.setTimeout( () => inputRef.value.setSelectionRange( 0, 9999 ), 1 );
 	focused.value = true;
 };
 

--- a/src/components/Slider/KeenSlider.vue
+++ b/src/components/Slider/KeenSlider.vue
@@ -34,11 +34,12 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue';
+import { inject, onMounted, ref, watch } from 'vue';
 import { KeenSliderOptions, useKeenSlider } from 'keen-slider/vue';
 import ChevronLeftIcon from '@src/components/Icons/ChevronLeftIcon.vue';
 import ChevronRightIcon from '@src/components/Icons/ChevronRightIcon.vue';
 import KeenSliderNavigation from '@src/components/Slider/KeenSliderNavigation.vue';
+import { Timer } from '@src/utils/Timer';
 
 enum SliderPlayingStates {
 	PENDING = 'wmde-banner-slider--pending',
@@ -69,7 +70,8 @@ const props = withDefaults( defineProps<Props>(), {
 const emit = defineEmits( [ 'slide-changed' ] );
 const sliderPlayingState = ref<SliderPlayingStates>( SliderPlayingStates.PENDING );
 const startAnimationTimeout = ref<number>( 0 );
-const timer = ref<number>( 0 );
+const timer = inject<Timer>( 'timer' );
+const timerId = ref<number>( 0 );
 
 const currentSlide = ref<number>( 0 );
 
@@ -87,15 +89,15 @@ const startAutoplay = (): void => {
 	if ( sliderPlayingState.value === SliderPlayingStates.PLAYING ) {
 		return;
 	}
-	startAnimationTimeout.value = window.setTimeout( () => {
-		timer.value = window.setInterval( slider.value.next, props.interval );
+	startAnimationTimeout.value = timer.setTimeout( () => {
+		timerId.value = timer.setInterval( slider.value.next, props.interval );
 		sliderPlayingState.value = SliderPlayingStates.PLAYING;
 	}, props.startDelay );
 };
 
 const stopAutoplay = (): void => {
-	clearInterval( timer.value );
-	clearTimeout( startAnimationTimeout.value );
+	timer.clearInterval( timerId.value );
+	timer.clearTimeout( startAnimationTimeout.value );
 	sliderPlayingState.value = SliderPlayingStates.STOPPED;
 };
 

--- a/src/components/SoftClose/SoftClose.vue
+++ b/src/components/SoftClose/SoftClose.vue
@@ -45,8 +45,9 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref } from 'vue';
+import { inject, onMounted, ref } from 'vue';
 import ButtonClose from '@src/components/ButtonClose/ButtonClose.vue';
+import { Timer } from '@src/utils/Timer';
 
 interface Props {
 	secondsTotal?: number;
@@ -58,33 +59,26 @@ const props = withDefaults( defineProps<Props>(), {
 	showCloseIcon: false
 } );
 
-const timer = ref<number>( 0 );
+const timer = inject<Timer>( 'timer' );
 const secondsRemaining = ref<number>( props.secondsTotal );
 
 const emit = defineEmits( [ 'close', 'maybeLater', 'timeOutClose' ] );
 
 const onMaybeLaterClick = (): void => {
-	window.clearInterval( timer.value );
 	emit( 'maybeLater' );
 };
 
 const onCloseClick = (): void => {
-	window.clearInterval( timer.value );
 	emit( 'close' );
 };
 
 onMounted( () => {
-	timer.value = window.setInterval( () => {
+	timer.setInterval( () => {
 		secondsRemaining.value = secondsRemaining.value - 1;
 		if ( secondsRemaining.value <= 0 ) {
-			window.clearInterval( timer.value );
 			emit( 'timeOutClose' );
 		}
 	}, 1000 );
-} );
-
-onUnmounted( () => {
-	window.clearInterval( timer.value );
 } );
 
 </script>

--- a/src/components/composables/useLiveDateAndTime.ts
+++ b/src/components/composables/useLiveDateAndTime.ts
@@ -1,5 +1,6 @@
-import { ref, Ref } from 'vue';
+import { inject, ref, Ref } from 'vue';
 import { DateAndTime } from '@src/utils/DynamicContent/DateAndTime';
+import { Timer } from '@src/utils/Timer';
 
 type ReturnType = {
 	liveDateAndTime: Ref<DateAndTime>;
@@ -8,17 +9,18 @@ type ReturnType = {
 }
 
 export function useLiveDateAndTime( getCurrentDateAndTime: () => DateAndTime ): ReturnType {
-	const timer = ref<number>( 0 );
+	const timer = inject<Timer>( 'timer' );
+	const timerId = ref<number>( 0 );
 	const liveDateAndTime = ref<DateAndTime>( getCurrentDateAndTime() );
 
 	const startTimer = (): void => {
-		timer.value = window.setInterval( () => {
+		timerId.value = timer.setInterval( () => {
 			liveDateAndTime.value = getCurrentDateAndTime();
 		}, 1000 );
 	};
 
 	const stopTimer = (): void => {
-		window.clearInterval( timer.value );
+		timer.clearInterval( timerId.value );
 	};
 
 	return {

--- a/src/utils/Timer.ts
+++ b/src/utils/Timer.ts
@@ -1,0 +1,56 @@
+export interface Timer {
+	setTimeout( fn: () => void, after: number ): number;
+	clearTimeout( id: number ): void;
+	setInterval( fn: () => void, after: number ): number;
+	clearInterval( id: number ): void;
+	clearAll(): void;
+	nextTick( fn: () => void ): void;
+}
+
+export class WindowTimer implements Timer {
+	private _intervals: number[] = [];
+	private _timers: number[] = [];
+
+	public setInterval( fn: () => void, after: number ): number {
+		const interval = window.setInterval( fn, after );
+		this._intervals.push( interval );
+		return interval;
+	}
+
+	public setTimeout( fn: () => void, after: number ): number {
+		const timer = window.setTimeout( fn, after );
+		this._timers.push( timer );
+		return timer;
+	}
+
+	public clearAll(): void {
+		this._intervals.forEach( id => window.clearInterval( id ) );
+		this._timers.forEach( id => window.clearTimeout( id ) );
+		this._intervals = [];
+		this._timers = [];
+	}
+
+	public clearInterval( id: number ): void {
+		const index = this._intervals.indexOf( id );
+		if ( index === -1 ) {
+			return;
+		}
+
+		window.clearInterval( id );
+		this._intervals.splice( index, 1 );
+	}
+
+	public clearTimeout( id: number ): void {
+		const index = this._timers.indexOf( id );
+		if ( index === -1 ) {
+			return;
+		}
+
+		window.clearTimeout( id );
+		this._timers.splice( index, 1 );
+	}
+
+	public nextTick( fn: () => void ): void {
+		window.setTimeout( fn );
+	}
+}

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_06/components/BannerCtrl.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_06/components/BannerCtrl.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test, vi } from 'vitest';
+import { beforeEach, describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '@banners/desktop/C24_WMDE_Desktop_DE_06/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -8,18 +8,15 @@ import { formItems } from '@test/banners/formItems';
 import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
 import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
-import {
-	bannerContentAnimatedTextFeatures,
-	bannerContentDateAndTimeFeatures,
-	bannerContentDisplaySwitchFeatures,
-	bannerContentFeatures
-} from '@test/features/BannerContent';
+import { bannerContentAnimatedTextFeatures, bannerContentDateAndTimeFeatures, bannerContentDisplaySwitchFeatures, bannerContentFeatures } from '@test/features/BannerContent';
 import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
 import { useFormModel } from '@src/components/composables/useFormModel';
 import { resetFormModel } from '@test/resetFormModel';
 import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 import { bannerMainFeatures } from '@test/features/MainBanner';
 import { formActionSwitchFeatures } from '@test/features/form_action_switch/MainDonation_UpgradeToYearlyButton';
+import { TimerStub } from '@test/fixtures/TimerStub';
+import { Timer } from '@src/utils/Timer';
 
 const formModel = useFormModel();
 const translator = ( key: string ): string => key;
@@ -28,15 +25,9 @@ describe( 'BannerCtrl.vue', () => {
 
 	beforeEach( () => {
 		resetFormModel( formModel );
-		vi.useFakeTimers();
 	} );
 
-	afterEach( () => {
-		vi.restoreAllMocks();
-		vi.useRealTimers();
-	} );
-
-	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
 		return mount( Banner, {
 			attachTo: document.body,
 			props: {
@@ -58,7 +49,8 @@ describe( 'BannerCtrl.vue', () => {
 					},
 					currencyFormatter: new CurrencyEn(),
 					formItems,
-					tracker: new TrackerStub()
+					tracker: new TrackerStub(),
+					timer: timer ?? new TimerStub()
 				}
 			}
 		} );

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_06/components/FallbackBanner.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_06/components/FallbackBanner.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test, vi } from 'vitest';
+import { describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import FallbackBanner from '@banners/desktop/C24_WMDE_Desktop_DE_06/components/FallbackBanner.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -8,19 +8,11 @@ import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 import { Tracker } from '@src/tracking/Tracker';
 import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { fallbackBannerFeatures, submitFeatures } from '@test/features/FallbackBanner';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 const translator = ( key: string ): string => key;
 
 describe( 'FallbackBanner.vue', () => {
-
-	beforeEach( () => {
-		vi.useFakeTimers();
-	} );
-
-	afterEach( () => {
-		vi.useRealTimers();
-	} );
-
 	const getWrapperAtWidth = ( width: number, dynamicContent: DynamicContent = null, tracker: Tracker = null ): VueWrapper<any> => {
 		Object.defineProperty( window, 'innerWidth', { writable: true, configurable: true, value: width } );
 		return mount( FallbackBanner, {
@@ -36,7 +28,8 @@ describe( 'FallbackBanner.vue', () => {
 				provide: {
 					translator: { translate: translator },
 					dynamicCampaignText: dynamicContent ?? newDynamicContent(),
-					tracker: tracker ?? new TrackerStub()
+					tracker: tracker ?? new TrackerStub(),
+					timer: new TimerStub()
 				}
 			}
 		} );

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_08/components/BannerCtrl.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_08/components/BannerCtrl.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test, vi } from 'vitest';
+import { beforeEach, describe, test, vi } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '@banners/desktop/C24_WMDE_Desktop_DE_08/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -8,7 +8,8 @@ import { formItems } from '@test/banners/formItems';
 import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
 import {
-	bannerContentAnimatedTextFeatures, bannerContentAverageDonationFeatures,
+	bannerContentAnimatedTextFeatures,
+	bannerContentAverageDonationFeatures,
 	bannerContentDateAndTimeFeatures,
 	bannerContentDisplaySwitchFeatures,
 	bannerContentFeatures
@@ -23,6 +24,8 @@ import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
 import { alreadyDonatedModalFeatures } from '@test/features/AlreadyDonatedModal';
 import { softCloseSubmitTrackingFeaturesDesktop } from '@test/features/SoftCloseSubmitTrackingDesktop';
 import { Tracker } from '@src/tracking/Tracker';
+import { Timer } from '@src/utils/Timer';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 const formModel = useFormModel();
 const translator = ( key: string ): string => key;
@@ -32,18 +35,12 @@ describe( 'BannerCtrl.vue', () => {
 
 	beforeEach( () => {
 		resetFormModel( formModel );
-		vi.useFakeTimers();
 		tracker = {
 			trackEvent: vi.fn()
 		};
 	} );
 
-	afterEach( () => {
-		vi.restoreAllMocks();
-		vi.useRealTimers();
-	} );
-
-	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
 		return mount( Banner, {
 			attachTo: document.body,
 			props: {
@@ -69,7 +66,8 @@ describe( 'BannerCtrl.vue', () => {
 					},
 					currencyFormatter: new CurrencyEn(),
 					formItems,
-					tracker
+					tracker,
+					timer: timer ?? new TimerStub()
 				}
 			}
 		} );
@@ -145,7 +143,7 @@ describe( 'BannerCtrl.vue', () => {
 		test.each( [
 			[ 'expectDoesNotShowSoftClose' ]
 		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper() );
+			await softCloseFeatures[ testName ]( getWrapper );
 		} );
 	} );
 

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_08/components/BannerVar.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_08/components/BannerVar.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test, vi } from 'vitest';
+import { beforeEach, describe, test, vi } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '@banners/desktop/C24_WMDE_Desktop_DE_08/components/BannerVar.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -7,12 +7,7 @@ import { useOfFundsContent } from '@test/banners/useOfFundsContent';
 import { formItems } from '@test/banners/formItems';
 import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
-import {
-	bannerContentAnimatedTextFeatures,
-	bannerContentDateAndTimeFeatures,
-	bannerContentDisplaySwitchFeatures,
-	bannerContentFeatures
-} from '@test/features/BannerContent';
+import { bannerContentAnimatedTextFeatures, bannerContentDateAndTimeFeatures, bannerContentDisplaySwitchFeatures, bannerContentFeatures } from '@test/features/BannerContent';
 import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
 import { useFormModel } from '@src/components/composables/useFormModel';
 import { resetFormModel } from '@test/resetFormModel';
@@ -23,6 +18,8 @@ import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
 import { alreadyDonatedModalFeatures } from '@test/features/AlreadyDonatedModal';
 import { softCloseSubmitTrackingFeaturesDesktop } from '@test/features/SoftCloseSubmitTrackingDesktop';
 import { Tracker } from '@src/tracking/Tracker';
+import { Timer } from '@src/utils/Timer';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 const formModel = useFormModel();
 const translator = ( key: string ): string => key;
@@ -32,18 +29,12 @@ describe( 'BannerVar.vue', () => {
 
 	beforeEach( () => {
 		resetFormModel( formModel );
-		vi.useFakeTimers();
 		tracker = {
 			trackEvent: vi.fn()
 		};
 	} );
 
-	afterEach( () => {
-		vi.restoreAllMocks();
-		vi.useRealTimers();
-	} );
-
-	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
 		return mount( Banner, {
 			attachTo: document.body,
 			props: {
@@ -69,7 +60,8 @@ describe( 'BannerVar.vue', () => {
 					},
 					currencyFormatter: new CurrencyEn(),
 					formItems,
-					tracker
+					tracker,
+					timer: timer ?? new TimerStub()
 				}
 			}
 		} );
@@ -144,7 +136,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper() );
+			await softCloseFeatures[ testName ]( getWrapper );
 		} );
 	} );
 

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_08/components/FallbackBanner.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_08/components/FallbackBanner.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test, vi } from 'vitest';
+import { describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import FallbackBanner from '@banners/desktop/C24_WMDE_Desktop_DE_08/components/FallbackBanner.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -8,19 +8,11 @@ import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 import { Tracker } from '@src/tracking/Tracker';
 import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { fallbackBannerFeatures, submitFeatures } from '@test/features/FallbackBanner';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 const translator = ( key: string ): string => key;
 
 describe( 'FallbackBanner.vue', () => {
-
-	beforeEach( () => {
-		vi.useFakeTimers();
-	} );
-
-	afterEach( () => {
-		vi.useRealTimers();
-	} );
-
 	const getWrapperAtWidth = ( width: number, dynamicContent: DynamicContent = null, tracker: Tracker = null ): VueWrapper<any> => {
 		Object.defineProperty( window, 'innerWidth', { writable: true, configurable: true, value: width } );
 		return mount( FallbackBanner, {
@@ -36,7 +28,8 @@ describe( 'FallbackBanner.vue', () => {
 				provide: {
 					translator: { translate: translator },
 					dynamicCampaignText: dynamicContent ?? newDynamicContent(),
-					tracker: tracker ?? new TrackerStub()
+					tracker: tracker ?? new TrackerStub(),
+					timer: new TimerStub()
 				}
 			}
 		} );

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_09/components/BannerCtrl.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_09/components/BannerCtrl.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test, vi } from 'vitest';
+import { beforeEach, describe, test, vi } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '@banners/desktop/C24_WMDE_Desktop_DE_09/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -7,12 +7,7 @@ import { useOfFundsContent } from '@test/banners/useOfFundsContent';
 import { formItems } from '@test/banners/formItems';
 import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
-import {
-	bannerContentAnimatedTextFeatures,
-	bannerContentDateAndTimeFeatures,
-	bannerContentDisplaySwitchFeatures,
-	bannerContentFeatures
-} from '@test/features/BannerContent';
+import { bannerContentAnimatedTextFeatures, bannerContentDateAndTimeFeatures, bannerContentDisplaySwitchFeatures, bannerContentFeatures } from '@test/features/BannerContent';
 import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
 import { useFormModel } from '@src/components/composables/useFormModel';
 import { resetFormModel } from '@test/resetFormModel';
@@ -23,6 +18,8 @@ import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
 import { alreadyDonatedModalFeatures } from '@test/features/AlreadyDonatedModal';
 import { softCloseSubmitTrackingFeaturesDesktop } from '@test/features/SoftCloseSubmitTrackingDesktop';
 import { Tracker } from '@src/tracking/Tracker';
+import { Timer } from '@src/utils/Timer';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 const formModel = useFormModel();
 const translator = ( key: string ): string => key;
@@ -32,18 +29,12 @@ describe( 'BannerVar.vue', () => {
 
 	beforeEach( () => {
 		resetFormModel( formModel );
-		vi.useFakeTimers();
 		tracker = {
 			trackEvent: vi.fn()
 		};
 	} );
 
-	afterEach( () => {
-		vi.restoreAllMocks();
-		vi.useRealTimers();
-	} );
-
-	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
 		return mount( Banner, {
 			attachTo: document.body,
 			props: {
@@ -69,7 +60,8 @@ describe( 'BannerVar.vue', () => {
 					},
 					currencyFormatter: new CurrencyEn(),
 					formItems,
-					tracker
+					tracker,
+					timer: timer ?? new TimerStub()
 				}
 			}
 		} );
@@ -144,7 +136,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper() );
+			await softCloseFeatures[ testName ]( getWrapper );
 		} );
 	} );
 

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_09/components/BannerVar.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_09/components/BannerVar.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test, vi } from 'vitest';
+import { beforeEach, describe, test, vi } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '@banners/desktop/C24_WMDE_Desktop_DE_09/components/BannerVar.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -7,12 +7,7 @@ import { useOfFundsContent } from '@test/banners/useOfFundsContent';
 import { formItems } from '@test/banners/formItems';
 import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
-import {
-	bannerContentAnimatedTextFeatures,
-	bannerContentDateAndTimeFeatures,
-	bannerContentDisplaySwitchFeatures,
-	bannerContentFeatures
-} from '@test/features/BannerContent';
+import { bannerContentAnimatedTextFeatures, bannerContentDateAndTimeFeatures, bannerContentDisplaySwitchFeatures, bannerContentFeatures } from '@test/features/BannerContent';
 import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
 import { useFormModel } from '@src/components/composables/useFormModel';
 import { resetFormModel } from '@test/resetFormModel';
@@ -23,6 +18,8 @@ import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
 import { alreadyDonatedModalFeatures } from '@test/features/AlreadyDonatedModal';
 import { softCloseSubmitTrackingFeaturesDesktop } from '@test/features/SoftCloseSubmitTrackingDesktop';
 import { Tracker } from '@src/tracking/Tracker';
+import { TimerStub } from '@test/fixtures/TimerStub';
+import { Timer } from '@src/utils/Timer';
 
 const formModel = useFormModel();
 const translator = ( key: string ): string => key;
@@ -32,18 +29,12 @@ describe( 'BannerVar.vue', () => {
 
 	beforeEach( () => {
 		resetFormModel( formModel );
-		vi.useFakeTimers();
 		tracker = {
 			trackEvent: vi.fn()
 		};
 	} );
 
-	afterEach( () => {
-		vi.restoreAllMocks();
-		vi.useRealTimers();
-	} );
-
-	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
 		return mount( Banner, {
 			attachTo: document.body,
 			props: {
@@ -69,7 +60,8 @@ describe( 'BannerVar.vue', () => {
 					},
 					currencyFormatter: new CurrencyEn(),
 					formItems,
-					tracker
+					tracker,
+					timer: timer ?? new TimerStub()
 				}
 			}
 		} );
@@ -144,7 +136,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper() );
+			await softCloseFeatures[ testName ]( getWrapper );
 		} );
 	} );
 

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_09/components/FallbackBanner.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_09/components/FallbackBanner.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test, vi } from 'vitest';
+import { describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import FallbackBanner from '@banners/desktop/C24_WMDE_Desktop_DE_09/components/FallbackBanner.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -8,19 +8,11 @@ import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 import { Tracker } from '@src/tracking/Tracker';
 import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { fallbackBannerFeatures, submitFeatures } from '@test/features/FallbackBanner';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 const translator = ( key: string ): string => key;
 
 describe( 'FallbackBanner.vue', () => {
-
-	beforeEach( () => {
-		vi.useFakeTimers();
-	} );
-
-	afterEach( () => {
-		vi.useRealTimers();
-	} );
-
 	const getWrapperAtWidth = ( width: number, dynamicContent: DynamicContent = null, tracker: Tracker = null ): VueWrapper<any> => {
 		Object.defineProperty( window, 'innerWidth', { writable: true, configurable: true, value: width } );
 		return mount( FallbackBanner, {
@@ -36,7 +28,8 @@ describe( 'FallbackBanner.vue', () => {
 				provide: {
 					translator: { translate: translator },
 					dynamicCampaignText: dynamicContent ?? newDynamicContent(),
-					tracker: tracker ?? new TrackerStub()
+					tracker: tracker ?? new TrackerStub(),
+					timer: new TimerStub()
 				}
 			}
 		} );

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_10/components/BannerCtrl.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_10/components/BannerCtrl.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test, vi } from 'vitest';
+import { beforeEach, describe, test, vi } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '@banners/desktop/C24_WMDE_Desktop_DE_10/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -7,12 +7,7 @@ import { useOfFundsContent } from '@test/banners/useOfFundsContent';
 import { formItems } from '@test/banners/formItems';
 import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
-import {
-	bannerContentAnimatedTextFeatures,
-	bannerContentDateAndTimeFeatures,
-	bannerContentDisplaySwitchFeatures,
-	bannerContentFeatures
-} from '@test/features/BannerContent';
+import { bannerContentAnimatedTextFeatures, bannerContentDateAndTimeFeatures, bannerContentDisplaySwitchFeatures, bannerContentFeatures } from '@test/features/BannerContent';
 import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
 import { useFormModel } from '@src/components/composables/useFormModel';
 import { resetFormModel } from '@test/resetFormModel';
@@ -23,6 +18,8 @@ import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
 import { alreadyDonatedModalFeatures } from '@test/features/AlreadyDonatedModal';
 import { softCloseSubmitTrackingFeaturesDesktop } from '@test/features/SoftCloseSubmitTrackingDesktop';
 import { Tracker } from '@src/tracking/Tracker';
+import { TimerStub } from '@test/fixtures/TimerStub';
+import { Timer } from '@src/utils/Timer';
 
 const formModel = useFormModel();
 const translator = ( key: string ): string => key;
@@ -32,18 +29,12 @@ describe( 'BannerVar.vue', () => {
 
 	beforeEach( () => {
 		resetFormModel( formModel );
-		vi.useFakeTimers();
 		tracker = {
 			trackEvent: vi.fn()
 		};
 	} );
 
-	afterEach( () => {
-		vi.restoreAllMocks();
-		vi.useRealTimers();
-	} );
-
-	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
 		return mount( Banner, {
 			attachTo: document.body,
 			props: {
@@ -69,7 +60,8 @@ describe( 'BannerVar.vue', () => {
 					},
 					currencyFormatter: new CurrencyEn(),
 					formItems,
-					tracker
+					tracker,
+					timer: timer ?? new TimerStub()
 				}
 			}
 		} );
@@ -144,7 +136,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper() );
+			await softCloseFeatures[ testName ]( getWrapper );
 		} );
 	} );
 

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_10/components/BannerVar.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_10/components/BannerVar.spec.ts
@@ -7,12 +7,7 @@ import { useOfFundsContent } from '@test/banners/useOfFundsContent';
 import { formItems } from '@test/banners/formItems';
 import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
-import {
-	bannerContentAnimatedTextFeatures,
-	bannerContentDateAndTimeFeatures,
-	bannerContentDisplaySwitchFeatures,
-	bannerContentFeatures
-} from '@test/features/BannerContent';
+import { bannerContentAnimatedTextFeatures, bannerContentDateAndTimeFeatures, bannerContentDisplaySwitchFeatures, bannerContentFeatures } from '@test/features/BannerContent';
 import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
 import { useFormModel } from '@src/components/composables/useFormModel';
 import { resetFormModel } from '@test/resetFormModel';
@@ -23,6 +18,8 @@ import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
 import { alreadyDonatedModalFeatures } from '@test/features/AlreadyDonatedModal';
 import { softCloseSubmitTrackingFeaturesDesktop } from '@test/features/SoftCloseSubmitTrackingDesktop';
 import { Tracker } from '@src/tracking/Tracker';
+import { Timer } from '@src/utils/Timer';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 const formModel = useFormModel();
 const translator = ( key: string ): string => key;
@@ -43,7 +40,7 @@ describe( 'BannerVar.vue', () => {
 		vi.useRealTimers();
 	} );
 
-	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
 		return mount( Banner, {
 			attachTo: document.body,
 			props: {
@@ -69,7 +66,8 @@ describe( 'BannerVar.vue', () => {
 					},
 					currencyFormatter: new CurrencyEn(),
 					formItems,
-					tracker
+					tracker,
+					timer: timer ?? new TimerStub()
 				}
 			}
 		} );
@@ -144,7 +142,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper() );
+			await softCloseFeatures[ testName ]( getWrapper );
 		} );
 	} );
 

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_10/components/FallbackBanner.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_10/components/FallbackBanner.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test, vi } from 'vitest';
+import { describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import FallbackBanner from '@banners/desktop/C24_WMDE_Desktop_DE_10/components/FallbackBanner.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -8,20 +8,13 @@ import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 import { Tracker } from '@src/tracking/Tracker';
 import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { fallbackBannerFeatures, submitFeatures } from '@test/features/FallbackBanner';
+import { Timer } from '@src/utils/Timer';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 const translator = ( key: string ): string => key;
 
 describe( 'FallbackBanner.vue', () => {
-
-	beforeEach( () => {
-		vi.useFakeTimers();
-	} );
-
-	afterEach( () => {
-		vi.useRealTimers();
-	} );
-
-	const getWrapperAtWidth = ( width: number, dynamicContent: DynamicContent = null, tracker: Tracker = null ): VueWrapper<any> => {
+	const getWrapperAtWidth = ( width: number, dynamicContent: DynamicContent = null, tracker: Tracker = null, timer: Timer = null ): VueWrapper<any> => {
 		Object.defineProperty( window, 'innerWidth', { writable: true, configurable: true, value: width } );
 		return mount( FallbackBanner, {
 			props: {
@@ -36,7 +29,8 @@ describe( 'FallbackBanner.vue', () => {
 				provide: {
 					translator: { translate: translator },
 					dynamicCampaignText: dynamicContent ?? newDynamicContent(),
-					tracker: tracker ?? new TrackerStub()
+					tracker: tracker ?? new TrackerStub(),
+					timer: timer ?? new TimerStub()
 				}
 			}
 		} );

--- a/test/banners/english/C24_WMDE_Desktop_EN_02b/components/BannerCtrl.spec.ts
+++ b/test/banners/english/C24_WMDE_Desktop_EN_02b/components/BannerCtrl.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test, vi } from 'vitest';
+import { beforeEach, describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '@banners/english/C24_WMDE_Desktop_EN_02b/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -7,12 +7,7 @@ import { useOfFundsContent } from '@test/banners/useOfFundsContent';
 import { formItems } from '@test/banners/formItems';
 import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
-import {
-	bannerContentAnimatedTextFeatures,
-	bannerContentDateAndTimeFeatures,
-	bannerContentDisplaySwitchFeatures,
-	bannerContentFeatures
-} from '@test/features/BannerContent';
+import { bannerContentAnimatedTextFeatures, bannerContentDateAndTimeFeatures, bannerContentDisplaySwitchFeatures, bannerContentFeatures } from '@test/features/BannerContent';
 import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
 import { useFormModel } from '@src/components/composables/useFormModel';
@@ -21,6 +16,8 @@ import { bannerMainFeatures } from '@test/features/MainBanner';
 import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 import { alreadyDonatedModalFeatures } from '@test/features/AlreadyDonatedModal';
 import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
+import { Timer } from '@src/utils/Timer';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 const formModel = useFormModel();
 const translator = ( key: string ): string => key;
@@ -29,15 +26,9 @@ describe( 'BannerCtrl.vue', () => {
 
 	beforeEach( () => {
 		resetFormModel( formModel );
-		vi.useFakeTimers();
 	} );
 
-	afterEach( () => {
-		vi.restoreAllMocks();
-		vi.useRealTimers();
-	} );
-
-	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
 		return mount( Banner, {
 			attachTo: document.body,
 			props: {
@@ -55,7 +46,8 @@ describe( 'BannerCtrl.vue', () => {
 					formActions: { donateWithAddressAction: 'https://example.com', donateWithoutAddressAction: 'https://example.com' },
 					currencyFormatter: new CurrencyEn(),
 					formItems,
-					tracker: new TrackerStub()
+					tracker: new TrackerStub(),
+					timer: timer ?? new TimerStub()
 				}
 			}
 		} );
@@ -120,7 +112,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
 			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ]
 		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper() );
+			await softCloseFeatures[ testName ]( getWrapper );
 		} );
 	} );
 

--- a/test/banners/english/C24_WMDE_Desktop_EN_02b/components/FallbackBanner.spec.ts
+++ b/test/banners/english/C24_WMDE_Desktop_EN_02b/components/FallbackBanner.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test, vi } from 'vitest';
+import { describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import FallbackBanner from '@banners/english/C24_WMDE_Desktop_EN_02b/components/FallbackBanner.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -8,20 +8,13 @@ import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 import { Tracker } from '@src/tracking/Tracker';
 import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { dynamicContentFeatures, fallbackBannerFeatures, submitFeatures } from '@test/features/FallbackBanner';
+import { TimerStub } from '@test/fixtures/TimerStub';
+import { Timer } from '@src/utils/Timer';
 
 const translator = ( key: string ): string => key;
 
 describe( 'FallbackBanner.vue', () => {
-
-	beforeEach( () => {
-		vi.useFakeTimers();
-	} );
-
-	afterEach( () => {
-		vi.useRealTimers();
-	} );
-
-	const getWrapperAtWidth = ( width: number, dynamicContent: DynamicContent = null, tracker: Tracker = null ): VueWrapper<any> => {
+	const getWrapperAtWidth = ( width: number, dynamicContent: DynamicContent = null, tracker: Tracker = null, timer: Timer = null ): VueWrapper<any> => {
 		Object.defineProperty( window, 'innerWidth', { writable: true, configurable: true, value: width } );
 		return mount( FallbackBanner, {
 			props: {
@@ -36,7 +29,8 @@ describe( 'FallbackBanner.vue', () => {
 				provide: {
 					translator: { translate: translator },
 					dynamicCampaignText: dynamicContent ?? newDynamicContent(),
-					tracker: tracker ?? new TrackerStub()
+					tracker: tracker ?? new TrackerStub(),
+					timer: timer ?? new TimerStub()
 				}
 			}
 		} );

--- a/test/banners/english/C24_WMDE_Desktop_EN_03/components/BannerCtrl.spec.ts
+++ b/test/banners/english/C24_WMDE_Desktop_EN_03/components/BannerCtrl.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test, vi } from 'vitest';
+import { beforeEach, describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '@banners/english/C24_WMDE_Desktop_EN_03/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -7,12 +7,7 @@ import { useOfFundsContent } from '@test/banners/useOfFundsContent';
 import { formItems } from '@test/banners/formItems';
 import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
-import {
-	bannerContentAnimatedTextFeatures,
-	bannerContentDateAndTimeFeatures,
-	bannerContentDisplaySwitchFeatures,
-	bannerContentFeatures
-} from '@test/features/BannerContent';
+import { bannerContentAnimatedTextFeatures, bannerContentDateAndTimeFeatures, bannerContentDisplaySwitchFeatures, bannerContentFeatures } from '@test/features/BannerContent';
 import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
 import { useFormModel } from '@src/components/composables/useFormModel';
@@ -21,6 +16,8 @@ import { bannerMainFeatures } from '@test/features/MainBanner';
 import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 import { alreadyDonatedModalFeatures } from '@test/features/AlreadyDonatedModal';
 import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
+import { Timer } from '@src/utils/Timer';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 const formModel = useFormModel();
 const translator = ( key: string ): string => key;
@@ -29,15 +26,9 @@ describe( 'BannerCtrl.vue', () => {
 
 	beforeEach( () => {
 		resetFormModel( formModel );
-		vi.useFakeTimers();
 	} );
 
-	afterEach( () => {
-		vi.restoreAllMocks();
-		vi.useRealTimers();
-	} );
-
-	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
 		return mount( Banner, {
 			attachTo: document.body,
 			props: {
@@ -55,7 +46,8 @@ describe( 'BannerCtrl.vue', () => {
 					formActions: { donateWithAddressAction: 'https://example.com', donateWithoutAddressAction: 'https://example.com' },
 					currencyFormatter: new CurrencyEn(),
 					formItems,
-					tracker: new TrackerStub()
+					tracker: new TrackerStub(),
+					timer: timer ?? new TimerStub()
 				}
 			}
 		} );
@@ -120,7 +112,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
 			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ]
 		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper() );
+			await softCloseFeatures[ testName ]( getWrapper );
 		} );
 	} );
 

--- a/test/banners/english/C24_WMDE_Desktop_EN_03/components/BannerVar.spec.ts
+++ b/test/banners/english/C24_WMDE_Desktop_EN_03/components/BannerVar.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test, vi } from 'vitest';
+import { beforeEach, describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '@banners/english/C24_WMDE_Desktop_EN_03/components/BannerVar.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -7,12 +7,7 @@ import { useOfFundsContent } from '@test/banners/useOfFundsContent';
 import { formItems } from '@test/banners/formItems';
 import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
-import {
-	bannerContentAnimatedTextFeatures,
-	bannerContentDateAndTimeFeatures,
-	bannerContentDisplaySwitchFeatures,
-	bannerContentFeatures
-} from '@test/features/BannerContent';
+import { bannerContentAnimatedTextFeatures, bannerContentDateAndTimeFeatures, bannerContentDisplaySwitchFeatures, bannerContentFeatures } from '@test/features/BannerContent';
 import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
 import { useFormModel } from '@src/components/composables/useFormModel';
@@ -22,23 +17,18 @@ import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 import { alreadyDonatedModalFeatures } from '@test/features/AlreadyDonatedModal';
 import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
 import { donationFormTransactionFeeFeatures } from '@test/features/forms/MainDonation_TransactionFee';
+import { TimerStub } from '@test/fixtures/TimerStub';
+import { Timer } from '@src/utils/Timer';
 
 const formModel = useFormModel();
 const translator = ( key: string, context: any ): string => context ? `${key} -- ${Object.entries( context )}` : key;
 
 describe( 'BannerCtrl.vue', () => {
-
 	beforeEach( () => {
 		resetFormModel( formModel );
-		vi.useFakeTimers();
 	} );
 
-	afterEach( () => {
-		vi.restoreAllMocks();
-		vi.useRealTimers();
-	} );
-
-	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
 		return mount( Banner, {
 			attachTo: document.body,
 			props: {
@@ -56,7 +46,8 @@ describe( 'BannerCtrl.vue', () => {
 					formActions: { donateWithAddressAction: 'https://example.com', donateWithoutAddressAction: 'https://example.com' },
 					currencyFormatter: new CurrencyEn(),
 					formItems,
-					tracker: new TrackerStub()
+					tracker: new TrackerStub(),
+					timer: timer ?? new TimerStub()
 				}
 			}
 		} );
@@ -121,7 +112,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
 			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ]
 		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper() );
+			await softCloseFeatures[ testName ]( getWrapper );
 		} );
 	} );
 

--- a/test/banners/english/C24_WMDE_Desktop_EN_03/components/FallbackBanner.spec.ts
+++ b/test/banners/english/C24_WMDE_Desktop_EN_03/components/FallbackBanner.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test, vi } from 'vitest';
+import { describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import FallbackBanner from '@banners/english/C24_WMDE_Desktop_EN_03/components/FallbackBanner.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -8,20 +8,13 @@ import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 import { Tracker } from '@src/tracking/Tracker';
 import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { dynamicContentFeatures, fallbackBannerFeatures, submitFeatures } from '@test/features/FallbackBanner';
+import { TimerStub } from '@test/fixtures/TimerStub';
+import { Timer } from '@src/utils/Timer';
 
 const translator = ( key: string ): string => key;
 
 describe( 'FallbackBanner.vue', () => {
-
-	beforeEach( () => {
-		vi.useFakeTimers();
-	} );
-
-	afterEach( () => {
-		vi.useRealTimers();
-	} );
-
-	const getWrapperAtWidth = ( width: number, dynamicContent: DynamicContent = null, tracker: Tracker = null ): VueWrapper<any> => {
+	const getWrapperAtWidth = ( width: number, dynamicContent: DynamicContent = null, tracker: Tracker = null, timer: Timer = null ): VueWrapper<any> => {
 		Object.defineProperty( window, 'innerWidth', { writable: true, configurable: true, value: width } );
 		return mount( FallbackBanner, {
 			props: {
@@ -36,7 +29,8 @@ describe( 'FallbackBanner.vue', () => {
 				provide: {
 					translator: { translate: translator },
 					dynamicCampaignText: dynamicContent ?? newDynamicContent(),
-					tracker: tracker ?? new TrackerStub()
+					tracker: tracker ?? new TrackerStub(),
+					timer: timer ?? new TimerStub()
 				}
 			}
 		} );

--- a/test/banners/mobile/C24_WMDE_Mobile_DE_06/components/BannerCtrl.spec.ts
+++ b/test/banners/mobile/C24_WMDE_Mobile_DE_06/components/BannerCtrl.spec.ts
@@ -19,6 +19,8 @@ import { formActionSwitchFeatures } from '@test/features/form_action_switch/Main
 import { Tracker } from '@src/tracking/Tracker';
 import { bannerContentAnimatedTextFeatures, bannerContentDateAndTimeFeatures } from '@test/features/BannerContent';
 import { softCloseSubmitTrackingFeatures } from '@test/features/SoftCloseSubmitTracking';
+import { Timer } from '@src/utils/Timer';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 let pageScroller: PageScroller;
 let tracker: Tracker;
@@ -29,7 +31,6 @@ describe( 'BannerCtrl.vue', () => {
 	let wrapper: VueWrapper<any>;
 	beforeEach( () => {
 		resetFormModel( formModel );
-		vi.useFakeTimers();
 
 		pageScroller = {
 			scrollIntoView: vi.fn(),
@@ -41,7 +42,11 @@ describe( 'BannerCtrl.vue', () => {
 		};
 	} );
 
-	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
+	afterEach( () => {
+		wrapper.unmount();
+	} );
+
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
 		// attachTo the document body to fix an issue with Vue Test Utils where
 		// clicking a submit button in a form does not fire the submit event
 		wrapper = mount( Banner, {
@@ -66,19 +71,14 @@ describe( 'BannerCtrl.vue', () => {
 					formActions: { donateWithAddressAction: 'https://example.com/with-address', donateAnonymouslyAction: 'https://example.com/without-address' },
 					currencyFormatter: new CurrencyEn(),
 					formItems,
-					tracker
+					tracker,
+					timer: timer ?? new TimerStub()
 				}
 			}
 		} );
 
 		return wrapper;
 	};
-
-	afterEach( () => {
-		wrapper.unmount();
-		vi.restoreAllMocks();
-		vi.useRealTimers();
-	} );
 
 	describe( 'Content', () => {
 		test.each( [
@@ -128,7 +128,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
 			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ]
 		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper() );
+			await softCloseFeatures[ testName ]( getWrapper );
 		} );
 	} );
 

--- a/test/banners/mobile/C24_WMDE_Mobile_DE_06/components/BannerVar.spec.ts
+++ b/test/banners/mobile/C24_WMDE_Mobile_DE_06/components/BannerVar.spec.ts
@@ -19,6 +19,8 @@ import { formActionSwitchFeatures } from '@test/features/form_action_switch/Main
 import { Tracker } from '@src/tracking/Tracker';
 import { bannerContentAnimatedTextFeatures, bannerContentDateAndTimeFeatures } from '@test/features/BannerContent';
 import { softCloseSubmitTrackingFeatures } from '@test/features/SoftCloseSubmitTracking';
+import { Timer } from '@src/utils/Timer';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 let pageScroller: PageScroller;
 let tracker: Tracker;
@@ -29,7 +31,6 @@ describe( 'BannerVar.vue', () => {
 	let wrapper: VueWrapper<any>;
 	beforeEach( () => {
 		resetFormModel( formModel );
-		vi.useFakeTimers();
 
 		pageScroller = {
 			scrollIntoView: vi.fn(),
@@ -41,7 +42,11 @@ describe( 'BannerVar.vue', () => {
 		};
 	} );
 
-	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
+	afterEach( () => {
+		wrapper.unmount();
+	} );
+
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
 		// attachTo the document body to fix an issue with Vue Test Utils where
 		// clicking a submit button in a form does not fire the submit event
 		wrapper = mount( Banner, {
@@ -66,19 +71,14 @@ describe( 'BannerVar.vue', () => {
 					formActions: { donateWithAddressAction: 'https://example.com/with-address', donateAnonymouslyAction: 'https://example.com/without-address' },
 					currencyFormatter: new CurrencyEn(),
 					formItems,
-					tracker
+					tracker,
+					timer: timer ?? new TimerStub()
 				}
 			}
 		} );
 
 		return wrapper;
 	};
-
-	afterEach( () => {
-		wrapper.unmount();
-		vi.restoreAllMocks();
-		vi.useRealTimers();
-	} );
 
 	describe( 'Content', () => {
 		test.each( [
@@ -128,7 +128,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
 			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ]
 		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper() );
+			await softCloseFeatures[ testName ]( getWrapper );
 		} );
 	} );
 

--- a/test/banners/mobile_english/C24_WMDE_Mobile_EN_01/components/BannerCtrl.spec.ts
+++ b/test/banners/mobile_english/C24_WMDE_Mobile_EN_01/components/BannerCtrl.spec.ts
@@ -18,6 +18,8 @@ import { fullPageBannerFeatures } from '@test/features/FullPageBanner';
 import { formActionSwitchFeatures } from '@test/features/form_action_switch/MainDonation_UpgradeToYearlyButton';
 import { Tracker } from '@src/tracking/Tracker';
 import { bannerContentAnimatedTextFeatures, bannerContentDateAndTimeFeatures } from '@test/features/BannerContent';
+import { TimerStub } from '@test/fixtures/TimerStub';
+import { Timer } from '@src/utils/Timer';
 
 let pageScroller: PageScroller;
 let tracker: Tracker;
@@ -29,7 +31,6 @@ describe( 'BannerCtrl.vue', () => {
 	let wrapper: VueWrapper<any>;
 	beforeEach( () => {
 		resetFormModel( formModel );
-		vi.useFakeTimers();
 
 		pageScroller = {
 			scrollIntoView: vi.fn(),
@@ -41,7 +42,11 @@ describe( 'BannerCtrl.vue', () => {
 		};
 	} );
 
-	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
+	afterEach( () => {
+		wrapper.unmount();
+	} );
+
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
 		// attachTo the document body to fix an issue with Vue Test Utils where
 		// clicking a submit button in a form does not fire the submit event
 		wrapper = mount( Banner, {
@@ -63,19 +68,14 @@ describe( 'BannerCtrl.vue', () => {
 					formActions: { donateWithAddressAction: 'https://example.com/with-address', donateAnonymouslyAction: 'https://example.com/without-address' },
 					currencyFormatter: new CurrencyEn(),
 					formItems,
-					tracker
+					tracker,
+					timer: timer ?? new TimerStub()
 				}
 			}
 		} );
 
 		return wrapper;
 	};
-
-	afterEach( () => {
-		wrapper.unmount();
-		vi.restoreAllMocks();
-		vi.useRealTimers();
-	} );
 
 	describe( 'Content', () => {
 		test.skip.each( [
@@ -125,7 +125,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
 			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ]
 		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper() );
+			await softCloseFeatures[ testName ]( getWrapper );
 		} );
 	} );
 

--- a/test/banners/mobile_english/C24_WMDE_Mobile_EN_01/components/BannerVar.spec.ts
+++ b/test/banners/mobile_english/C24_WMDE_Mobile_EN_01/components/BannerVar.spec.ts
@@ -19,6 +19,8 @@ import { formActionSwitchFeatures } from '@test/features/form_action_switch/Main
 import { Tracker } from '@src/tracking/Tracker';
 import { bannerContentAnimatedTextFeatures, bannerContentDateAndTimeFeatures } from '@test/features/BannerContent';
 import { UseOfFundsShownEvent } from '@src/tracking/events/UseOfFundsShownEvent';
+import { Timer } from '@src/utils/Timer';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 let pageScroller: PageScroller;
 let tracker: Tracker;
@@ -30,7 +32,6 @@ describe( 'BannerVar.vue', () => {
 	let wrapper: VueWrapper<any>;
 	beforeEach( () => {
 		resetFormModel( formModel );
-		vi.useFakeTimers();
 
 		pageScroller = {
 			scrollIntoView: vi.fn(),
@@ -42,7 +43,11 @@ describe( 'BannerVar.vue', () => {
 		};
 	} );
 
-	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
+	afterEach( () => {
+		wrapper.unmount();
+	} );
+
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
 		// attachTo the document body to fix an issue with Vue Test Utils where
 		// clicking a submit button in a form does not fire the submit event
 		wrapper = mount( Banner, {
@@ -64,19 +69,14 @@ describe( 'BannerVar.vue', () => {
 					formActions: { donateWithAddressAction: 'https://example.com/with-address', donateAnonymouslyAction: 'https://example.com/without-address' },
 					currencyFormatter: new CurrencyEn(),
 					formItems,
-					tracker
+					tracker,
+					timer: timer ?? new TimerStub()
 				}
 			}
 		} );
 
 		return wrapper;
 	};
-
-	afterEach( () => {
-		wrapper.unmount();
-		vi.restoreAllMocks();
-		vi.useRealTimers();
-	} );
 
 	describe( 'Content', () => {
 		test.skip.each( [
@@ -126,7 +126,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
 			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ]
 		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper() );
+			await softCloseFeatures[ testName ]( getWrapper );
 		} );
 	} );
 

--- a/test/banners/pad/C24_WMDE_iPad_DE_01/components/BannerCtrl.spec.ts
+++ b/test/banners/pad/C24_WMDE_iPad_DE_01/components/BannerCtrl.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '@banners/pad/C24_WMDE_iPad_DE_01/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -15,6 +15,8 @@ import { useFormModel } from '@src/components/composables/useFormModel';
 import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
 import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 import { bannerMainFeatures } from '@test/features/MainBanner';
+import { TimerStub } from '@test/fixtures/TimerStub';
+import { Timer } from '@src/utils/Timer';
 
 const formModel = useFormModel();
 const translator = ( key: string ): string => key;
@@ -23,16 +25,13 @@ describe( 'BannerCtrl.vue', () => {
 	let wrapper: VueWrapper<any>;
 	beforeEach( () => {
 		resetFormModel( formModel );
-		vi.useFakeTimers();
 	} );
 
 	afterEach( () => {
 		wrapper.unmount();
-		vi.restoreAllMocks();
-		vi.useRealTimers();
 	} );
 
-	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
 		// attachTo the document body to fix an issue with Vue Test Utils where
 		// clicking a submit button in a form does not fire the submit event
 		wrapper = mount( Banner, {
@@ -52,7 +51,8 @@ describe( 'BannerCtrl.vue', () => {
 					formActions: { donateWithAddressAction: 'https://example.com', donateWithoutAddressAction: 'https://example.com' },
 					currencyFormatter: new CurrencyEn(),
 					formItems,
-					tracker: new TrackerStub()
+					tracker: new TrackerStub(),
+					timer: timer ?? new TimerStub()
 				}
 			}
 		} );
@@ -105,7 +105,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
 			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ]
 		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper() );
+			await softCloseFeatures[ testName ]( getWrapper );
 		} );
 	} );
 

--- a/test/banners/pad/C24_WMDE_iPad_DE_01/components/BannerVar.spec.ts
+++ b/test/banners/pad/C24_WMDE_iPad_DE_01/components/BannerVar.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '@banners/pad/C24_WMDE_iPad_DE_01/components/BannerVar.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -15,6 +15,8 @@ import { useFormModel } from '@src/components/composables/useFormModel';
 import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
 import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 import { bannerMainFeatures } from '@test/features/MainBanner';
+import { Timer } from '@src/utils/Timer';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 const formModel = useFormModel();
 const translator = ( key: string ): string => key;
@@ -23,16 +25,13 @@ describe( 'BannerCtrl.vue', () => {
 	let wrapper: VueWrapper<any>;
 	beforeEach( () => {
 		resetFormModel( formModel );
-		vi.useFakeTimers();
 	} );
 
 	afterEach( () => {
 		wrapper.unmount();
-		vi.restoreAllMocks();
-		vi.useRealTimers();
 	} );
 
-	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
 		// attachTo the document body to fix an issue with Vue Test Utils where
 		// clicking a submit button in a form does not fire the submit event
 		wrapper = mount( Banner, {
@@ -52,7 +51,8 @@ describe( 'BannerCtrl.vue', () => {
 					formActions: { donateWithAddressAction: 'https://example.com', donateWithoutAddressAction: 'https://example.com' },
 					currencyFormatter: new CurrencyEn(),
 					formItems,
-					tracker: new TrackerStub()
+					tracker: new TrackerStub(),
+					timer: timer ?? new TimerStub()
 				}
 			}
 		} );
@@ -105,7 +105,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
 			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ]
 		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper() );
+			await softCloseFeatures[ testName ]( getWrapper );
 		} );
 	} );
 

--- a/test/banners/thank_you/components/BannerCtrl.de.spec.ts
+++ b/test/banners/thank_you/components/BannerCtrl.de.spec.ts
@@ -14,6 +14,7 @@ import { ThankYouModalShownEvent } from '@src/tracking/events/ThankYouModalShown
 import { BannerSubmitEvent } from '@src/tracking/events/BannerSubmitEvent';
 import { MembershipFormActions } from '@banners/thank_you/MembershipFormActions';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 const formActions: MembershipFormActions = {
 	create: ( extraUrlParameters: Record<string, string> ) => `URL [ ${ extraUrlParameters?.interval }, ${ extraUrlParameters?.fee } ]`
@@ -40,7 +41,8 @@ describe( 'BannerCtrl.de.vue', () => {
 				},
 				provide: {
 					tracker: tracker,
-					formActions
+					formActions,
+					timer: new TimerStub()
 				}
 			}
 		} );

--- a/test/banners/thank_you/components/BannerCtrl.en.spec.ts
+++ b/test/banners/thank_you/components/BannerCtrl.en.spec.ts
@@ -14,6 +14,7 @@ import { ThankYouModalShownEvent } from '@src/tracking/events/ThankYouModalShown
 import { BannerSubmitEvent } from '@src/tracking/events/BannerSubmitEvent';
 import { MembershipFormActions } from '@banners/thank_you/MembershipFormActions';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 const formActions: MembershipFormActions = {
 	create: ( extraUrlParameters: Record<string, string> ) => `URL [ ${ extraUrlParameters?.interval }, ${ extraUrlParameters?.fee } ]`
@@ -40,7 +41,8 @@ describe( 'BannerCtrl.en.vue', () => {
 				},
 				provide: {
 					tracker: tracker,
-					formActions
+					formActions,
+					timer: new TimerStub()
 				}
 			}
 		} );

--- a/test/banners/thank_you/components/BannerVar.de.spec.ts
+++ b/test/banners/thank_you/components/BannerVar.de.spec.ts
@@ -14,6 +14,7 @@ import { ThankYouModalShownEvent } from '@src/tracking/events/ThankYouModalShown
 import { BannerSubmitEvent } from '@src/tracking/events/BannerSubmitEvent';
 import { MembershipFormActions } from '@banners/thank_you/MembershipFormActions';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 const formActions: MembershipFormActions = {
 	create: ( extraUrlParameters: Record<string, string> ) => `URL [ ${ extraUrlParameters?.interval }, ${ extraUrlParameters?.fee } ]`
@@ -40,7 +41,8 @@ describe( 'BannerVar.de.vue', () => {
 				},
 				provide: {
 					tracker: tracker,
-					formActions
+					formActions,
+					timer: new TimerStub()
 				}
 			}
 		} );

--- a/test/banners/thank_you/components/BannerVar.en.spec.ts
+++ b/test/banners/thank_you/components/BannerVar.en.spec.ts
@@ -14,6 +14,7 @@ import { ThankYouModalShownEvent } from '@src/tracking/events/ThankYouModalShown
 import { BannerSubmitEvent } from '@src/tracking/events/BannerSubmitEvent';
 import { MembershipFormActions } from '@banners/thank_you/MembershipFormActions';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 const formActions: MembershipFormActions = {
 	create: ( extraUrlParameters: Record<string, string> ) => `URL [ ${ extraUrlParameters?.interval }, ${ extraUrlParameters?.fee } ]`
@@ -40,7 +41,8 @@ describe( 'BannerVar.en.vue', () => {
 				},
 				provide: {
 					tracker: tracker,
-					formActions
+					formActions,
+					timer: new TimerStub()
 				}
 			}
 		} );

--- a/test/banners/wpde_desktop/C24_WPDE_Desktop_01/components/BannerCtrl.spec.ts
+++ b/test/banners/wpde_desktop/C24_WPDE_Desktop_01/components/BannerCtrl.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test, vi } from 'vitest';
+import { beforeEach, describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '@banners/wpde_desktop/C24_WPDE_Desktop_01/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -7,11 +7,7 @@ import { useOfFundsContent } from '@test/banners/useOfFundsContent';
 import { formItems } from '@test/banners/formItems';
 import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
-import {
-	bannerContentAnimatedTextFeatures, bannerContentDateAndTimeFeatures,
-	bannerContentDisplaySwitchFeatures,
-	bannerContentFeatures
-} from '@test/features/BannerContent';
+import { bannerContentAnimatedTextFeatures, bannerContentDateAndTimeFeatures, bannerContentDisplaySwitchFeatures, bannerContentFeatures } from '@test/features/BannerContent';
 import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
 import { useFormModel } from '@src/components/composables/useFormModel';
@@ -21,6 +17,8 @@ import { bannerMainFeatures } from '@test/features/MainBanner';
 import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
 import { setCookieImageFeatures } from '@test/features/SetCookieImage';
 import { alreadyDonatedModalFeatures } from '@test/features/AlreadyDonatedModal';
+import { TimerStub } from '@test/fixtures/TimerStub';
+import { Timer } from '@src/utils/Timer';
 
 const formModel = useFormModel();
 const translator = ( key: string ): string => key;
@@ -29,15 +27,9 @@ describe( 'BannerCtrl.vue', () => {
 
 	beforeEach( () => {
 		resetFormModel( formModel );
-		vi.useFakeTimers();
 	} );
 
-	afterEach( () => {
-		vi.restoreAllMocks();
-		vi.useRealTimers();
-	} );
-
-	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
 		return mount( Banner, {
 			props: {
 				bannerState: BannerStates.Pending,
@@ -54,7 +46,8 @@ describe( 'BannerCtrl.vue', () => {
 					formActions: { donateWithAddressAction: 'https://example.com', donateWithoutAddressAction: 'https://example.com' },
 					currencyFormatter: new CurrencyEn(),
 					formItems,
-					tracker: new TrackerStub()
+					tracker: new TrackerStub(),
+					timer: timer ?? new TimerStub()
 				}
 			},
 			// Needed for isVisible checks, see https://test-utils.vuejs.org/api/#isVisible
@@ -123,7 +116,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
 			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ]
 		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper() );
+			await softCloseFeatures[ testName ]( getWrapper );
 		} );
 	} );
 
@@ -135,7 +128,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectSetCookieImageOnAlreadyDonatedLink' ],
 			[ 'expectSetsMaybeLaterCookieOnSoftCloseMaybeLater' ]
 		] )( '%s', async ( testName: string ) => {
-			await setCookieImageFeatures[ testName ]( getWrapper() );
+			await setCookieImageFeatures[ testName ]( getWrapper );
 		} );
 	} );
 

--- a/test/banners/wpde_desktop/C24_WPDE_Desktop_01/components/BannerVar.spec.ts
+++ b/test/banners/wpde_desktop/C24_WPDE_Desktop_01/components/BannerVar.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test, vi } from 'vitest';
+import { beforeEach, describe, test } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '@banners/wpde_desktop/C24_WPDE_Desktop_01/components/BannerVar.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -7,11 +7,7 @@ import { useOfFundsContent } from '@test/banners/useOfFundsContent';
 import { formItems } from '@test/banners/formItems';
 import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
 import { useOfFundsFeatures } from '@test/features/UseOfFunds';
-import {
-	bannerContentAnimatedTextFeatures, bannerContentDateAndTimeFeatures,
-	bannerContentDisplaySwitchFeatures,
-	bannerContentFeatures
-} from '@test/features/BannerContent';
+import { bannerContentAnimatedTextFeatures, bannerContentDateAndTimeFeatures, bannerContentDisplaySwitchFeatures, bannerContentFeatures } from '@test/features/BannerContent';
 import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
 import { donationFormTransactionFeeFeatures } from '@test/features/forms/MainDonation_TransactionFee';
@@ -22,6 +18,8 @@ import { bannerMainFeatures } from '@test/features/MainBanner';
 import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
 import { setCookieImageFeatures } from '@test/features/SetCookieImage';
 import { alreadyDonatedModalFeatures } from '@test/features/AlreadyDonatedModal';
+import { Timer } from '@src/utils/Timer';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 const formModel = useFormModel();
 const translator = ( key: string, context: any ): string => context ? `${key} -- ${Object.entries( context )}` : key;
@@ -30,15 +28,9 @@ describe( 'BannerVar.vue', () => {
 
 	beforeEach( () => {
 		resetFormModel( formModel );
-		vi.useFakeTimers();
 	} );
 
-	afterEach( () => {
-		vi.restoreAllMocks();
-		vi.useRealTimers();
-	} );
-
-	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
 		return mount( Banner, {
 			props: {
 				bannerState: BannerStates.Pending,
@@ -55,7 +47,8 @@ describe( 'BannerVar.vue', () => {
 					formActions: { donateWithAddressAction: 'https://example.com', donateWithoutAddressAction: 'https://example.com' },
 					currencyFormatter: new CurrencyEn(),
 					formItems,
-					tracker: new TrackerStub()
+					tracker: new TrackerStub(),
+					timer: timer ?? new TimerStub()
 				}
 			},
 			// Needed for isVisible checks, see https://test-utils.vuejs.org/api/#isVisible
@@ -134,7 +127,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
 			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ]
 		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper() );
+			await softCloseFeatures[ testName ]( getWrapper );
 		} );
 	} );
 
@@ -146,7 +139,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectSetCookieImageOnAlreadyDonatedLink' ],
 			[ 'expectSetsMaybeLaterCookieOnSoftCloseMaybeLater' ]
 		] )( '%s', async ( testName: string ) => {
-			await setCookieImageFeatures[ testName ]( getWrapper() );
+			await setCookieImageFeatures[ testName ]( getWrapper );
 		} );
 	} );
 

--- a/test/banners/wpde_mobile/C24_WPDE_Mobile_01/components/BannerCtrl.spec.ts
+++ b/test/banners/wpde_mobile/C24_WPDE_Mobile_01/components/BannerCtrl.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, vi, test } from 'vitest';
+import { afterEach, beforeEach, describe, test, vi } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '@banners/wpde_mobile/C24_WPDE_Mobile_01/components/BannerCtrl.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -17,6 +17,8 @@ import { resetFormModel } from '@test/resetFormModel';
 import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 import { fullPageBannerFeatures } from '@test/features/FullPageBanner';
 import { setCookieImageFeatures } from '@test/features/SetCookieImageMobile';
+import { TimerStub } from '@test/fixtures/TimerStub';
+import { Timer } from '@src/utils/Timer';
 
 let pageScroller: PageScroller;
 const formModel = useFormModel();
@@ -27,7 +29,6 @@ describe( 'BannerCtrl.vue', () => {
 	let wrapper: VueWrapper<any>;
 	beforeEach( () => {
 		resetFormModel( formModel );
-		vi.useFakeTimers();
 
 		pageScroller = {
 			scrollIntoView: vi.fn(),
@@ -37,11 +38,9 @@ describe( 'BannerCtrl.vue', () => {
 
 	afterEach( () => {
 		wrapper.unmount();
-		vi.restoreAllMocks();
-		vi.useRealTimers();
 	} );
 
-	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
 		// attachTo the document body to fix an issue with Vue Test Utils where
 		// clicking a submit button in a form does not fire the submit event
 		wrapper = mount( Banner, {
@@ -62,7 +61,8 @@ describe( 'BannerCtrl.vue', () => {
 					formActions: { donateWithAddressAction: 'https://example.com', donateWithoutAddressAction: 'https://example.com' },
 					currencyFormatter: new CurrencyEn(),
 					formItems,
-					tracker: new TrackerStub()
+					tracker: new TrackerStub(),
+					timer: timer ?? new TimerStub()
 				}
 			}
 		} );
@@ -91,7 +91,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
 			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ]
 		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper() );
+			await softCloseFeatures[ testName ]( getWrapper );
 		} );
 	} );
 
@@ -100,7 +100,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectSetsCookieImageOnSoftCloseClose' ],
 			[ 'expectSetsCookieImageOnSoftCloseTimeOut' ]
 		] )( '%s', async ( testName: string ) => {
-			await setCookieImageFeatures[ testName ]( getWrapper() );
+			await setCookieImageFeatures[ testName ]( getWrapper );
 		} );
 	} );
 

--- a/test/banners/wpde_mobile/C24_WPDE_Mobile_01/components/BannerVar.spec.ts
+++ b/test/banners/wpde_mobile/C24_WPDE_Mobile_01/components/BannerVar.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, vi, test } from 'vitest';
+import { afterEach, beforeEach, describe, test, vi } from 'vitest';
 import { mount, VueWrapper } from '@vue/test-utils';
 import Banner from '@banners/wpde_mobile/C24_WPDE_Mobile_01/components/BannerVar.vue';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
@@ -17,6 +17,8 @@ import { resetFormModel } from '@test/resetFormModel';
 import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 import { fullPageBannerFeatures } from '@test/features/FullPageBanner';
 import { setCookieImageFeatures } from '@test/features/SetCookieImageMobile';
+import { TimerStub } from '@test/fixtures/TimerStub';
+import { Timer } from '@src/utils/Timer';
 
 let pageScroller: PageScroller;
 const formModel = useFormModel();
@@ -27,7 +29,6 @@ describe( 'BannerVar.vue', () => {
 	let wrapper: VueWrapper<any>;
 	beforeEach( () => {
 		resetFormModel( formModel );
-		vi.useFakeTimers();
 
 		pageScroller = {
 			scrollIntoView: vi.fn(),
@@ -37,11 +38,9 @@ describe( 'BannerVar.vue', () => {
 
 	afterEach( () => {
 		wrapper.unmount();
-		vi.restoreAllMocks();
-		vi.useRealTimers();
 	} );
 
-	const getWrapper = ( dynamicContent: DynamicContent = null ): VueWrapper<any> => {
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
 		// attachTo the document body to fix an issue with Vue Test Utils where
 		// clicking a submit button in a form does not fire the submit event
 		wrapper = mount( Banner, {
@@ -62,7 +61,8 @@ describe( 'BannerVar.vue', () => {
 					formActions: { donateWithAddressAction: 'https://example.com', donateWithoutAddressAction: 'https://example.com' },
 					currencyFormatter: new CurrencyEn(),
 					formItems,
-					tracker: new TrackerStub()
+					tracker: new TrackerStub(),
+					timer: timer ?? new TimerStub()
 				}
 			}
 		} );
@@ -91,7 +91,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
 			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ]
 		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper() );
+			await softCloseFeatures[ testName ]( getWrapper );
 		} );
 	} );
 
@@ -100,7 +100,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectSetsCookieImageOnSoftCloseClose' ],
 			[ 'expectSetsCookieImageOnSoftCloseTimeOut' ]
 		] )( '%s', async ( testName: string ) => {
-			await setCookieImageFeatures[ testName ]( getWrapper() );
+			await setCookieImageFeatures[ testName ]( getWrapper );
 		} );
 	} );
 

--- a/test/components/BannerConductor/BannerConductor.spec.ts
+++ b/test/components/BannerConductor/BannerConductor.spec.ts
@@ -15,6 +15,7 @@ import { ReactiveProperty } from '@src/domain/StateMachine/ReactiveProperty';
 import { BannerState } from '@src/components/BannerConductor/StateMachine/states/BannerState';
 import { CloseEvent } from '@src/tracking/events/CloseEvent';
 import { ResizeHandler } from '@src/utils/ResizeHandler';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 vi.mock( '@src/components/BannerConductor/StateMachine/BannerStateMachine', async () => {
 	const actual = await vi.importActual( '@src/components/BannerConductor/StateMachine/BannerStateMachine' );
@@ -63,7 +64,8 @@ describe( 'BannerConductor.vue', () => {
 			},
 			global: {
 				provide: {
-					tracker: new TrackerStub()
+					tracker: new TrackerStub(),
+					timer: new TimerStub()
 				}
 			}
 		} );

--- a/test/components/BannerConductor/FallbackBannerConductor.spec.ts
+++ b/test/components/BannerConductor/FallbackBannerConductor.spec.ts
@@ -15,6 +15,7 @@ import { ReactiveProperty } from '@src/domain/StateMachine/ReactiveProperty';
 import { BannerState } from '@src/components/BannerConductor/StateMachine/states/BannerState';
 import { CloseEvent } from '@src/tracking/events/CloseEvent';
 import { ResizeHandler } from '@src/utils/ResizeHandler';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 vi.mock( '@src/components/BannerConductor/StateMachine/BannerStateMachine', async () => {
 	const actual = await vi.importActual( '@src/components/BannerConductor/StateMachine/BannerStateMachine' );
@@ -71,7 +72,8 @@ describe( 'FallbackBannerConductor.vue', () => {
 			},
 			global: {
 				provide: {
-					tracker: new TrackerStub()
+					tracker: new TrackerStub(),
+					timer: new TimerStub()
 				}
 			}
 		} );

--- a/test/components/BannerConductor/StateMachine/states/ClosedState.spec.ts
+++ b/test/components/BannerConductor/StateMachine/states/ClosedState.spec.ts
@@ -5,12 +5,20 @@ import { PageStub } from '@test/fixtures/PageStub';
 import { TrackerStub } from '@test/fixtures/TrackerStub';
 import { ResizeHandlerStub } from '@test/fixtures/ResizeHandlerStub';
 import { CloseChoices } from '@src/domain/CloseChoices';
+import { TimerStub } from '@test/fixtures/TimerStub';
+import { TimerSpy } from '@test/fixtures/TimerSpy';
 
 describe( 'ClosedState', function () {
 	it( 'tracks close event on enter', function () {
 		const tracker = { trackEvent: vitest.fn() };
 		const closeEvent = new CloseEvent( 'MainBanner', CloseChoices.Close );
-		const state = new ClosedState( closeEvent, new PageStub(), tracker, new ResizeHandlerStub() );
+		const state = new ClosedState(
+			closeEvent,
+			new PageStub(),
+			tracker,
+			new ResizeHandlerStub(),
+			new TimerStub()
+		);
 
 		state.enter();
 
@@ -21,7 +29,13 @@ describe( 'ClosedState', function () {
 		const page = new PageStub();
 		page.setSpace = vitest.fn( () => page );
 		page.unsetAnimated = vitest.fn( () => page );
-		const state = new ClosedState( new CloseEvent( 'MainBanner', CloseChoices.Close ), page, new TrackerStub(), new ResizeHandlerStub() );
+		const state = new ClosedState(
+			new CloseEvent( 'MainBanner', CloseChoices.Close ),
+			page,
+			new TrackerStub(),
+			new ResizeHandlerStub(),
+			new TimerStub()
+		);
 
 		state.enter();
 
@@ -33,7 +47,13 @@ describe( 'ClosedState', function () {
 		const page = new PageStub();
 		page.setCloseCookieIfNecessary = vitest.fn( () => page );
 		const closeEvent = new CloseEvent( 'MainBanner', CloseChoices.Close );
-		const state = new ClosedState( closeEvent, page, new TrackerStub(), new ResizeHandlerStub() );
+		const state = new ClosedState(
+			closeEvent,
+			page,
+			new TrackerStub(),
+			new ResizeHandlerStub(),
+			new TimerStub()
+		);
 
 		state.enter();
 
@@ -46,7 +66,13 @@ describe( 'ClosedState', function () {
 		const resizeHandler = new ResizeHandlerStub();
 		page.removePageEventListeners = vitest.fn( () => page );
 		resizeHandler.onClose = vitest.fn();
-		const state = new ClosedState( new CloseEvent( 'MainBanner', CloseChoices.Close ), page, new TrackerStub(), resizeHandler );
+		const state = new ClosedState(
+			new CloseEvent( 'MainBanner', CloseChoices.Close ),
+			page,
+			new TrackerStub(),
+			resizeHandler,
+			new TimerStub()
+		);
 
 		state.enter();
 
@@ -54,12 +80,28 @@ describe( 'ClosedState', function () {
 		expect( resizeHandler.onClose ).toHaveBeenCalledOnce();
 	} );
 
+	it( 'stops the timers', function () {
+		const timer = new TimerSpy();
+		const state = new ClosedState(
+			new CloseEvent( 'MainBanner', CloseChoices.Close ),
+			new PageStub(),
+			new TrackerStub(),
+			new ResizeHandlerStub(),
+			timer
+		);
+
+		state.enter();
+
+		expect( timer.clearAllCalls ).toStrictEqual( 1 );
+	} );
+
 	it( 'throws error on exit', function () {
 		const state = new ClosedState(
 			new CloseEvent( 'MainBanner', CloseChoices.Close ),
 			new PageStub(),
 			new TrackerStub(),
-			new ResizeHandlerStub()
+			new ResizeHandlerStub(),
+			new TimerStub()
 		);
 
 		expect( () => state.exit() ).toThrowError( 'This state will never be exited' );

--- a/test/components/BannerConductor/StateMachine/states/PendingState.spec.ts
+++ b/test/components/BannerConductor/StateMachine/states/PendingState.spec.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vitest } from 'vitest';
 import { PendingState } from '@src/components/BannerConductor/StateMachine/states/PendingState';
 import { Page } from '@src/page/Page';
+import { TimerStub } from '@test/fixtures/TimerStub';
+import { TimerSpy } from '@test/fixtures/TimerSpy';
 
 describe( 'PendingState', function () {
 	let page: Page;
@@ -10,7 +12,7 @@ describe( 'PendingState', function () {
 	} );
 
 	it( 'sets banner height on enter', async () => {
-		const pendingState = new PendingState( page, 60, 1 );
+		const pendingState = new PendingState( page, 60, 1, new TimerStub() );
 
 		await pendingState.enter();
 
@@ -19,26 +21,29 @@ describe( 'PendingState', function () {
 	} );
 
 	it( 'starts delay timeout on enter', async () => {
-		const setTimeoutSpy = vitest.spyOn( window, 'setTimeout' );
-		const pendingState = new PendingState( page, 60, 1 );
+		const timerSpy = new TimerSpy();
+
+		const pendingState = new PendingState( page, 60, 1, timerSpy );
 
 		await pendingState.enter();
 
-		expect( setTimeoutSpy ).toHaveBeenCalledOnce();
-		expect( setTimeoutSpy ).toHaveBeenCalledWith( expect.any( Function ), 1 );
+		expect( timerSpy.setTimeoutCalls.length ).toStrictEqual( 1 );
+		expect( timerSpy.setTimeoutCalls[ 0 ] ).toStrictEqual( 1 );
 	} );
 
 	it( 'stops delay timeout on exit', async () => {
-		const clearTimeoutSpy = vitest.spyOn( window, 'clearTimeout' );
-		const pendingState = new PendingState( page, 60, 1 );
+		const timerSpy = new TimerSpy();
+		const pendingState = new PendingState( page, 60, 1, timerSpy );
 
+		await pendingState.enter();
 		await pendingState.exit();
 
-		expect( clearTimeoutSpy ).toHaveBeenCalledOnce();
+		expect( timerSpy.clearTimeoutIds.length ).toStrictEqual( 1 );
+		expect( timerSpy.clearTimeoutIds[ 0 ] ).toStrictEqual( 0 );
 	} );
 
 	it( 'sets banner size on resize', () => {
-		const pendingState = new PendingState( page, 60, 1 );
+		const pendingState = new PendingState( page, 60, 1, new TimerStub() );
 
 		pendingState.onResize( 42 );
 

--- a/test/components/BannerConductor/StateMachine/states/ShowingState.spec.ts
+++ b/test/components/BannerConductor/StateMachine/states/ShowingState.spec.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vitest } from 'vitest';
 import { ShowingState } from '@src/components/BannerConductor/StateMachine/states/ShowingState';
 import { Page } from '@src/page/Page';
 import { PageStub } from '@test/fixtures/PageStub';
+import { TimerStub } from '@test/fixtures/TimerStub';
+import { TimerSpy } from '@test/fixtures/TimerSpy';
 
 describe( 'ShowingState', function () {
 	let page: Page;
@@ -15,7 +17,7 @@ describe( 'ShowingState', function () {
 	} );
 
 	it( 'shows banner on enter', async () => {
-		const showingState = new ShowingState( page, 1 );
+		const showingState = new ShowingState( page, 1, new TimerStub() );
 
 		await showingState.enter();
 
@@ -26,26 +28,29 @@ describe( 'ShowingState', function () {
 	} );
 
 	it( 'starts transitionDuration timeout on enter', async () => {
-		const setTimeoutSpy = vitest.spyOn( window, 'setTimeout' );
-		const showingState = new ShowingState( page, 1 );
+		const timerSpy = new TimerSpy();
+
+		const showingState = new ShowingState( page, 1, timerSpy );
 
 		await showingState.enter();
 
-		expect( setTimeoutSpy ).toHaveBeenCalledOnce();
-		expect( setTimeoutSpy ).toHaveBeenCalledWith( expect.any( Function ), 1 );
+		expect( timerSpy.setTimeoutCalls.length ).toStrictEqual( 1 );
+		expect( timerSpy.setTimeoutCalls[ 0 ] ).toStrictEqual( 1 );
 	} );
 
 	it( 'stops delay timeout on exit', async () => {
-		const clearTimeoutSpy = vitest.spyOn( window, 'clearTimeout' );
-		const showingState = new ShowingState( page, 1 );
+		const timerSpy = new TimerSpy();
+		const showingState = new ShowingState( page, 1, timerSpy );
 
+		await showingState.enter();
 		await showingState.exit();
 
-		expect( clearTimeoutSpy ).toHaveBeenCalledOnce();
+		expect( timerSpy.clearTimeoutIds.length ).toStrictEqual( 1 );
+		expect( timerSpy.clearTimeoutIds[ 0 ] ).toStrictEqual( 0 );
 	} );
 
 	it( 'sets banner size on resize', () => {
-		const showingState = new ShowingState( page, 1 );
+		const showingState = new ShowingState( page, 1, new TimerStub() );
 
 		showingState.onResize( 42 );
 
@@ -54,7 +59,7 @@ describe( 'ShowingState', function () {
 	} );
 
 	it( 'sets banner size on content changed', () => {
-		const showingState = new ShowingState( page, 1 );
+		const showingState = new ShowingState( page, 1, new TimerStub() );
 
 		showingState.onContentChanged( 42 );
 

--- a/test/components/DonationForm/MultiStepDonation.spec.ts
+++ b/test/components/DonationForm/MultiStepDonation.spec.ts
@@ -6,6 +6,7 @@ import { StepController } from '@src/components/DonationForm/StepController';
 import { PageScroller } from '@src/utils/PageScroller/PageScroller';
 import { StepControllerSpy } from '@test/fixtures/StepControllerSpy';
 import { TrackerSpy } from '@test/fixtures/TrackerSpy';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 const subFormEmitterTemplate = `<template #form-page-1="{ pageIndex, submit, previous }">
 	<button
@@ -40,7 +41,8 @@ describe( 'MultistepDonation.vue', () => {
 						donateWithAddressAction: `https://example.com/withAddress`,
 						donateWithoutAddressAction: `https://example.com/?withoutAddress=okay`
 					},
-					tracker
+					tracker,
+					timer: new TimerStub()
 				}
 			}
 		} );

--- a/test/components/Footer/SelectionInput.spec.ts
+++ b/test/components/Footer/SelectionInput.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, VueWrapper } from '@vue/test-utils';
 import SelectionInput from '@src/components/Footer/SelectionInput.vue';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 describe( 'SelectionInput.vue', () => {
 
@@ -12,35 +13,36 @@ describe( 'SelectionInput.vue', () => {
 		vi.restoreAllMocks();
 	} );
 
-	it( 'sets prop value as both values', () => {
-		const wrapper = shallowMount( SelectionInput, {
+	const getWrapper = (): VueWrapper<any> => {
+		return shallowMount( SelectionInput, {
 			props: {
 				value: 'value'
+			},
+			global: {
+				provide: {
+					timer: new TimerStub()
+				}
 			}
 		} );
+	};
+
+	it( 'sets prop value as both values', () => {
+		const wrapper = getWrapper();
 
 		expect( wrapper.find<HTMLInputElement>( '.wmde-banner-selection-input-input' ).element.value ).toBe( 'value' );
 		expect( wrapper.find( '.wmde-banner-selection-input-text' ).text() ).toBe( 'value' );
 	} );
 
-	it( 'sets focusedValue as input text when one is provided as a prop', () => {
-		const wrapper = shallowMount( SelectionInput, {
-			props: {
-				value: 'value',
-				focusedValue: 'focusedValue'
-			}
-		} );
+	it( 'sets focusedValue as input text when one is provided as a prop', async () => {
+		const wrapper = getWrapper();
+		await wrapper.setProps( { focusedValue: 'focusedValue' } );
 
 		expect( wrapper.find<HTMLInputElement>( '.wmde-banner-selection-input-input' ).element.value ).toBe( 'focusedValue' );
 		expect( wrapper.find( '.wmde-banner-selection-input-text' ).text() ).toBe( 'value' );
 	} );
 
 	it( 'selects text on focus', () => {
-		const wrapper = shallowMount( SelectionInput, {
-			props: {
-				value: 'value'
-			}
-		} );
+		const wrapper = getWrapper();
 
 		const input = wrapper.find<HTMLInputElement>( '.wmde-banner-selection-input-input' );
 		input.trigger( 'focus' );
@@ -51,12 +53,8 @@ describe( 'SelectionInput.vue', () => {
 	} );
 
 	it( 'sets and removes focus class', async () => {
-		const wrapper = shallowMount( SelectionInput, {
-			props: {
-				value: 'value',
-				focusedValue: 'focusedValue'
-			}
-		} );
+		const wrapper = getWrapper();
+		await wrapper.setProps( { focusedValue: 'focusedValue' } );
 
 		const input = wrapper.find<HTMLInputElement>( '.wmde-banner-selection-input-input' );
 

--- a/test/features/MiniBanner.ts
+++ b/test/features/MiniBanner.ts
@@ -1,11 +1,9 @@
 import { VueWrapper } from '@vue/test-utils';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
-import { expect, vi } from 'vitest';
+import { expect } from 'vitest';
 
 const expectSlideShowPlaysWhenMiniBannerBecomesVisible = async ( wrapper: VueWrapper<any> ): Promise<any> => {
 	await wrapper.setProps( { bannerState: BannerStates.Visible } );
-
-	await vi.runOnlyPendingTimersAsync();
 
 	expect( wrapper.find( '.wmde-banner-slider--playing' ).exists() ).toBeTruthy();
 };

--- a/test/features/SetCookieImage.ts
+++ b/test/features/SetCookieImage.ts
@@ -1,54 +1,75 @@
 import { VueWrapper } from '@vue/test-utils';
-import { expect, vi } from 'vitest';
+import { expect } from 'vitest';
+import { TimerSpy } from '@test/fixtures/TimerSpy';
+import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import { Timer } from '@src/utils/Timer';
 
-const expectSetsCookieImageOnSoftCloseClose = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+const expectSetsCookieImageOnSoftCloseClose = async ( getWrapper: () => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapper();
+
 	await wrapper.find( '.wmde-banner-close' ).trigger( 'click' );
 	await wrapper.find( '.wmde-banner-soft-close-button-close' ).trigger( 'click' );
 
 	expect( wrapper.find( '.wmde-banner-set-cookie-image' ).exists() ).toBeTruthy();
 };
 
-const expectSetsCookieImageOnSoftCloseTimeOut = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+const expectSetsCookieImageOnSoftCloseTimeOut = async ( getWrapper: ( dynamicContent: DynamicContent, timer: Timer ) => VueWrapper<any> ): Promise<any> => {
+	const timer = new TimerSpy();
+	const wrapper = getWrapper( null, timer );
+
 	await wrapper.find( '.wmde-banner-close' ).trigger( 'click' );
 
-	await vi.runAllTimersAsync();
+	// The soft close counts down over 15 seconds so we need to keep advancing until it runs out
+	for ( let i: number = 0; i < 15; i++ ) {
+		await timer.advanceInterval();
+	}
 
 	expect( wrapper.find( '.wmde-banner-set-cookie-image' ).exists() ).toBeTruthy();
 };
 
-const expectDoesNotSetCookieImageOnSoftCloseMaybeLater = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+const expectDoesNotSetCookieImageOnSoftCloseMaybeLater = async ( getWrapper: () => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapper();
+
 	await wrapper.find( '.wmde-banner-close' ).trigger( 'click' );
 	await wrapper.find( '.wmde-banner-soft-close-button-maybe-later' ).trigger( 'click' );
 
 	expect( wrapper.find( '.wmde-banner-set-cookie-image' ).exists() ).toBeFalsy();
 };
 
-const expectSetCookieImageOnAlreadyDonatedMaybeLater = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+const expectSetCookieImageOnAlreadyDonatedMaybeLater = async ( getWrapper: () => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapper();
+
 	await wrapper.find( '.wmde-banner-already-donated-button-maybe-later' ).trigger( 'click' );
 
 	expect( wrapper.find( '.wmde-banner-set-cookie-image' ).exists() ).toBeTruthy();
 };
 
-const expectSetAlreadyDonatedCookieImageOnAlreadyDonatedNoMoreBanners = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+const expectSetAlreadyDonatedCookieImageOnAlreadyDonatedNoMoreBanners = async ( getWrapper: () => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapper();
+
 	await wrapper.find( '.wmde-banner-already-donated-button-go-away' ).trigger( 'click' );
 
 	expect( wrapper.find( '.wmde-banner-set-cookie-image-already-donated' ).exists() ).toBeTruthy();
 };
 
-const expectSetCookieImageOnAlreadyDonatedLink = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+const expectSetCookieImageOnAlreadyDonatedLink = async ( getWrapper: () => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapper();
+
 	await wrapper.find( '.wmde-banner-footer-already-donated' ).trigger( 'click' );
 
 	expect( wrapper.find( '.wmde-banner-set-cookie-image-already-donated' ).exists() ).toBeTruthy();
 };
 
-const expectSetsMaybeLaterCookieOnSoftCloseMaybeLater = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+const expectSetsMaybeLaterCookieOnSoftCloseMaybeLater = async ( getWrapper: () => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapper();
+
 	await wrapper.find( '.wmde-banner-close' ).trigger( 'click' );
 	await wrapper.find( '.wmde-banner-soft-close-button-maybe-later' ).trigger( 'click' );
 
 	expect( wrapper.find( '.wmde-banner-set-cookie-image' ).exists() ).toBeFalsy();
 };
 
-export const setCookieImageFeatures: Record<string, ( wrapper: VueWrapper<any> ) => Promise<any>> = {
+export const setCookieImageFeatures: Record<string, ( getWrapper: () => VueWrapper<any> ) => Promise<any>> = {
 	expectSetsCookieImageOnSoftCloseClose,
 	expectSetsCookieImageOnSoftCloseTimeOut,
 	expectDoesNotSetCookieImageOnSoftCloseMaybeLater,

--- a/test/features/SetCookieImageMobile.ts
+++ b/test/features/SetCookieImageMobile.ts
@@ -1,33 +1,44 @@
 import { VueWrapper } from '@vue/test-utils';
 import { expect, vi } from 'vitest';
+import { TimerSpy } from '@test/fixtures/TimerSpy';
+import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import { Timer } from '@src/utils/Timer';
 
-const expectSetsCookieImageOnSoftCloseClose = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+const expectSetsCookieImageOnSoftCloseClose = async ( getWrapper: () => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapper();
+
 	await wrapper.find( '.wmde-banner-mini-close-button' ).trigger( 'click' );
 	await wrapper.find( '.wmde-banner-soft-close-button-close' ).trigger( 'click' );
 
 	expect( wrapper.find( '.wmde-banner-set-cookie-image' ).exists() ).toBeTruthy();
 };
 
-const expectSetsCookieImageOnSoftCloseTimeOut = async ( wrapper: VueWrapper<any> ): Promise<any> => {
-	vi.useFakeTimers();
+const expectSetsCookieImageOnSoftCloseTimeOut = async ( getWrapper: ( dynamicContent: DynamicContent, timer: Timer ) => VueWrapper<any> ): Promise<any> => {
+	const timer = new TimerSpy();
+	const wrapper = getWrapper( null, timer );
 
 	await wrapper.find( '.wmde-banner-mini-close-button' ).trigger( 'click' );
 
-	await vi.runAllTimersAsync();
+	// The soft close counts down over 15 seconds so we need to keep advancing until it runs out
+	for ( let i: number = 0; i < 15; i++ ) {
+		await timer.advanceInterval();
+	}
 
 	expect( wrapper.find( '.wmde-banner-set-cookie-image' ).exists() ).toBeTruthy();
 
 	vi.restoreAllMocks();
 };
 
-const expectDoesNotSetCookieImageOnSoftCloseMaybeLater = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+const expectDoesNotSetCookieImageOnSoftCloseMaybeLater = async ( getWrapper: () => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapper();
+
 	await wrapper.find( '.wmde-banner-mini-close-button' ).trigger( 'click' );
 	await wrapper.find( '.wmde-banner-soft-close-button-maybe-later' ).trigger( 'click' );
 
 	expect( wrapper.find( '.wmde-banner-set-cookie-image' ).exists() ).toBeFalsy();
 };
 
-export const setCookieImageFeatures: Record<string, ( wrapper: VueWrapper<any> ) => Promise<any>> = {
+export const setCookieImageFeatures: Record<string, ( getWrapper: () => VueWrapper<any> ) => Promise<any>> = {
 	expectSetsCookieImageOnSoftCloseClose,
 	expectSetsCookieImageOnSoftCloseTimeOut,
 	expectDoesNotSetCookieImageOnSoftCloseMaybeLater

--- a/test/features/SoftCloseDesktop.ts
+++ b/test/features/SoftCloseDesktop.ts
@@ -1,22 +1,31 @@
-import { expect, vi } from 'vitest';
+import { expect } from 'vitest';
 import { VueWrapper } from '@vue/test-utils';
 import { CloseChoices } from '@src/domain/CloseChoices';
 import { CloseEvent } from '@src/tracking/events/CloseEvent';
+import { TimerSpy } from '@test/fixtures/TimerSpy';
+import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import { Timer } from '@src/utils/Timer';
 
-const expectShowsSoftClose = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+const expectShowsSoftClose = async ( getWrapper: () => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapper();
+
 	await wrapper.find( '.wmde-banner-close' ).trigger( 'click' );
 
 	expect( wrapper.find( '.wmde-banner-soft-close' ).exists() ).toBeTruthy();
 };
 
-const expectDoesNotShowSoftClose = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+const expectDoesNotShowSoftClose = async ( getWrapper: () => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapper();
+
 	await wrapper.find( '.wmde-banner-close' ).trigger( 'click' );
 
 	expect( wrapper.find( '.wmde-banner-soft-close' ).exists() ).toBeFalsy();
 	expect( wrapper.emitted( 'bannerClosed' )[ 0 ][ 0 ] ).toEqual( new CloseEvent( 'MainBanner', CloseChoices.Close ) );
 };
 
-const expectEmitsSoftCloseCloseEvent = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+const expectEmitsSoftCloseCloseEvent = async ( getWrapper: () => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapper();
+
 	await wrapper.find( '.wmde-banner-close' ).trigger( 'click' );
 	await wrapper.find( '.wmde-banner-soft-close-button-close' ).trigger( 'click' );
 
@@ -24,7 +33,9 @@ const expectEmitsSoftCloseCloseEvent = async ( wrapper: VueWrapper<any> ): Promi
 	expect( wrapper.emitted( 'bannerClosed' )[ 0 ][ 0 ] ).toEqual( new CloseEvent( 'SoftClose', CloseChoices.Close ) );
 };
 
-const expectEmitsSoftCloseMaybeLaterEvent = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+const expectEmitsSoftCloseMaybeLaterEvent = async ( getWrapper: () => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapper();
+
 	await wrapper.find( '.wmde-banner-close' ).trigger( 'click' );
 	await wrapper.find( '.wmde-banner-soft-close-button-maybe-later' ).trigger( 'click' );
 
@@ -32,22 +43,32 @@ const expectEmitsSoftCloseMaybeLaterEvent = async ( wrapper: VueWrapper<any> ): 
 	expect( wrapper.emitted( 'bannerClosed' )[ 0 ][ 0 ] ).toEqual( new CloseEvent( 'SoftClose', CloseChoices.MaybeLater ) );
 };
 
-const expectEmitsSoftCloseTimeOutEvent = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+const expectEmitsSoftCloseTimeOutEvent = async ( getWrapper: ( dynamicContent: DynamicContent, timer: Timer ) => VueWrapper<any> ): Promise<any> => {
+	const timer = new TimerSpy();
+	const wrapper = getWrapper( null, timer );
+
 	await wrapper.find( '.wmde-banner-close' ).trigger( 'click' );
 
-	await vi.runAllTimersAsync();
+	// The soft close counts down over 15 seconds so we need to keep advancing until it runs out
+	for ( let i: number = 0; i < 15; i++ ) {
+		await timer.advanceInterval();
+	}
 
 	expect( wrapper.emitted( 'bannerClosed' ).length ).toBe( 1 );
 	expect( wrapper.emitted( 'bannerClosed' )[ 0 ][ 0 ] ).toEqual( new CloseEvent( 'SoftClose', CloseChoices.TimeOut ) );
 };
 
-const expectEmitsBannerContentChangedOnSoftClose = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+const expectEmitsBannerContentChangedOnSoftClose = async ( getWrapper: () => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapper();
+
 	await wrapper.find( '.wmde-banner-close' ).trigger( 'click' );
 
 	expect( wrapper.emitted( 'bannerContentChanged' ).length ).toBe( 1 );
 };
 
-const expectDoesNotShowSoftCloseOnFinalBannerImpression = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+const expectDoesNotShowSoftCloseOnFinalBannerImpression = async ( getWrapper: () => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapper();
+
 	await wrapper.setProps( { remainingImpressions: 0 } );
 	await wrapper.find( '.wmde-banner-close' ).trigger( 'click' );
 
@@ -56,13 +77,17 @@ const expectDoesNotShowSoftCloseOnFinalBannerImpression = async ( wrapper: VueWr
 	expect( wrapper.emitted( 'bannerClosed' )[ 0 ][ 0 ] ).toEqual( new CloseEvent( 'MainBanner', CloseChoices.Close ) );
 };
 
-const expectShowsCloseIcon = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+const expectShowsCloseIcon = async ( getWrapper: () => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapper();
+
 	await wrapper.find( '.wmde-banner-close' ).trigger( 'click' );
 
 	expect( wrapper.find( '.wmde-banner-soft-close .wmde-banner-close' ).exists() ).toBeTruthy();
 };
 
-const expectCloseIconEmitsCloseEvent = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+const expectCloseIconEmitsCloseEvent = async ( getWrapper: () => VueWrapper<any> ): Promise<any> => {
+	const wrapper = getWrapper();
+
 	await wrapper.find( '.wmde-banner-close' ).trigger( 'click' );
 
 	await wrapper.find( '.wmde-banner-soft-close .wmde-banner-close' ).trigger( 'click' );
@@ -71,7 +96,7 @@ const expectCloseIconEmitsCloseEvent = async ( wrapper: VueWrapper<any> ): Promi
 	expect( wrapper.emitted( 'bannerClosed' )[ 0 ][ 0 ] ).toEqual( new CloseEvent( 'SoftClose', CloseChoices.Close ) );
 };
 
-export const softCloseFeatures: Record<string, ( wrapper: VueWrapper<any> ) => Promise<any>> = {
+export const softCloseFeatures: Record<string, ( getWrapper: () => VueWrapper<any> ) => Promise<any>> = {
 	expectShowsSoftClose,
 	expectEmitsSoftCloseCloseEvent,
 	expectEmitsSoftCloseMaybeLaterEvent,

--- a/test/fixtures/TimerSpy.ts
+++ b/test/fixtures/TimerSpy.ts
@@ -1,0 +1,47 @@
+import { Timer } from '@src/utils/Timer';
+import { nextTick } from 'vue';
+
+export class TimerSpy implements Timer {
+	public clearAllCalls: number = 0;
+	public clearIntervalIds: number[] = [];
+	public clearTimeoutIds: number[] = [];
+	public nextTickCalls: number = 0;
+	public setIntervalCalls: number[] = [];
+	public setTimeoutCalls: number[] = [];
+
+	private _interval: () => void;
+
+	public clearAll(): void {
+		this.clearAllCalls++;
+	}
+
+	public clearInterval( id: number ): void {
+		this.clearIntervalIds.push( id );
+	}
+
+	public clearTimeout( id: number ): void {
+		this.clearTimeoutIds.push( id );
+	}
+
+	public nextTick( fn: () => void ): void {
+		this.nextTickCalls++;
+		fn();
+	}
+
+	public setInterval( fn: () => void, after: number ): number {
+		this.setIntervalCalls.push( after );
+		this._interval = fn;
+		return 0;
+	}
+
+	public setTimeout( fn: () => void, after: number ): number {
+		this.setTimeoutCalls.push( after );
+		fn();
+		return 0;
+	}
+
+	public async advanceInterval(): Promise<void> {
+		this._interval();
+		return await nextTick();
+	}
+}

--- a/test/fixtures/TimerStub.ts
+++ b/test/fixtures/TimerStub.ts
@@ -1,0 +1,26 @@
+import { Timer } from '@src/utils/Timer';
+
+export class TimerStub implements Timer {
+	public clearAll(): void {
+	}
+
+	public clearInterval(): void {
+	}
+
+	public clearTimeout(): void {
+	}
+
+	public setInterval( fn: () => void ): number {
+		fn();
+		return 0;
+	}
+
+	public setTimeout( fn: () => void ): number {
+		fn();
+		return 0;
+	}
+
+	public nextTick( fn: () => void ): void {
+		fn();
+	}
+}


### PR DESCRIPTION
Components that use timers are hard to test. This
removed the window timers and replaces them with
an interface that we can mock.

Ticket: https://phabricator.wikimedia.org/T378589