### PR TITLE
Fix body styles when modal is open

### DIFF
--- a/src/page/PageWPORG.ts
+++ b/src/page/PageWPORG.ts
@@ -216,6 +216,7 @@ class PageWPORG implements Page {
 		const scrollY = window.scrollY;
 		document.body.style.position = 'fixed';
 		document.body.style.top = `-${ scrollY }px`;
+		document.body.style.width = '100vw';
 	}
 
 	/**
@@ -226,6 +227,7 @@ class PageWPORG implements Page {
 		const scrollY = document.body.style.top;
 		document.body.style.position = '';
 		document.body.style.top = '';
+		document.body.style.width = '';
 		window.scrollTo( 0, parseInt( scrollY || '0' ) * -1 );
 	}
 }


### PR DESCRIPTION
The existing styles we were adding to the body
when we open a modal aren't working properly on
Vector 2022.

This sets the width of the body to ensure the
centre positioning does not get lost when the
body is set to fixed.