### PR TITLE
Fix Fallback Banner for EN Desktop

### DIFF
--- a/banners/english/C24_WMDE_Desktop_EN_06/styles/FallbackBanner.scss
+++ b/banners/english/C24_WMDE_Desktop_EN_06/styles/FallbackBanner.scss
@@ -70,7 +70,7 @@ $breakpoint: 800px;
 			display: flex;
 			flex-direction: column;
 			background: var( --fallback-message-background );
-			border: 4px solid var( --fallback-message-border );
+			border: none;
 			border-radius: 4px;
 			padding: 8px 0;
 		}


### PR DESCRIPTION
Test 06 introduced a border in the main banner which now needs to be overwritten in the Fallback banner since they share class names
