### PR TITLE
Move urgency message variable into config

### DIFF
--- a/docs/2025PostCampaignCleanUp.md
+++ b/docs/2025PostCampaignCleanUp.md
@@ -104,3 +104,11 @@ into the `MainDonationForm` messages.
 
 - `src/components/DonationForm/Forms/messages/MainDonationForm.*.ts`
 - `banners/*/*/messages.ts`
+
+## Remove deprecated urgencyMessageDaysLeft parameter from DynamicTextPlugin
+
+This was hardcoded in our banner entry points and is now moved into the campaign configuration. Deleting it from the plugin constructor items would cause backwards breaking changes so it is deprecated instead and should be removed in 2025.
+
+### Files to look at:
+
+- `src/DynamicTextPlugin.ts`

--- a/src/DynamicTextPlugin.ts
+++ b/src/DynamicTextPlugin.ts
@@ -11,6 +11,9 @@ interface DynamicCampaignTextOptions {
     formatters: Formatters;
     campaignParameters: CampaignParameters;
     impressionCount: ImpressionCount;
+	/**
+	 * @deprecated This should be removed in the 2025 campaign cleanup
+	 */
 	urgencyMessageDaysLeft?: number;
 }
 
@@ -21,8 +24,7 @@ export default {
 			options.translator,
 			options.formatters,
 			options.campaignParameters,
-			options.impressionCount,
-			options.urgencyMessageDaysLeft
+			options.impressionCount
 		) );
 	}
 };

--- a/src/domain/CampaignParameters.ts
+++ b/src/domain/CampaignParameters.ts
@@ -38,6 +38,7 @@ export interface CampaignParameters {
     endDate: string,
     numberOfMembers: number,
     isLateProgress: boolean,
+    urgencyMessageDaysLeft: number,
 
     thankYouCampaign: ThankYouCampaignParameters
 }

--- a/src/page/PageWPORG.ts
+++ b/src/page/PageWPORG.ts
@@ -170,6 +170,7 @@ class PageWPORG implements Page {
 			endDate: data.endDate,
 			numberOfMembers: Number( data.numberOfMembers ),
 			isLateProgress: data.isLateProgress === 'true',
+			urgencyMessageDaysLeft: Number( data.urgencyMessageDaysLeft ),
 			thankYouCampaign: {
 				numberOfDonors: Number( data.tyNumberOfDonors ),
 				progressBarPercentage: Number( data.tyProgressBarPercentage )

--- a/src/utils/DynamicContent/DynamicCampaignText.ts
+++ b/src/utils/DynamicContent/DynamicCampaignText.ts
@@ -23,7 +23,6 @@ export default class DynamicCampaignText implements DynamicContent {
 	private _formatters: Formatters;
 	private _campaignParameters: CampaignParameters;
 	private _impressionCount: ImpressionCount;
-	private readonly _urgencyMessageDaysLeft: number;
 	private _cache: Map<string, string>;
 	private _campaignTimeRange: TimeRange;
 	private _campaignProjection: CampaignProjection;
@@ -36,15 +35,13 @@ export default class DynamicCampaignText implements DynamicContent {
 		translator: Translator,
 		formatters: Formatters,
 		campaignParameters: CampaignParameters,
-		impressionCount: ImpressionCount,
-		urgencyMessageDaysLeft: number = 10
+		impressionCount: ImpressionCount
 	) {
 		this._date = date;
 		this._translator = translator;
 		this._formatters = formatters;
 		this._campaignParameters = campaignParameters;
 		this._impressionCount = impressionCount;
-		this._urgencyMessageDaysLeft = urgencyMessageDaysLeft;
 		this._cache = new Map<string, string>();
 		this.getCurrentDateAndTime = this.getCurrentDateAndTime.bind( this );
 	}
@@ -73,7 +70,7 @@ export default class DynamicCampaignText implements DynamicContent {
 				this.getCampaignTimeRange(),
 				this._translator,
 				this._formatters.ordinal,
-				this._urgencyMessageDaysLeft
+				this._campaignParameters.urgencyMessageDaysLeft
 			).getText();
 		} );
 	}

--- a/test/components/FallbackBanner/LargeFooter.spec.ts
+++ b/test/components/FallbackBanner/LargeFooter.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { mount } from '@vue/test-utils';
 import LargeFooter from '@src/components/FallbackBanner/LargeFooter.vue';
+import { TimerStub } from '@test/fixtures/TimerStub';
 
 describe( 'LargeFooter.vue', () => {
 	it( 'emits show use of funds event on use of funds link click', async () => {
@@ -8,6 +9,9 @@ describe( 'LargeFooter.vue', () => {
 			global: {
 				mocks: {
 					$translate: ( key: string ) => key
+				},
+				provide: {
+					timer: new TimerStub()
 				}
 			}
 		} );
@@ -22,6 +26,9 @@ describe( 'LargeFooter.vue', () => {
 			global: {
 				mocks: {
 					$translate: ( key: string ) => key
+				},
+				provide: {
+					timer: new TimerStub()
 				}
 			}
 		} );

--- a/test/fixtures/PageStub.ts
+++ b/test/fixtures/PageStub.ts
@@ -69,6 +69,7 @@ export class PageStub implements Page {
 			numberOfMembers: 0,
 			startDate: '',
 			isLateProgress: false,
+			urgencyMessageDaysLeft: 0,
 			thankYouCampaign: {
 				progressBarPercentage: 0,
 				numberOfDonors: 0

--- a/test/integration/page/PageWPDE.spec.ts
+++ b/test/integration/page/PageWPDE.spec.ts
@@ -21,6 +21,7 @@ describe( 'PageWPDE', function () {
 			numberOfMembers: 0,
 			startDate: '2023-11-01',
 			isLateProgress: false,
+			urgencyMessageDaysLeft: 10,
 			thankYouCampaign: {
 				progressBarPercentage: 80,
 				numberOfDonors: 42

--- a/test/unit/environment/prod/CampaignOverride.spec.ts
+++ b/test/unit/environment/prod/CampaignOverride.spec.ts
@@ -19,6 +19,7 @@ describe( 'getCampaignParameterOverride (prod version)', () => {
 			numberOfMembers: 0,
 			startDate: '',
 			isLateProgress: false,
+			urgencyMessageDaysLeft: 0,
 			thankYouCampaign: {
 				progressBarPercentage: 0,
 				numberOfDonors: 0

--- a/test/unit/utils/DynamicContent/DynamicCampaignText.spec.ts
+++ b/test/unit/utils/DynamicContent/DynamicCampaignText.spec.ts
@@ -39,6 +39,7 @@ const campaignParameters: CampaignParameters = {
 	millionImpressionsPerDay: 42,
 	numberOfMembers: 200,
 	startDate: '2023-11-03',
+	urgencyMessageDaysLeft: 10,
 	isLateProgress: false,
 	thankYouCampaign: {
 		progressBarPercentage: 80,


### PR DESCRIPTION
The campaign day sentence urgency threshold is currently
hardcoded.

This moves it into the campaign config.

Ticket: https://phabricator.wikimedia.org/T380269