### PR TITLE
Add items to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 dist/
 !dist/index.html
 coverage
+vitest.campaign.config.mjs.timestamp*


### PR DESCRIPTION
- Prevent `vitest.campaign.config.mjs.timestamp*` from getting checked in accidently