### PR TITLE
Add single BC check for labeled PRs

### DIFF
--- a/.github/workflows/bc-check-on-label-change.yaml
+++ b/.github/workflows/bc-check-on-label-change.yaml
@@ -1,10 +1,12 @@
-name: Check backwards compatibility for all Banners
+name: BC check for all banners on "Ready for review" label
+#Check backwards compatibility for all Banners whenever "Ready for review" label is added to a pull request
 on:
-  schedule:
-    - cron: "0 0 * * *"
+  pull_request:
+    types: [ labeled ]
 
 jobs:
-  daily-bc-check:
+  bc-check:
+    if: ${{ github.event.label.name == 'Ready for review' }}
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
- everytime a PR gets labeled with "Ready for review" the playbook job runs ( npm run ci and npm run test:all-banners)
- this could increase the response time to errors compared to scheduled checks per day (at midnight e.g)