### PR TITLE
Prepare C24_WMDE_Desktop_DE_19 for lateprogress switch

### DIFF
--- a/banners/desktop/C24_WMDE_Desktop_DE_19/components/BannerCtrl.vue
+++ b/banners/desktop/C24_WMDE_Desktop_DE_19/components/BannerCtrl.vue
@@ -104,7 +104,7 @@ import { TrackingFeatureName } from '@src/tracking/TrackingEvent';
 import ButtonClose from '@src/components/ButtonClose/ButtonClose.vue';
 import FooterAlreadyDonated from '@src/components/Footer/FooterAlreadyDonated.vue';
 import WMDEFundsForwardingDE from '@src/components/UseOfFunds/Infographics/WMDEFundsForwardingDE.vue';
-import ProgressBar from '@src/components/ProgressBar/ProgressBar.vue';
+import ProgressBar from '@src/components/ProgressBar/ProgressBarAlternative.vue';
 import SoftClose from '@src/components/SoftClose/SoftClose.vue';
 import { LocalCloseTracker } from '@src/utils/LocalCloseTracker';
 import { BannerSubmitOnReturnEvent } from '@src/tracking/events/BannerSubmitOnReturnEvent';

--- a/banners/desktop/C24_WMDE_Desktop_DE_19/components/BannerVar.vue
+++ b/banners/desktop/C24_WMDE_Desktop_DE_19/components/BannerVar.vue
@@ -118,7 +118,7 @@ import { TrackingFeatureName } from '@src/tracking/TrackingEvent';
 import ButtonClose from '@src/components/ButtonClose/ButtonClose.vue';
 import FooterAlreadyDonated from '@src/components/Footer/FooterAlreadyDonated.vue';
 import WMDEFundsForwardingDE from '@src/components/UseOfFunds/Infographics/WMDEFundsForwardingDE.vue';
-import ProgressBar from '@src/components/ProgressBar/ProgressBar.vue';
+import ProgressBar from '@src/components/ProgressBar/ProgressBarAlternative.vue';
 import SoftClose from '@src/components/SoftClose/SoftClose.vue';
 import { LocalCloseTracker } from '@src/utils/LocalCloseTracker';
 import { BannerSubmitOnReturnEvent } from '@src/tracking/events/BannerSubmitOnReturnEvent';

--- a/banners/desktop/C24_WMDE_Desktop_DE_19/components/FallbackBanner.vue
+++ b/banners/desktop/C24_WMDE_Desktop_DE_19/components/FallbackBanner.vue
@@ -31,7 +31,7 @@
 		<div class="wmde-banner-fallback-large" v-if="onLargeScreen">
 			<div class="wmde-banner-fallback-message">
 				<FallbackText/>
-				<ProgressBar amount-to-show-on-right="TARGET"/>
+				<ProgressBarAlternative amount-to-show-on-right="TARGET"/>
 			</div>
 
 			<LargeFooter @useOfFundsButtonClicked="isFundsModalVisible = true" @submitButtonClicked="onSubmit"/>
@@ -71,7 +71,7 @@ import LargeFooter from '@src/components/FallbackBanner/LargeFooter.vue';
 import { Tracker } from '@src/tracking/Tracker';
 import { FallbackBannerSubmitEvent } from '@src/tracking/events/FallbackBannerSubmitEvent';
 import WMDEFundsForwardingDE from '@src/components/UseOfFunds/Infographics/WMDEFundsForwardingDE.vue';
-import ProgressBar from '@src/components/ProgressBar/ProgressBar.vue';
+import ProgressBarAlternative from '@src/components/ProgressBar/ProgressBarAlternative.vue';
 
 interface Props {
 	bannerState: BannerStates;

--- a/banners/desktop/C24_WMDE_Desktop_DE_19/styles/styles.scss
+++ b/banners/desktop/C24_WMDE_Desktop_DE_19/styles/styles.scss
@@ -17,7 +17,7 @@
 );
 @use 'src/themes/Treedip/defaults';
 @use 'src/themes/Treedip/ButtonClose/ButtonClose';
-@use 'src/themes/Treedip/ProgressBar/ProgressBar' with (
+@use 'src/themes/Treedip/ProgressBar/ProgressBarAlternative' with (
 	$progress-bar-margin: 0 15px
 );
 @use 'src/themes/Treedip/DonationForm/DonationForm';

--- a/banners/desktop/C24_WMDE_Desktop_DE_19/styles/styles_var.scss
+++ b/banners/desktop/C24_WMDE_Desktop_DE_19/styles/styles_var.scss
@@ -17,7 +17,7 @@
 );
 @use 'src/themes/Treedip/defaults';
 @use 'src/themes/Treedip/ButtonClose/ButtonClose';
-@use 'src/themes/Treedip/ProgressBar/ProgressBar' with (
+@use 'src/themes/Treedip/ProgressBar/ProgressBarAlternative' with (
 	$progress-bar-margin: 0 15px
 );
 @use 'src/themes/Treedip/DonationForm/DonationForm';

--- a/dashboard/wpde-offline/index.html
+++ b/dashboard/wpde-offline/index.html
@@ -79,7 +79,7 @@
 		startDate: '2024-10-01',
 		endDate: '2024-12-31',
 		numberOfMembers: 73832,
-		isLateProgress: false,
+		isLateProgress: true,
 		thankYouCampaign: {
 			numberOfDonors: 350000,
 			progressBarPercentage: 100

--- a/src/environment/dev/CampaignParameterOverride.ts
+++ b/src/environment/dev/CampaignParameterOverride.ts
@@ -17,6 +17,6 @@ export function getCampaignParameterOverride( campaignParameters: CampaignParame
 		...campaignParameters,
 		startDate: '2024-10-28',
 		endDate: '2024-12-31',
-		isLateProgress: false
+		isLateProgress: true
 	};
 }

--- a/src/themes/Fijitiv/ProgressBar/ProgressBar.scss
+++ b/src/themes/Fijitiv/ProgressBar/ProgressBar.scss
@@ -7,6 +7,8 @@ $progress-bar-height: 30px !default;
 $progress-bar-margin: 0 !default;
 
 .wmde-banner .wmde-banner-fallback {
+	@include ProgressBar.layout;
+
 	.wmde-banner {
 		&-progress-bar {
 			position: relative;
@@ -69,19 +71,18 @@ $progress-bar-margin: 0 !default;
 
 			&--late-progress {
 				.wmde-banner-progress-bar-text-left {
+					color: var( --fallback-progressbar-color );
+
 					@include breakpoints.extra-small-up {
 						visibility: visible;
 					}
 				}
-
 				.wmde-banner-progress-bar-text-right {
 					visibility: hidden;
 				}
-
 				.wmde-banner-progress-bar-fill {
 					min-width: 100px;
 				}
-
 				.wmde-banner-progress-bar-target {
 					flex: 0 0 auto;
 					display: block;


### PR DESCRIPTION
- [X] enable lateprogress in the local dev environment
- [X] desktop 19 var fix
 	- use ProgressBarAlternative to show donation goal to the right of the bar
- [x] desktop 19 fallback banner progress bar fix

fixup for https://github.com/wmde/fundraising-banners/pull/649


https://phabricator.wikimedia.org/T381957