### PR TITLE
Improve coverage report

### DIFF
--- a/docs/2025PostCampaignCleanUp.md
+++ b/docs/2025PostCampaignCleanUp.md
@@ -163,3 +163,18 @@ Also the CSS that's currently in the Vue component should be moved or removed.
 - `src/themes/Modo/ThankYouBox/ThankYouBox.scss`
 - `src/themes/Mikings/ThankYouBox/ThankYouBox.scss`
 - `src/components/ThankYouBox/ThankYouBox.vue`
+
+## Request coverage of all banners
+
+We want our coverage report to check *all* banners
+
+- Remove `coverage.exclude` section from `vitest.campaign.config.mjs` and
+  clean up the `ignoredBannersGlob` generation from `getFilterForInactiveCampaigns`
+- Remove the `coverage:filtered` script from `package.json`
+
+### Files to look at
+
+- `vitest.campaign.config.mjs`
+- `package.json`
+- `test/filterForInactiveCampaigns.mjs`
+

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "ci": "npm-run-all check-tracking-conf lint test check-content-version",
     "check-content-version": "ts-node tools/check-content-version.ts",
     "check-tracking-conf": "ts-node tools/CampaignConfigurationCheck/check-tracking-number-and-date.mjs",
-    "coverage": "vitest run --coverage",
+    "coverage:filtered": "vitest run --coverage --config vitest.campaign.config.mjs",
+    "coverage:all": "vitest run --coverage",
     "update-content": "npm update fundraising-frontend-content"
   },
   "keywords": [],

--- a/test/filterInactiveCampaigns.mjs
+++ b/test/filterInactiveCampaigns.mjs
@@ -21,8 +21,10 @@ function getCampaignNamesAndMappings( campaignConfigPath ) {
  * @param {string} campaignConfigPath Path to the campaign config file, defaults to 'campaign_info.toml'
  * @return {{inactiveCampaignGlobs: string[], campaignsWithoutTests: string[], activeCampaigns: string[]}}
  */
-export function getFilterForInactiveCampaigns( bannerTestGlob, campaignConfigPath ) {
+export function getFilterForInactiveCampaigns( bannerGlob, bannerTestGlob, campaignConfigPath ) {
 	const potentialCampaignTestFolders = fg.globSync( bannerTestGlob, { onlyDirectories: true } );
+	const potentialBannerFolders = fg.globSync( bannerGlob, { onlyDirectories: true } );
+
 	const { activeCampaigns, campaignsToChannels } = getCampaignNamesAndMappings( campaignConfigPath );
 
 	// Filter out "legacy" tests that are not in a CAMPAIGN_NAME/components folder
@@ -40,12 +42,21 @@ export function getFilterForInactiveCampaigns( bannerTestGlob, campaignConfigPat
 		return !activeCampaigns.includes( campaignName );
 	} );
 
+	const inactiveBannerFolders = potentialBannerFolders.filter( folder => {
+		const campaignName = path.basename( folder );
+		return !activeCampaigns.includes( campaignName );
+	} );
+
 	// Create recursive glob expressions for use in vitest "exclude"
 	const inactiveCampaignGlobs = inactiveCampaignTestFolders.map( folder => path.join( folder, '**' ) );
+
+	// Create recursive glob expressions for use in vitest "coverage.exclude"
+	const inactiveBannerGlobs = inactiveBannerFolders.map( folder => path.join( folder, '**' ) );
 
 	return {
 		activeCampaigns,
 		inactiveCampaignGlobs,
+		inactiveBannerGlobs,
 		campaignsWithoutTests
 	};
 }

--- a/vitest.campaign.config.mjs
+++ b/vitest.campaign.config.mjs
@@ -6,7 +6,11 @@ import defaultConfig from './vitest.config.mjs';
 // Set to 'warn' to print a warning, set to 'error' to throw an error, or 'ignore' to do nothing
 const CAMPAIGN_WITHOUT_TEST_HANDLING = 'error';
 
-const { inactiveCampaignGlobs, campaignsWithoutTests } = getFilterForInactiveCampaigns( 'test/banners/*/*', 'campaign_info.toml' );
+const {
+	inactiveCampaignGlobs,
+	inactiveBannerGlobs,
+	campaignsWithoutTests
+} = getFilterForInactiveCampaigns( 'banners/*/*',  'test/banners/*/*', 'campaign_info.toml' );
 
 const outputMissingCampaigns = ( missingCampaigns ) => {
 	missingCampaigns.forEach( c => console.log( `  ${c}` ) );
@@ -30,6 +34,14 @@ export default mergeConfig( defaultConfig, defineConfig( {
 			// in the wrong places and choke on tests in node_modules
 			...configDefaults.exclude,
 			...inactiveCampaignGlobs
-		]
+		],
+		coverage: {
+
+			// Remove this array in 2025, it should inherit from defaultConfig instead.
+			exclude: [
+				...defaultConfig.test.coverage.exclude,
+				...inactiveBannerGlobs,
+			]
+		}
 	}
 } ) );

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 import Vue from '@vitejs/plugin-vue';
 import path from 'path';
 
@@ -12,7 +12,34 @@ export default defineConfig( {
 			[ 'test/integration/**', 'jsdom' ],
 			[ 'test/components/**', 'jsdom' ],
 			[ 'test/banners/**', 'jsdom' ]
-		]
+		],
+		coverage: {
+			exclude: [
+				...configDefaults.coverage.exclude,
+
+				// Ignore entry points, form items, event mappings and translations in each banner.
+				// The entry points are just factories, the other files are configurations written in TypeScript
+				'banners/*/*/{banner_ctrl,banner_var,form_items,form_items_var,event_map,event_map_var,messages,messages_var}.ts',
+				
+				// Ignore translation files and Locale Factories
+				'src/**/messages/*',
+				'src/utils/LocaleFactory/*',
+				
+				// Ignore environment-specific setup files
+				'src/environment/*',
+				
+				// Additional non-banner files that are not relevant for coverage
+				'dashboard/*',
+				'dist/*',
+				'check-content-version.ts',
+				'stylelint.config.mjs',
+				'vitest.campaign.config.mjs',
+				'webpack/*',
+				'webpack.common.js',
+				'webpack.production.js',
+				'webpack.config.js',
+			]
+		}
 	},
 	resolve: {
 		alias: {


### PR DESCRIPTION
Bring up coverage by ignoring files that are not relevant for coverage.
This change helps us to spot files that *actually* lack coverage that
would otherwise be hard to find in a sea of "uncovered" files.

- Exclude config, factory and translation files from coverage
- Exclude development environment files from coverage.
- Exclude all banners not in current config (because older banners
  don't have individual tests). We should change this back in 2025 to
  always check coverage of all banners.
