### PR TITLE
Switch from Mio to thousand (amount needed)

### DIFF
--- a/src/utils/DynamicContent/generators/ProgressBarContent.ts
+++ b/src/utils/DynamicContent/generators/ProgressBarContent.ts
@@ -53,7 +53,7 @@ export class ProgressBarContent implements DynamicProgressBarContent {
 
 	public get amountNeeded(): string {
 		return this._translator.translate( 'amount-missing', {
-			amount: this._currencyFormatter.millions( this._remainingDonationSum )
+			amount: this._currencyFormatter.euroAmountWithThousandSeparator( this._remainingDonationSum )
 		} );
 	}
 

--- a/test/unit/utils/DynamicContent/DynamicCampaignText.spec.ts
+++ b/test/unit/utils/DynamicContent/DynamicCampaignText.spec.ts
@@ -131,7 +131,7 @@ describe( 'DynamicCampaignText', () => {
 		expect( dynamicCampaignText.progressBarContent.donationTarget ).toBe( 'Progress total €9.0M' );
 		expect( dynamicCampaignText.progressBarContent.donationTargetAmount ).toBe( '€9.0M' );
 		expect( dynamicCampaignText.progressBarContent.amountDonated ).toBe( '€0.1M' );
-		expect( dynamicCampaignText.progressBarContent.amountNeeded ).toBe( 'Progress missing €8.9M' );
+		expect( dynamicCampaignText.progressBarContent.amountNeeded ).toBe( 'Progress missing 8,900,000 euro' );
 	} );
 
 	it( 'Gets the average donation', () => {


### PR DESCRIPTION
- show the "still needed" amount with thousand seperator instead of millions again due to the number being below 1 Mio

will look like this:
![Bildschirmfoto vom 2024-12-20 17-27-02](https://github.com/user-attachments/assets/1995f0aa-889e-4026-b7b6-4107bc7c39b9)
![Bildschirmfoto vom 2024-12-20 17-27-18](https://github.com/user-attachments/assets/2e63e733-4e85-4bdb-a6e6-ddf5053ad95f)
![Bildschirmfoto vom 2024-12-20 17-27-28](https://github.com/user-attachments/assets/8c8d938d-554b-40bf-ae48-25a15c69eeae)

instead of "0,9Mio"

 - would require a redeployment of the banners to Central Notice