### PR TITLE
Fix Linux Firefox font alignment

### DIFF
--- a/banners/thank_you/styles/settings/_fonts.scss
+++ b/banners/thank_you/styles/settings/_fonts.scss
@@ -1,5 +1,5 @@
 /* These font stacks come from: https://github.com/system-fonts/modern-font-stacks */
-$-neo-grotesque: 'Inter', 'Roboto', 'Helvetica Neue', 'Arial Nova', 'Nimbus Sans', 'Arial', sans-serif;
+$-neo-grotesque: 'Inter', 'Roboto', 'Helvetica Neue', 'Arial Nova', 'Liberation Sans', 'Arial', sans-serif;
 $-transitional: 'Iowan Old Style', 'Bitstream Charter', 'Sitka Text', 'Cambria', serif;
 
 /* This is used for all the ui text, buttons, inputs, labels etc */

--- a/src/themes/Fijitiv/variables/_fonts.scss
+++ b/src/themes/Fijitiv/variables/_fonts.scss
@@ -1,5 +1,5 @@
 /* These font stacks come from: https://github.com/system-fonts/modern-font-stacks */
-$-neo-grotesque: 'Inter', 'Roboto', 'Helvetica Neue', 'Arial Nova', 'Nimbus Sans', 'Arial', sans-serif;
+$-neo-grotesque: 'Inter', 'Roboto', 'Helvetica Neue', 'Arial Nova', 'Liberation Sans', 'Arial', sans-serif;
 $-transitional: 'Iowan Old Style', 'Bitstream Charter', 'Sitka Text', 'Cambria', serif;
 
 /* This is used for all the ui text, buttons, inputs, labels etc */

--- a/src/themes/Mikings/variables/_fonts.scss
+++ b/src/themes/Mikings/variables/_fonts.scss
@@ -1,5 +1,5 @@
 /* These font stacks come from: https://github.com/system-fonts/modern-font-stacks */
-$-neo-grotesque: 'Inter', 'Roboto', 'Helvetica Neue', 'Arial Nova', 'Nimbus Sans', 'Arial', sans-serif;
+$-neo-grotesque: 'Inter', 'Roboto', 'Helvetica Neue', 'Arial Nova', 'Liberation Sans', 'Arial', sans-serif;
 $-transitional: 'Charter', 'Bitstream Charter', 'Sitka Text', 'Cambria', serif;
 
 /* This is used for all the ui text, buttons, inputs, labels etc */

--- a/src/themes/Svingle/DonationForm/SubComponents/SelectGroupRadios.scss
+++ b/src/themes/Svingle/DonationForm/SubComponents/SelectGroupRadios.scss
@@ -10,14 +10,6 @@ $font-size: 0.95em !default;
 			margin-top: 3px;
 			cursor: pointer;
 			height: 25px;
-
-			@include breakpoints.medium-up {
-				height: 29px;
-			}
-
-			@include breakpoints.large-up {
-				height: 25px;
-			}
 		}
 
 		&-label {

--- a/src/themes/Svingle/variables/_fonts.scss
+++ b/src/themes/Svingle/variables/_fonts.scss
@@ -1,5 +1,5 @@
 /* These font stacks come from: https://github.com/system-fonts/modern-font-stacks */
-$-neo-grotesque: 'Inter', 'Roboto', 'Helvetica Neue', 'Arial Nova', 'Nimbus Sans', 'Arial', sans-serif;
+$-neo-grotesque: 'Inter', 'Roboto', 'Helvetica Neue', 'Arial Nova', 'Liberation Sans', 'Arial', sans-serif;
 $-transitional: 'Iowan Old Style', 'Bitstream Charter', 'Sitka Text', 'Cambria', serif;
 
 /* This is used for all the ui text, buttons, inputs, labels etc */

--- a/src/themes/Treedip/DonationForm/SubComponents/SelectGroupRadios.scss
+++ b/src/themes/Treedip/DonationForm/SubComponents/SelectGroupRadios.scss
@@ -6,14 +6,6 @@
 			padding: 3px 10px 0 25px;
 			cursor: pointer;
 			height: 25px;
-
-			@include breakpoints.medium-up {
-				height: 29px;
-			}
-
-			@include breakpoints.large-up {
-				height: 25px;
-			}
 		}
 
 		&-label {

--- a/src/themes/Treedip/variables/_fonts.scss
+++ b/src/themes/Treedip/variables/_fonts.scss
@@ -1,5 +1,5 @@
 /* These font stacks come from: https://github.com/system-fonts/modern-font-stacks */
-$-neo-grotesque: 'Inter', 'Roboto', 'Helvetica Neue', 'Arial Nova', 'Nimbus Sans', 'Arial', sans-serif;
+$-neo-grotesque: 'Inter', 'Roboto', 'Helvetica Neue', 'Arial Nova', 'Liberation Sans', 'Arial', sans-serif;
 $-transitional: 'Iowan Old Style', 'Bitstream Charter', 'Sitka Text', 'Cambria', serif;
 
 /* This is used for all the ui text, buttons, inputs, labels etc */

--- a/src/themes/Yperala/variables/_fonts.scss
+++ b/src/themes/Yperala/variables/_fonts.scss
@@ -1,5 +1,5 @@
 /* These font stacks come from: https://github.com/system-fonts/modern-font-stacks */
-$-neo-grotesque: 'Inter', 'Roboto', 'Helvetica Neue', 'Arial Nova', 'Nimbus Sans', 'Arial', sans-serif;
+$-neo-grotesque: 'Inter', 'Roboto', 'Helvetica Neue', 'Arial Nova', 'Liberation Sans', 'Arial', sans-serif;
 $-transitional: 'Charter', 'Bitstream Charter', 'Sitka Text', 'Cambria', serif;
 
 /* This is used for all the ui text, buttons, inputs, labels etc */


### PR DESCRIPTION
- Swap Nimbus Sans with Liberation Sans in the font stack
- Fix alignment of radios and text in Treedip and Svingle

Ticket: https://phabricator.wikimedia.org/T377933
(cherry picked from commit a7ea28df7cb957c18bdc2ea09300c72f8a180770)