### PR TITLE
Fix soft close button of C24_WMDE_Desktop_DE_17

### DIFF
--- a/banners/desktop/C24_WMDE_Desktop_DE_17/components/BannerVar.vue
+++ b/banners/desktop/C24_WMDE_Desktop_DE_17/components/BannerVar.vue
@@ -90,11 +90,7 @@
 			@maybeLater="() => onClose( 'SoftClose', CloseChoices.MaybeLater )"
 			@timeOutClose="() => onClose( 'SoftClose', CloseChoices.TimeOut )"
 			@maybeLater7Days="() => onClose('SoftClose', CloseChoices.Close)"
-		>
-			<template #close-button>
-				<ButtonClose/>
-			</template>
-		</SoftClose>
+		/>
 
 		<FundsModal
 			:content="useOfFundsContent"
@@ -131,7 +127,6 @@ import { CloseChoices } from '@src/domain/CloseChoices';
 import { CloseEvent } from '@src/tracking/events/CloseEvent';
 import { TrackingFeatureName } from '@src/tracking/TrackingEvent';
 import ButtonCloseWithText from '@src/components/ButtonCloseWithText/ButtonCloseWithText.vue';
-import ButtonClose from '@src/components/ButtonClose/ButtonClose.vue';
 import FooterAlreadyDonated from '@src/components/Footer/FooterAlreadyDonated.vue';
 import WMDEFundsForwardingDE from '@src/components/UseOfFunds/Infographics/WMDEFundsForwardingDE.vue';
 import ProgressBar from '@src/components/ProgressBar/ProgressBar.vue';


### PR DESCRIPTION
The close button in the upper right corner was not hooked up to an event
handler. After checking the code and trying out the banner, I concluded
that overriding the close button is not necessary in this instance.

The test that checks the close function of the soft close only started
to fail after the branch was merged.

Ticket: https://phabricator.wikimedia.org/T380464
