### PR TITLE
Add tests to increase coverage

### DIFF
--- a/src/tracking/events/CoverTransactionFeesEvent.ts
+++ b/src/tracking/events/CoverTransactionFeesEvent.ts
@@ -8,6 +8,6 @@ export class CoverTransactionFeesEvent implements TrackingEvent<void> {
 
 	public readonly eventName = CoverTransactionFeesEvent.EVENT_NAME;
 	public readonly customData: void;
-	public readonly feature: TrackingFeatureName = 'AlreadyDonatedModal';
+	public readonly feature: TrackingFeatureName = 'MainBanner';
 	public readonly userChoice: string = '';
 }

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_08/components/BannerVar.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_08/components/BannerVar.spec.ts
@@ -69,7 +69,8 @@ describe( 'BannerVar.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );
@@ -133,6 +134,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ],
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_09/components/BannerCtrl.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_09/components/BannerCtrl.spec.ts
@@ -69,7 +69,8 @@ describe( 'BannerVar.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );
@@ -133,6 +134,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ],
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_09/components/BannerVar.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_09/components/BannerVar.spec.ts
@@ -69,7 +69,8 @@ describe( 'BannerVar.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );
@@ -133,6 +134,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ],
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_10/components/BannerCtrl.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_10/components/BannerCtrl.spec.ts
@@ -69,7 +69,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );
@@ -133,6 +134,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ],
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_10/components/BannerVar.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_10/components/BannerVar.spec.ts
@@ -69,7 +69,8 @@ describe( 'BannerVar.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );
@@ -133,6 +134,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ],
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_11/components/BannerCtrl.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_11/components/BannerCtrl.spec.ts
@@ -74,7 +74,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );
@@ -144,6 +145,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ],
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_11/components/BannerVar.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_11/components/BannerVar.spec.ts
@@ -74,7 +74,8 @@ describe( 'BannerVar.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );
@@ -144,6 +145,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ],
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_12/components/BannerCtrl.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_12/components/BannerCtrl.spec.ts
@@ -74,7 +74,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );
@@ -144,6 +145,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ],
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_12/components/BannerVar.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_12/components/BannerVar.spec.ts
@@ -74,7 +74,8 @@ describe( 'BannerVar.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );
@@ -144,6 +145,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ],
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_13/components/BannerCtrl.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_13/components/BannerCtrl.spec.ts
@@ -74,7 +74,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );
@@ -144,6 +145,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ],
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_13/components/BannerVar.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_13/components/BannerVar.spec.ts
@@ -14,7 +14,10 @@ import {
 	bannerContentFeatures
 } from '@test/features/BannerContent';
 import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
-import { donationFormTransactionFeeFeatures } from '@test/features/forms/MainDonation_TransactionFee';
+import {
+	donationFormTransactionFeeFeatures,
+	donationFormTransactionFeeTracking
+} from '@test/features/forms/MainDonation_TransactionFee';
 import { useFormModel } from '@src/components/composables/useFormModel';
 import { resetFormModel } from '@test/resetFormModel';
 import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
@@ -75,7 +78,8 @@ describe( 'BannerVar.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );
@@ -146,6 +150,13 @@ describe( 'BannerVar.vue', () => {
 		] )( '%s', async ( testName: string ) => {
 			await donationFormTransactionFeeFeatures[ testName ]( getWrapper() );
 		} );
+
+		test.each( [
+			[ 'expectTracksCoverTransactionFeesEventOnSubmit' ],
+			[ 'expectDoesNotTrackCoverTransactionFeesEventWhenUnchecked' ]
+		] )( '%s', async ( testName: string ) => {
+			await donationFormTransactionFeeTracking[ testName ]( getWrapper(), tracker );
+		} );
 	} );
 
 	describe( 'Soft Close', () => {
@@ -155,6 +166,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ],
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_14/components/BannerCtrl.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_14/components/BannerCtrl.spec.ts
@@ -74,7 +74,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );
@@ -144,6 +145,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ],
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_14/components/BannerVar.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_14/components/BannerVar.spec.ts
@@ -90,7 +90,8 @@ describe( 'BannerVar.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );
@@ -160,6 +161,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ],
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_15/components/BannerCtrl.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_15/components/BannerCtrl.spec.ts
@@ -74,7 +74,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );
@@ -143,6 +144,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ],
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_15/components/BannerVar.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_15/components/BannerVar.spec.ts
@@ -74,7 +74,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );
@@ -143,6 +144,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ],
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_16/components/BannerCtrl.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_16/components/BannerCtrl.spec.ts
@@ -74,7 +74,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );
@@ -143,6 +144,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ],
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_16/components/BannerVar.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_16/components/BannerVar.spec.ts
@@ -74,7 +74,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );
@@ -143,6 +144,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ],
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_17/components/BannerCtrl.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_17/components/BannerCtrl.spec.ts
@@ -74,7 +74,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );
@@ -143,6 +144,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ],
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_17/components/BannerVar.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_17/components/BannerVar.spec.ts
@@ -75,7 +75,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );
@@ -144,6 +145,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ],
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_18/components/BannerCtrl.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_18/components/BannerCtrl.spec.ts
@@ -74,7 +74,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );
@@ -143,6 +144,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ],
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {

--- a/test/banners/desktop/C24_WMDE_Desktop_DE_18/components/BannerVar.spec.ts
+++ b/test/banners/desktop/C24_WMDE_Desktop_DE_18/components/BannerVar.spec.ts
@@ -74,7 +74,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );
@@ -143,6 +144,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
 			[ 'expectEmitsSoftCloseTimeOutEvent' ],
 			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ],
 			[ 'expectShowsCloseIcon' ],
 			[ 'expectCloseIconEmitsCloseEvent' ]
 		] )( '%s', async ( testName: string ) => {

--- a/test/banners/english/C24_WMDE_Desktop_EN_02b/components/BannerCtrl.spec.ts
+++ b/test/banners/english/C24_WMDE_Desktop_EN_02b/components/BannerCtrl.spec.ts
@@ -55,7 +55,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );

--- a/test/banners/english/C24_WMDE_Desktop_EN_03/components/BannerCtrl.spec.ts
+++ b/test/banners/english/C24_WMDE_Desktop_EN_03/components/BannerCtrl.spec.ts
@@ -55,7 +55,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );

--- a/test/banners/english/C24_WMDE_Desktop_EN_04/components/BannerCtrl.spec.ts
+++ b/test/banners/english/C24_WMDE_Desktop_EN_04/components/BannerCtrl.spec.ts
@@ -55,7 +55,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );

--- a/test/banners/english/C24_WMDE_Desktop_EN_04/components/BannerVar.spec.ts
+++ b/test/banners/english/C24_WMDE_Desktop_EN_04/components/BannerVar.spec.ts
@@ -55,7 +55,8 @@ describe( 'BannerVar.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );

--- a/test/banners/english/C24_WMDE_Desktop_EN_05/components/BannerCtrl.spec.ts
+++ b/test/banners/english/C24_WMDE_Desktop_EN_05/components/BannerCtrl.spec.ts
@@ -55,7 +55,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );

--- a/test/banners/english/C24_WMDE_Desktop_EN_05/components/BannerVar.spec.ts
+++ b/test/banners/english/C24_WMDE_Desktop_EN_05/components/BannerVar.spec.ts
@@ -55,7 +55,8 @@ describe( 'BannerVar.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );

--- a/test/banners/mobile/C24_WMDE_Mobile_DE_06/components/BannerCtrl.spec.ts
+++ b/test/banners/mobile/C24_WMDE_Mobile_DE_06/components/BannerCtrl.spec.ts
@@ -163,6 +163,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectSlideShowPlaysWhenMiniBannerBecomesVisible' ],
 			[ 'expectSlideShowStopsWhenFullBannerBecomesVisible' ],
 			[ 'expectShowsFullPageWhenCallToActionIsClicked' ],
+			[ 'expectShowsFullPageWithPreselectedAmountWhenPreselectButtonIsClicked' ],
 			[ 'expectEmitsBannerContentChangedEventWhenCallToActionIsClicked' ]
 		] )( '%s', async ( testName: string ) => {
 			await miniBannerFeatures[ testName ]( getWrapper() );

--- a/test/banners/mobile/C24_WMDE_Mobile_DE_06/components/BannerVar.spec.ts
+++ b/test/banners/mobile/C24_WMDE_Mobile_DE_06/components/BannerVar.spec.ts
@@ -165,6 +165,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectSlideShowPlaysWhenMiniBannerBecomesVisible' ],
 			[ 'expectSlideShowStopsWhenFullBannerBecomesVisible' ],
 			[ 'expectShowsFullPageWhenCallToActionIsClicked' ],
+			[ 'expectShowsFullPageWithPreselectedAmountWhenPreselectButtonIsClicked' ],
 			[ 'expectEmitsBannerContentChangedEventWhenCallToActionIsClicked' ]
 		] )( '%s', async ( testName: string ) => {
 			await miniBannerFeatures[ testName ]( getWrapper() );

--- a/test/banners/mobile/C24_WMDE_Mobile_DE_07/components/BannerCtrl.spec.ts
+++ b/test/banners/mobile/C24_WMDE_Mobile_DE_07/components/BannerCtrl.spec.ts
@@ -165,6 +165,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectSlideShowPlaysWhenMiniBannerBecomesVisible' ],
 			[ 'expectSlideShowStopsWhenFullBannerBecomesVisible' ],
 			[ 'expectShowsFullPageWhenCallToActionIsClicked' ],
+			[ 'expectShowsFullPageWithPreselectedAmountWhenPreselectButtonIsClicked' ],
 			[ 'expectEmitsBannerContentChangedEventWhenCallToActionIsClicked' ]
 		] )( '%s', async ( testName: string ) => {
 			await miniBannerFeatures[ testName ]( getWrapper() );

--- a/test/banners/mobile/C24_WMDE_Mobile_DE_07/components/BannerVar.spec.ts
+++ b/test/banners/mobile/C24_WMDE_Mobile_DE_07/components/BannerVar.spec.ts
@@ -166,6 +166,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectSlideShowPlaysWhenMiniBannerBecomesVisible' ],
 			// [ 'expectSlideShowStopsWhenFullBannerBecomesVisible' ],
 			[ 'expectShowsFullPageWhenCallToActionIsClicked' ],
+			[ 'expectShowsFullPageWithPreselectedAmountWhenPreselectButtonIsClicked' ],
 			[ 'expectEmitsBannerContentChangedEventWhenCallToActionIsClicked' ]
 		] )( '%s', async ( testName: string ) => {
 			await miniBannerFeatures[ testName ]( getWrapper() );

--- a/test/banners/mobile/C24_WMDE_Mobile_DE_08/components/BannerCtrl.spec.ts
+++ b/test/banners/mobile/C24_WMDE_Mobile_DE_08/components/BannerCtrl.spec.ts
@@ -165,6 +165,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectSlideShowPlaysWhenMiniBannerBecomesVisible' ],
 			[ 'expectSlideShowStopsWhenFullBannerBecomesVisible' ],
 			[ 'expectShowsFullPageWhenCallToActionIsClicked' ],
+			[ 'expectShowsFullPageWithPreselectedAmountWhenPreselectButtonIsClicked' ],
 			[ 'expectEmitsBannerContentChangedEventWhenCallToActionIsClicked' ]
 		] )( '%s', async ( testName: string ) => {
 			await miniBannerFeatures[ testName ]( getWrapper() );

--- a/test/banners/mobile/C24_WMDE_Mobile_DE_08/components/BannerVar.spec.ts
+++ b/test/banners/mobile/C24_WMDE_Mobile_DE_08/components/BannerVar.spec.ts
@@ -165,6 +165,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectSlideShowPlaysWhenMiniBannerBecomesVisible' ],
 			[ 'expectSlideShowStopsWhenFullBannerBecomesVisible' ],
 			[ 'expectShowsFullPageWhenCallToActionIsClicked' ],
+			[ 'expectShowsFullPageWithPreselectedAmountWhenPreselectButtonIsClicked' ],
 			[ 'expectEmitsBannerContentChangedEventWhenCallToActionIsClicked' ]
 		] )( '%s', async ( testName: string ) => {
 			await miniBannerFeatures[ testName ]( getWrapper() );

--- a/test/banners/mobile/C24_WMDE_Mobile_DE_09/components/BannerCtrl.spec.ts
+++ b/test/banners/mobile/C24_WMDE_Mobile_DE_09/components/BannerCtrl.spec.ts
@@ -165,6 +165,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectSlideShowPlaysWhenMiniBannerBecomesVisible' ],
 			[ 'expectSlideShowStopsWhenFullBannerBecomesVisible' ],
 			[ 'expectShowsFullPageWhenCallToActionIsClicked' ],
+			[ 'expectShowsFullPageWithPreselectedAmountWhenPreselectButtonIsClicked' ],
 			[ 'expectEmitsBannerContentChangedEventWhenCallToActionIsClicked' ]
 		] )( '%s', async ( testName: string ) => {
 			await miniBannerFeatures[ testName ]( getWrapper() );

--- a/test/banners/mobile/C24_WMDE_Mobile_DE_09/components/BannerVar.spec.ts
+++ b/test/banners/mobile/C24_WMDE_Mobile_DE_09/components/BannerVar.spec.ts
@@ -191,6 +191,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectSlideShowPlaysWhenMiniBannerBecomesVisible' ],
 			[ 'expectSlideShowStopsWhenFullBannerBecomesVisible' ],
 			[ 'expectShowsFullPageWhenCallToActionIsClicked' ],
+			[ 'expectShowsFullPageWithPreselectedAmountWhenPreselectButtonIsClicked' ],
 			[ 'expectEmitsBannerContentChangedEventWhenCallToActionIsClicked' ]
 		] )( '%s', async ( testName: string ) => {
 			await miniBannerFeatures[ testName ]( getWrapper() );

--- a/test/banners/mobile/C24_WMDE_Mobile_DE_10/components/BannerCtrl.spec.ts
+++ b/test/banners/mobile/C24_WMDE_Mobile_DE_10/components/BannerCtrl.spec.ts
@@ -165,6 +165,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectSlideShowPlaysWhenMiniBannerBecomesVisible' ],
 			[ 'expectSlideShowStopsWhenFullBannerBecomesVisible' ],
 			[ 'expectShowsFullPageWhenCallToActionIsClicked' ],
+			[ 'expectShowsFullPageWithPreselectedAmountWhenPreselectButtonIsClicked' ],
 			[ 'expectEmitsBannerContentChangedEventWhenCallToActionIsClicked' ]
 		] )( '%s', async ( testName: string ) => {
 			await miniBannerFeatures[ testName ]( getWrapper() );

--- a/test/banners/mobile/C24_WMDE_Mobile_DE_10/components/BannerVar.spec.ts
+++ b/test/banners/mobile/C24_WMDE_Mobile_DE_10/components/BannerVar.spec.ts
@@ -165,6 +165,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectSlideShowPlaysWhenMiniBannerBecomesVisible' ],
 			[ 'expectSlideShowStopsWhenFullBannerBecomesVisible' ],
 			[ 'expectShowsFullPageWhenCallToActionIsClicked' ],
+			[ 'expectShowsFullPageWithPreselectedAmountWhenPreselectButtonIsClicked' ],
 			[ 'expectEmitsBannerContentChangedEventWhenCallToActionIsClicked' ]
 		] )( '%s', async ( testName: string ) => {
 			await miniBannerFeatures[ testName ]( getWrapper() );

--- a/test/banners/mobile/C24_WMDE_Mobile_DE_11/components/BannerCtrl.spec.ts
+++ b/test/banners/mobile/C24_WMDE_Mobile_DE_11/components/BannerCtrl.spec.ts
@@ -165,6 +165,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectSlideShowPlaysWhenMiniBannerBecomesVisible' ],
 			[ 'expectSlideShowStopsWhenFullBannerBecomesVisible' ],
 			[ 'expectShowsFullPageWhenCallToActionIsClicked' ],
+			[ 'expectShowsFullPageWithPreselectedAmountWhenPreselectButtonIsClicked' ],
 			[ 'expectEmitsBannerContentChangedEventWhenCallToActionIsClicked' ]
 		] )( '%s', async ( testName: string ) => {
 			await miniBannerFeatures[ testName ]( getWrapper() );

--- a/test/banners/mobile/C24_WMDE_Mobile_DE_11/components/BannerVar.spec.ts
+++ b/test/banners/mobile/C24_WMDE_Mobile_DE_11/components/BannerVar.spec.ts
@@ -165,6 +165,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectSlideShowPlaysWhenMiniBannerBecomesVisible' ],
 			[ 'expectSlideShowStopsWhenFullBannerBecomesVisible' ],
 			[ 'expectShowsFullPageWhenCallToActionIsClicked' ],
+			[ 'expectShowsFullPageWithPreselectedAmountWhenPreselectButtonIsClicked' ],
 			[ 'expectEmitsBannerContentChangedEventWhenCallToActionIsClicked' ]
 		] )( '%s', async ( testName: string ) => {
 			await miniBannerFeatures[ testName ]( getWrapper() );

--- a/test/banners/mobile_english/C24_WMDE_Mobile_EN_01/components/BannerCtrl.spec.ts
+++ b/test/banners/mobile_english/C24_WMDE_Mobile_EN_01/components/BannerCtrl.spec.ts
@@ -150,6 +150,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectSlideShowPlaysWhenMiniBannerBecomesVisible' ],
 			[ 'expectSlideShowStopsWhenFullBannerBecomesVisible' ],
 			[ 'expectShowsFullPageWhenCallToActionIsClicked' ],
+			[ 'expectShowsFullPageWithPreselectedAmountWhenPreselectButtonIsClicked' ],
 			[ 'expectEmitsBannerContentChangedEventWhenCallToActionIsClicked' ]
 		] )( '%s', async ( testName: string ) => {
 			await miniBannerFeatures[ testName ]( getWrapper() );

--- a/test/banners/mobile_english/C24_WMDE_Mobile_EN_01/components/BannerVar.spec.ts
+++ b/test/banners/mobile_english/C24_WMDE_Mobile_EN_01/components/BannerVar.spec.ts
@@ -160,6 +160,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectSlideShowPlaysWhenMiniBannerBecomesVisible' ],
 			[ 'expectSlideShowStopsWhenFullBannerBecomesVisible' ],
 			[ 'expectShowsFullPageWhenCallToActionIsClicked' ],
+			[ 'expectShowsFullPageWithPreselectedAmountWhenPreselectButtonIsClicked' ],
 			[ 'expectEmitsBannerContentChangedEventWhenCallToActionIsClicked' ]
 		] )( '%s', async ( testName: string ) => {
 			await miniBannerFeatures[ testName ]( getWrapper() );

--- a/test/banners/pad/C24_WMDE_iPad_DE_01/components/BannerCtrl.spec.ts
+++ b/test/banners/pad/C24_WMDE_iPad_DE_01/components/BannerCtrl.spec.ts
@@ -62,7 +62,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );

--- a/test/banners/pad/C24_WMDE_iPad_DE_01/components/BannerVar.spec.ts
+++ b/test/banners/pad/C24_WMDE_iPad_DE_01/components/BannerVar.spec.ts
@@ -62,7 +62,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );

--- a/test/banners/wpde_desktop/C24_WPDE_Desktop_01/components/BannerCtrl.spec.ts
+++ b/test/banners/wpde_desktop/C24_WPDE_Desktop_01/components/BannerCtrl.spec.ts
@@ -57,7 +57,8 @@ describe( 'BannerCtrl.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ]
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
 		} );

--- a/test/banners/wpde_mobile/C24_WPDE_Mobile_01/components/BannerCtrl.spec.ts
+++ b/test/banners/wpde_mobile/C24_WPDE_Mobile_01/components/BannerCtrl.spec.ts
@@ -125,6 +125,7 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectSlideShowPlaysWhenMiniBannerBecomesVisible' ],
 			[ 'expectSlideShowStopsWhenFullBannerBecomesVisible' ],
 			[ 'expectShowsFullPageWhenCallToActionIsClicked' ],
+			[ 'expectShowsFullPageWithPreselectedAmountWhenPreselectButtonIsClicked' ],
 			[ 'expectEmitsBannerContentChangedEventWhenCallToActionIsClicked' ]
 		] )( '%s', async ( testName: string ) => {
 			await miniBannerFeatures[ testName ]( getWrapper() );

--- a/test/banners/wpde_mobile/C24_WPDE_Mobile_01/components/BannerVar.spec.ts
+++ b/test/banners/wpde_mobile/C24_WPDE_Mobile_01/components/BannerVar.spec.ts
@@ -125,6 +125,7 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectSlideShowPlaysWhenMiniBannerBecomesVisible' ],
 			[ 'expectSlideShowStopsWhenFullBannerBecomesVisible' ],
 			[ 'expectShowsFullPageWhenCallToActionIsClicked' ],
+			[ 'expectShowsFullPageWithPreselectedAmountWhenPreselectButtonIsClicked' ],
 			[ 'expectEmitsBannerContentChangedEventWhenCallToActionIsClicked' ]
 		] )( '%s', async ( testName: string ) => {
 			await miniBannerFeatures[ testName ]( getWrapper() );

--- a/test/features/MainBanner.ts
+++ b/test/features/MainBanner.ts
@@ -10,6 +10,15 @@ const expectEmitsCloseEvent = async ( wrapper: VueWrapper<any> ): Promise<any> =
 	expect( wrapper.emitted( 'bannerClosed' )[ 0 ][ 0 ] ).toEqual( new CloseEvent( 'MainBanner', CloseChoices.Close ) );
 };
 
+const expectEmitsCloseEventWhenRemainingImpressionsAreZero = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+
+	await wrapper.setProps( { remainingImpressions: 0 } );
+	await wrapper.find( '.wmde-banner-main .wmde-banner-close' ).trigger( 'click' );
+
+	expect( wrapper.emitted( 'bannerClosed' ).length ).toBe( 1 );
+	expect( wrapper.emitted( 'bannerClosed' )[ 0 ][ 0 ] ).toEqual( new CloseEvent( 'MainBanner', CloseChoices.Close ) );
+};
+
 const expectDoesNotEmitCloseEvent = async ( wrapper: VueWrapper<any> ): Promise<any> => {
 	await wrapper.find( '.wmde-banner-main .wmde-banner-close' ).trigger( 'click' );
 
@@ -31,6 +40,7 @@ const expectClosesBannerWhenWindowBecomesSmall = async ( getWrapper: () => VueWr
 
 export const bannerMainFeatures: Record<string, ( wrapper: VueWrapper<any> ) => Promise<any>> = {
 	expectEmitsCloseEvent,
+	expectEmitsCloseEventWhenRemainingImpressionsAreZero,
 	expectDoesNotEmitCloseEvent
 };
 

--- a/test/features/MiniBanner.ts
+++ b/test/features/MiniBanner.ts
@@ -21,6 +21,14 @@ const expectShowsFullPageWhenCallToActionIsClicked = async ( wrapper: VueWrapper
 	expect( wrapper.classes() ).toContain( 'wmde-banner-wrapper--full-page' );
 };
 
+const expectShowsFullPageWithPreselectedAmountWhenPreselectButtonIsClicked = async ( wrapper: VueWrapper<any> ): Promise<any> => {
+	await wrapper.find( '.wmde-banner-mini-button-preselect' ).trigger( 'click' );
+
+	expect( wrapper.classes() ).toContain( 'wmde-banner-wrapper--full-page' );
+	const preselectedAmountValue = wrapper.find<HTMLInputElement>( '.wmde-banner-submit-form input[name=amount]' ).element.value;
+	expect( preselectedAmountValue ).toBeTruthy();
+};
+
 const expectEmitsBannerContentChangedEventWhenCallToActionIsClicked = async ( wrapper: VueWrapper<any> ): Promise<any> => {
 	await wrapper.find( '.wmde-banner-mini-button' ).trigger( 'click' );
 
@@ -31,5 +39,6 @@ export const miniBannerFeatures: Record<string, ( wrapper: VueWrapper<any> ) => 
 	expectSlideShowPlaysWhenMiniBannerBecomesVisible,
 	expectSlideShowStopsWhenFullBannerBecomesVisible,
 	expectShowsFullPageWhenCallToActionIsClicked,
+	expectShowsFullPageWithPreselectedAmountWhenPreselectButtonIsClicked,
 	expectEmitsBannerContentChangedEventWhenCallToActionIsClicked
 };

--- a/test/unit/createFAQPageURL.spec.ts
+++ b/test/unit/createFAQPageURL.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { createFAQPageURL } from '@src/createFAQPageURL';
+
+describe( 'createFAQURL', () => {
+	it( 'should create FAQ page URL with tracking information', () => {
+		const ctrlLink = createFAQPageURL( { campaign: 'C1', keyword: 'banner-ctrl' } );
+		const varLink = createFAQPageURL( { campaign: 'C1', keyword: 'banner-var' } );
+
+		expect( ctrlLink ).toStrictEqual( 'https://spenden.wikimedia.de/faq?piwik_kwd=banner-ctrl_faq&piwik_campaign=C1' );
+		expect( varLink ).toStrictEqual( 'https://spenden.wikimedia.de/faq?piwik_kwd=banner-var_faq&piwik_campaign=C1' );
+	} );
+} );

--- a/test/unit/utils/parseFloatFromFormattedString.spec.ts
+++ b/test/unit/utils/parseFloatFromFormattedString.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, test } from 'vitest';
+import { parseFloatFromFormattedString } from '@src/utils/parseFloatFromFormattedString';
+
+describe( 'parseFloatFromFormattedString', () => {
+
+	test.each( [
+		[ '4,3', 4.3 ],
+		[ '0', 0.0 ],
+		[ '1', 1 ],
+		[ '0,0000000001', 0.0000000001 ],
+		[ '0.9999999999', 0.9999999999 ],
+		[ '999999999999999', 999999999999999 ],
+		[ '9999999999.99999', 9999999999.99999 ],
+		[ '11,22,33.99', 112233.99 ],
+		[ '11.22.33,99', 112233.99 ]
+	] )( 'parses float from float-like looking string', ( input: string, expectedOutput: number ) => {
+		expect( parseFloatFromFormattedString( input ) ).toBe( expectedOutput );
+	} );
+
+	it( 'strips off non-numeric characters', () => {
+		expect( parseFloatFromFormattedString( 'abc5.3abc' ) ).toBe( 5.3 );
+	} );
+
+	it( 'returns 0 for non-numeric input', () => {
+		expect( parseFloatFromFormattedString( 'a_bc' ) ).toBe( 0 );
+		expect( parseFloatFromFormattedString( '.' ) ).toBe( 0 );
+		expect( parseFloatFromFormattedString( ',' ) ).toBe( 0 );
+	} );
+} );


### PR DESCRIPTION
- add tests for preselected amount in mobile banners
- add tests for close events on number of remaining impressions (desktop)
- add tests for parseFloatFromFormattedString.ts
- add tests for tracking of the transaction fee checkbox

Previous coverage stats:
``` 
44.7% Statements 16601/37136
84.77% Branches 3045/3592
63.47% Functions 1079/1700
44.7% Lines 16601/37136

``` 


New coverage stats:
``` 
45.13% Statements 16761/37134
85.66% Branches 3120/3642
65.23% Functions 1109/1700
45.13% Lines 16761/37134
``` 
