### PR TITLE
Fix checkbox alignment on EN banner radios

### DIFF
--- a/src/themes/Treedip/DonationForm/BubbleForm/SelectGroupRadioBubbles.scss
+++ b/src/themes/Treedip/DonationForm/BubbleForm/SelectGroupRadioBubbles.scss
@@ -18,6 +18,7 @@ $check-size: 10px;
 			margin-bottom: 8px;
 
 			label {
+				scale: 1;
 				display: flex;
 				align-items: center;
 				padding: 0 10px 0 25px;

--- a/src/themes/Treedip/DonationForm/BubbleForm/radio-input.scss
+++ b/src/themes/Treedip/DonationForm/BubbleForm/radio-input.scss
@@ -1,6 +1,6 @@
 @use 'sass:math';
 
-$size: 10px;
+$size: 12px;
 
 @mixin styles( $left: 6px ) {
 	appearance: none;


### PR DESCRIPTION
There was some sub-pixel rendering happening on the en
checkbox that was causing the check to be mis-aligned.

This increases the size and sets a scale to improve
sub-pixel rendering of a radio which has appearance
none.

Ticket: https://phabricator.wikimedia.org/T379621