### PR TITLE
Test BC breaks of all banners on review request

### DIFF
--- a/.github/workflows/daily-bc-check.yaml
+++ b/.github/workflows/daily-bc-check.yaml
@@ -2,6 +2,8 @@ name: Check backwards compatibility for all Banners
 on:
   schedule:
     - cron: "0 0 * * *"
+  pull_request:
+    types: [ review_requested ]
 
 jobs:
   bc-check:


### PR DESCRIPTION
To avoid merging code that breaks backwards compatibility while still
limiting the costly test run, we run the check for backwards
compatibility of old banners when the author requests review. This
happens only once or twice in our workflow and won't run the tests too
often.
