### PR TITLE
Revert "Test BC breaks of all banners on review request"

### DIFF
--- a/.github/workflows/daily-bc-check.yaml
+++ b/.github/workflows/daily-bc-check.yaml
@@ -2,8 +2,6 @@ name: Check backwards compatibility for all Banners
 on:
   schedule:
     - cron: "0 0 * * *"
-  pull_request:
-    types: [ review_requested ]
 
 jobs:
   bc-check:


### PR DESCRIPTION
The change in #667 runs the expensive action for every reviewer selected. This eats too much in our GitHub CI budget. The ideal behavior should be to run only once. We can achieve this by querying the GitHub API (with the [github-script container](https://github.com/actions/github-script) for the list of reviewers and only executing when the user name in the current run of the action matches the first user name from the list of reviewers in the API. Until we have time to implement this, we should revert the expensive change

Reverts wmde/fundraising-banners#667