### PR TITLE
Protoype for fixing banner performance issues

### DIFF
--- a/banners/mobile_english/C24_WMDE_Mobile_EN_01/banner_ctrl.ts
+++ b/banners/mobile_english/C24_WMDE_Mobile_EN_01/banner_ctrl.ts
@@ -39,7 +39,7 @@ const currencyFormatter = localeFactory.getCurrencyFormatter();
 const app = createVueApp( BannerConductor, {
 	page,
 	bannerConfig: {
-		delay: runtimeEnvironment.getBannerDelay( 7500 ),
+		delay: runtimeEnvironment.getBannerDelay( 0 ),
 		transitionDuration: 1000
 	},
 	bannerProps: {

--- a/banners/mobile_english/C24_WMDE_Mobile_EN_01/banner_var.ts
+++ b/banners/mobile_english/C24_WMDE_Mobile_EN_01/banner_var.ts
@@ -39,7 +39,7 @@ const currencyFormatter = localeFactory.getCurrencyFormatter();
 const app = createVueApp( BannerConductor, {
 	page,
 	bannerConfig: {
-		delay: runtimeEnvironment.getBannerDelay( 7500 ),
+		delay: runtimeEnvironment.getBannerDelay( 0 ),
 		transitionDuration: 1000
 	},
 	bannerProps: {

--- a/webpack/wikitext_templates/wikipedia_org.hbs
+++ b/webpack/wikitext_templates/wikipedia_org.hbs
@@ -10,6 +10,11 @@
 {{{ bannerValues }}}
 {{{ useOfFundsTransclude }}}
 <nowiki>
-	<script>mw.loader.using(['vue'], function(){ {{{ banner }}} })</script>
+	<script>setTimeout(function(){
+        mw.loader.using(['vue'], function(){ {{{ banner }}} });
+        },
+        7500
+        );
+     </script>
 </nowiki>
 


### PR DESCRIPTION
This change moves the banner delay from a parameter that's passed to
the BannerConductor to the Wikitext template. This means that point
where the browser has to execute the whole banner code (loading Vue, rendering the banner,
determining the size, installing event handlers, etc) is delayed and
does not interfere with the suer experience (and quick loading of the
page) until the banner is really ready to be shown. This change has
really [improved the banner performance metrics](https://wikimedia.sitespeed.io/en.m.wikipedia.org/2024-11-13-19-18-34/pages/en_m_wikipedia_org/wiki/Barack_Obama/query-be116471/index.html#compare)

If the WMF agrees to this change, we will need to rearchitect a bit, to
move the code from the Skin constructors (that prevents banner display
when the user interacts with the page, but tracks the reason) into plain
JavaScript in the template. My suggestion would be as follows: have a
big `switch` statement that installs event handlers depending on the
skin. The handler itself sets a `data-user-interaction` data
attribute when triggered. If you use `{once:true}` as an argument for
`addEventListener`, you don't have to worry about removing those
mini-event-listerners.
The `hideBannerListener` passed into the skins
would wrap the listener and additionally check if the data attribute was
set and if it is set, immediately trigger the event (calling the
listener method)
