### PR TITLE
Introduce averageDonation variable to all channels (recent banners)

### DIFF
--- a/banners/pad/C24_WMDE_iPad_DE_01/content/BannerSlides.vue
+++ b/banners/pad/C24_WMDE_iPad_DE_01/content/BannerSlides.vue
@@ -12,7 +12,7 @@
 		<p>
 			{{ campaignDaySentence }}
 			Insgesamt spenden 99&nbsp;% nichts – sie übergehen diesen Aufruf. Wikipedia wird
-			durch Spenden von durchschnittlich 22,49&nbsp;€ finanziert.
+			durch Spenden von durchschnittlich {{ averageDonation }} finanziert.
 		</p>
 	</KeenSliderSlide>
 	<KeenSliderSlide :is-current="currentSlide === 2">
@@ -47,7 +47,8 @@ const {
 	currentDayName,
 	currentDate,
 	campaignDaySentence,
-	visitorsVsDonorsSentence
+	visitorsVsDonorsSentence,
+	averageDonation
 }: DynamicContent = inject( 'dynamicCampaignText' );
 
 const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );

--- a/banners/pad/C24_WMDE_iPad_DE_01/content/BannerSlidesVar.vue
+++ b/banners/pad/C24_WMDE_iPad_DE_01/content/BannerSlidesVar.vue
@@ -12,7 +12,7 @@
 		<p>
 			{{ campaignDaySentence }}
 			Insgesamt spenden 99&nbsp;% nichts – sie übergehen diesen Aufruf. Wikipedia wird
-			durch Spenden von durchschnittlich 22,49&nbsp;€ finanziert.
+			durch Spenden von durchschnittlich {{ averageDonation }} finanziert.
 		</p>
 	</KeenSliderSlide>
 	<KeenSliderSlide :is-current="currentSlide === 2">
@@ -47,7 +47,8 @@ const {
 	currentDayName,
 	currentDate,
 	campaignDaySentence,
-	visitorsVsDonorsSentence
+	visitorsVsDonorsSentence,
+	averageDonation
 }: DynamicContent = inject( 'dynamicCampaignText' );
 
 const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );

--- a/banners/wpde_desktop/C24_WPDE_Desktop_01/content/BannerSlides.vue
+++ b/banners/wpde_desktop/C24_WPDE_Desktop_01/content/BannerSlides.vue
@@ -10,7 +10,7 @@
 		</p>
 	</KeenSliderSlide>
 	<KeenSliderSlide :is-current="currentSlide === 1">
-		<p>Wikipedia wird durch Spenden von durchschnittlich 22,49&nbsp;€ finanziert, aber 99&nbsp;% der
+		<p>Wikipedia wird durch Spenden von durchschnittlich {{ averageDonation }} finanziert, aber 99&nbsp;% der
 			Lesenden spenden nicht. <strong>Wenn alle, die das jetzt lesen, einen kleinen Beitrag leisten, wäre unser
 				Spendenziel bereits heute erreicht.</strong></p>
 	</KeenSliderSlide>
@@ -51,7 +51,8 @@ const {
 	currentDayName,
 	getCurrentDateAndTime,
 	campaignDaySentence,
-	visitorsVsDonorsSentence
+	visitorsVsDonorsSentence,
+	averageDonation
 }: DynamicContent = inject( 'dynamicCampaignText' );
 
 const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );

--- a/banners/wpde_desktop/C24_WPDE_Desktop_01/content/BannerText.vue
+++ b/banners/wpde_desktop/C24_WPDE_Desktop_01/content/BannerText.vue
@@ -6,7 +6,7 @@
 				{{ liveDateAndTime.currentTime }} sind Sie gefragt:
 			</p>
 			<p>
-				{{ campaignDaySentence }} Wikipedia wird durch Spenden von durchschnittlich 22,49&nbsp;€ finanziert, aber 99&nbsp;% der
+				{{ campaignDaySentence }} Wikipedia wird durch Spenden von durchschnittlich {{ averageDonation }} finanziert, aber 99&nbsp;% der
 				Lesenden spenden nicht. <strong>Wenn alle, die das jetzt lesen, einen kleinen Beitrag leisten, wäre unser
 				Spendenziel bereits heute erreicht.</strong> Menschen spenden aus einem einfachen Grund – weil
 				Wikipedia nützlich ist. Schon der Preis einer Tasse Kaffee würde genügen.
@@ -32,7 +32,8 @@ const {
 	currentDayName,
 	getCurrentDateAndTime,
 	campaignDaySentence,
-	visitorsVsDonorsSentence
+	visitorsVsDonorsSentence,
+	averageDonation
 }: DynamicContent = inject( 'dynamicCampaignText' );
 
 const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );

--- a/banners/wpde_mobile/C24_WPDE_Mobile_01/content/BannerSlides.vue
+++ b/banners/wpde_mobile/C24_WPDE_Mobile_01/content/BannerSlides.vue
@@ -14,7 +14,7 @@
 	<KeenSliderSlide :is-current="currentSlide === 2">
 		<p>
 			Heute bitten wir Sie um Ihre Unterstützung. Insgesamt spenden 99% nichts – sie übergehen diesen
-			Aufruf. Wikipedia wird durch Spenden von durchschnittlich 22,49&nbsp;€ finanziert.
+			Aufruf. Wikipedia wird durch Spenden von durchschnittlich {{ averageDonation }} finanziert.
 		</p>
 	</KeenSliderSlide>
 	<KeenSliderSlide :is-current="currentSlide === 3">
@@ -52,7 +52,8 @@ const {
 	currentDayName,
 	currentDate,
 	visitorsVsDonorsSentence,
-	goalDonationSum
+	goalDonationSum,
+	averageDonation
 }: DynamicContent = inject( 'dynamicCampaignText' );
 
 const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );

--- a/banners/wpde_mobile/C24_WPDE_Mobile_01/content/BannerSlidesVar.vue
+++ b/banners/wpde_mobile/C24_WPDE_Mobile_01/content/BannerSlidesVar.vue
@@ -14,7 +14,7 @@
 	<KeenSliderSlide :is-current="currentSlide === 2">
 		<p>
 			Heute bitten wir Sie um Ihre Unterstützung. Insgesamt spenden 99% nichts – sie übergehen diesen
-			Aufruf. Wikipedia wird durch Spenden von durchschnittlich 22,49&nbsp;€ finanziert.
+			Aufruf. Wikipedia wird durch Spenden von durchschnittlich {{ averageDonation }} finanziert.
 		</p>
 	</KeenSliderSlide>
 	<KeenSliderSlide :is-current="currentSlide === 3">
@@ -52,7 +52,8 @@ const {
 	currentDayName,
 	currentDate,
 	visitorsVsDonorsSentence,
-	goalDonationSum
+	goalDonationSum,
+	averageDonation
 }: DynamicContent = inject( 'dynamicCampaignText' );
 
 const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );

--- a/banners/wpde_mobile/C24_WPDE_Mobile_01/content/BannerText.vue
+++ b/banners/wpde_mobile/C24_WPDE_Mobile_01/content/BannerText.vue
@@ -9,7 +9,7 @@
 				{{ currentDayName }}, den {{ currentDate }} um {{ liveDateAndTime.currentTime }} Uhr, bitten wir Sie
 				bescheiden, die Unabhängigkeit von Wikipedia zu unterstützen. Heute bitten wir Sie um Ihre Unterstützung.
 				Insgesamt spenden 99% nichts – sie übergehen diesen Aufruf. Wikipedia wird durch Spenden von
-				durchschnittlich 22,49&nbsp;€ finanziert. Doch schon mit einer Spende von 5&nbsp;€ kann Wikipedia sich auch
+				durchschnittlich {{ averageDonation }} finanziert. Doch schon mit einer Spende von 5&nbsp;€ kann Wikipedia sich auch
 				in Zukunft erfolgreich entwickeln. <AnimatedText :content="visitorsVsDonorsSentence"/> Die meisten
 				Menschen spenden, weil sie Wikipedia nützlich finden. Hat Wikipedia Ihnen in diesem Jahr Wissen im Wert
 				einer Tasse Kaffee geschenkt? Dann nehmen Sie sich doch bitte eine Minute Zeit und geben Sie etwas zurück.
@@ -35,7 +35,8 @@ const {
 	getCurrentDateAndTime,
 	currentDayName,
 	currentDate,
-	visitorsVsDonorsSentence
+	visitorsVsDonorsSentence,
+	averageDonation
 }: DynamicContent = inject( 'dynamicCampaignText' );
 
 const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );

--- a/banners/wpde_mobile/C24_WPDE_Mobile_01/content/BannerTextVar.vue
+++ b/banners/wpde_mobile/C24_WPDE_Mobile_01/content/BannerTextVar.vue
@@ -9,7 +9,7 @@
 				{{ currentDayName }}, den {{ currentDate }} um {{ liveDateAndTime.currentTime }} Uhr, bitten wir Sie
 				bescheiden, die Unabhängigkeit von Wikipedia zu unterstützen. Heute bitten wir Sie um Ihre Unterstützung.
 				Insgesamt spenden 99% nichts – sie übergehen diesen Aufruf. Wikipedia wird durch Spenden von
-				durchschnittlich 22,49&nbsp;€ finanziert. Doch schon mit einer Spende von 15&nbsp;€ kann Wikipedia sich auch
+				durchschnittlich {{ averageDonation }} finanziert. Doch schon mit einer Spende von 15&nbsp;€ kann Wikipedia sich auch
 				in Zukunft erfolgreich entwickeln. <AnimatedText :content="visitorsVsDonorsSentence"/> Die meisten
 				Menschen spenden, weil sie Wikipedia nützlich finden. Hat Wikipedia Ihnen in diesem Jahr Wissen im Wert
 				einer Tasse Kaffee geschenkt? Dann nehmen Sie sich doch bitte eine Minute Zeit und geben Sie etwas zurück.
@@ -35,7 +35,8 @@ const {
 	getCurrentDateAndTime,
 	currentDayName,
 	currentDate,
-	visitorsVsDonorsSentence
+	visitorsVsDonorsSentence,
+	averageDonation
 }: DynamicContent = inject( 'dynamicCampaignText' );
 
 const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );

--- a/package-lock.json
+++ b/package-lock.json
@@ -6637,7 +6637,8 @@
     },
     "node_modules/fundraising-frontend-content": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/wmde/fundraising-frontend-content.git#7885b65b3892c6e32ec94548a2f901e7323fe439"
+      "resolved": "git+ssh://git@github.com/wmde/fundraising-frontend-content.git#a15a417b75aba9b485df180e537047b4b47f065a",
+      "license": "CC0-1.0"
     },
     "node_modules/get-intrinsic": {
       "version": "1.2.4",


### PR DESCRIPTION
the variable got introduced with this ticket: https://phabricator.wikimedia.org/T378212 but wasn't used in all recent channels yet

- the change for mobile DE will be done by https://github.com/wmde/fundraising-banners/pull/604

- this PR is for trying to make sure we use the variable in future banners, 
- not necessarily changing much older banners