### PR TITLE
Make cookie distinguishable

### DIFF
--- a/banners/desktop/C24_WMDE_Desktop_DE_00/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_00/banner_ctrl.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_00/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_00/banner_var.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_01/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_01/banner_ctrl.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_01/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_01/banner_var.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_02/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_02/banner_ctrl.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_02/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_02/banner_var.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_03/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_03/banner_ctrl.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_03/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_03/banner_var.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_04/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_04/banner_ctrl.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_04/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_04/banner_var.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_05/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_05/banner_ctrl.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_05/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_05/banner_var.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_06/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_06/banner_ctrl.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_06/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_06/banner_var.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_07/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_07/banner_ctrl.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_07/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_07/banner_var.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_08/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_08/banner_ctrl.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_08/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_08/banner_var.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_09/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_09/banner_ctrl.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_09/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_09/banner_var.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_10/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_10/banner_ctrl.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_10/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_10/banner_var.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_11/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_11/banner_ctrl.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_11/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_11/banner_var.ts
@@ -45,6 +45,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_12/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_12/banner_ctrl.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_12/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_12/banner_var.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_13/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_13/banner_ctrl.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_13/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_13/banner_var.ts
@@ -44,6 +44,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_14/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_14/banner_ctrl.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_14/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_14/banner_var.ts
@@ -45,6 +45,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/desktop/C24_WMDE_Desktop_DE_15/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_15/banner_ctrl.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_15/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_15/banner_var.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_16/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_16/banner_ctrl.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_16/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_16/banner_var.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_17/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_17/banner_ctrl.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_17/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_17/banner_var.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_18/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_18/banner_ctrl.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_18/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_18/banner_var.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),

--- a/banners/desktop/C24_WMDE_Desktop_DE_19/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_19/banner_ctrl.ts
@@ -41,6 +41,7 @@ const app = createVueApp( BannerConductor, {
 		transitionDuration: 1000
 	},
 	bannerProps: {
+		bannerCategory: 'fundraising',
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),
 		localCloseTracker: new LocalStorageCloseTracker(),

--- a/banners/desktop/C24_WMDE_Desktop_DE_19/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_19/banner_var.ts
@@ -41,6 +41,7 @@ const app = createVueApp( BannerConductor, {
 		transitionDuration: 1000
 	},
 	bannerProps: {
+		bannerCategory: 'fundraising',
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),
 		localCloseTracker: new LocalStorageCloseTracker(),

--- a/banners/desktop/C24_WMDE_Desktop_DE_20/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_20/banner_ctrl.ts
@@ -41,6 +41,7 @@ const app = createVueApp( BannerConductor, {
 		transitionDuration: 1000
 	},
 	bannerProps: {
+		bannerCategory: 'fundraising',
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),
 		localCloseTracker: new LocalStorageCloseTracker(),

--- a/banners/desktop/C24_WMDE_Desktop_DE_20/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_20/banner_var.ts
@@ -42,6 +42,7 @@ const app = createVueApp( BannerConductor, {
 		transitionDuration: 1000
 	},
 	bannerProps: {
+		bannerCategory: 'fundraising',
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),
 		localCloseTracker: new LocalStorageCloseTracker(),

--- a/banners/desktop/C24_WMDE_Desktop_DE_21/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_21/banner_ctrl.ts
@@ -42,6 +42,7 @@ const app = createVueApp( BannerConductor, {
 		transitionDuration: 1000
 	},
 	bannerProps: {
+		bannerCategory: 'fundraising',
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),
 		localCloseTracker: new LocalStorageCloseTracker(),

--- a/banners/desktop/C24_WMDE_Desktop_DE_21/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_21/banner_var.ts
@@ -42,6 +42,7 @@ const app = createVueApp( BannerConductor, {
 		transitionDuration: 1000
 	},
 	bannerProps: {
+		bannerCategory: 'fundraising',
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),
 		localCloseTracker: new LocalStorageCloseTracker(),

--- a/banners/desktop/C24_WMDE_Desktop_DE_22/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_22/banner_ctrl.ts
@@ -42,6 +42,7 @@ const app = createVueApp( BannerConductor, {
 		transitionDuration: 1000
 	},
 	bannerProps: {
+		bannerCategory: 'fundraising',
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),
 		localCloseTracker: new LocalStorageCloseTracker(),

--- a/banners/desktop/C24_WMDE_Desktop_DE_22/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_22/banner_var.ts
@@ -42,6 +42,7 @@ const app = createVueApp( BannerConductor, {
 		transitionDuration: 1000
 	},
 	bannerProps: {
+		bannerCategory: 'fundraising',
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),
 		localCloseTracker: new LocalStorageCloseTracker(),

--- a/banners/desktop/C24_WMDE_Desktop_DE_23/banner_ctrl.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_23/banner_ctrl.ts
@@ -42,6 +42,7 @@ const app = createVueApp( BannerConductor, {
 		transitionDuration: 1000
 	},
 	bannerProps: {
+		bannerCategory: 'fundraising',
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),
 		localCloseTracker: new LocalStorageCloseTracker(),

--- a/banners/desktop/C24_WMDE_Desktop_DE_23/banner_var.ts
+++ b/banners/desktop/C24_WMDE_Desktop_DE_23/banner_var.ts
@@ -42,6 +42,7 @@ const app = createVueApp( BannerConductor, {
 		transitionDuration: 1000
 	},
 	bannerProps: {
+		bannerCategory: 'fundraising',
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),
 		localCloseTracker: new LocalStorageCloseTracker(),

--- a/banners/english/C24_WMDE_Desktop_EN_00/banner_ctrl.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_00/banner_ctrl.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'english' ) ),

--- a/banners/english/C24_WMDE_Desktop_EN_00/banner_var.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_00/banner_var.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'english' ) ),

--- a/banners/english/C24_WMDE_Desktop_EN_01/banner_ctrl.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_01/banner_ctrl.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'english' ) ),

--- a/banners/english/C24_WMDE_Desktop_EN_01/banner_var.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_01/banner_var.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'english' ) ),

--- a/banners/english/C24_WMDE_Desktop_EN_02/banner_ctrl.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_02/banner_ctrl.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'english' ) ),

--- a/banners/english/C24_WMDE_Desktop_EN_02/banner_var.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_02/banner_var.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'english' ) ),

--- a/banners/english/C24_WMDE_Desktop_EN_02b/banner_ctrl.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_02b/banner_ctrl.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'english' ) ),

--- a/banners/english/C24_WMDE_Desktop_EN_02b/banner_var.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_02b/banner_var.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'english' ) ),

--- a/banners/english/C24_WMDE_Desktop_EN_03/banner_ctrl.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_03/banner_ctrl.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'english' ) ),

--- a/banners/english/C24_WMDE_Desktop_EN_03/banner_var.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_03/banner_var.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'english' ) ),

--- a/banners/english/C24_WMDE_Desktop_EN_04/banner_ctrl.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_04/banner_ctrl.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'english' ) ),

--- a/banners/english/C24_WMDE_Desktop_EN_04/banner_var.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_04/banner_var.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'english' ) ),

--- a/banners/english/C24_WMDE_Desktop_EN_05/banner_ctrl.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_05/banner_ctrl.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'english' ) ),

--- a/banners/english/C24_WMDE_Desktop_EN_05/banner_var.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_05/banner_var.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'english' ) ),

--- a/banners/english/C24_WMDE_Desktop_EN_06/banner_ctrl.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_06/banner_ctrl.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		transitionDuration: 1000
 	},
 	bannerProps: {
+		bannerCategory: 'fundraising',
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'english' ) ),
 		donationLink: createFallbackDonationURL( page.getTracking(), impressionCount, { locale: Locales.EN } )

--- a/banners/english/C24_WMDE_Desktop_EN_06/banner_var.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_06/banner_var.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'english' ) ),

--- a/banners/english/C24_WMDE_Desktop_EN_07/banner_ctrl.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_07/banner_ctrl.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'english' ) ),

--- a/banners/english/C24_WMDE_Desktop_EN_07/banner_var.ts
+++ b/banners/english/C24_WMDE_Desktop_EN_07/banner_var.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'english' ) ),

--- a/banners/mobile/C24_WMDE_Mobile_DE_00/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_00/banner_ctrl.ts
@@ -37,6 +37,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_00/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_00/banner_var.ts
@@ -37,6 +37,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_01/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_01/banner_ctrl.ts
@@ -37,6 +37,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_01/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_01/banner_var.ts
@@ -37,6 +37,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_02/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_02/banner_ctrl.ts
@@ -37,6 +37,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_02/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_02/banner_var.ts
@@ -37,6 +37,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_03/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_03/banner_ctrl.ts
@@ -37,6 +37,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_03/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_03/banner_var.ts
@@ -37,6 +37,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_04/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_04/banner_ctrl.ts
@@ -37,6 +37,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_04/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_04/banner_var.ts
@@ -37,6 +37,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_05/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_05/banner_ctrl.ts
@@ -37,6 +37,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_05/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_05/banner_var.ts
@@ -37,6 +37,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_06/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_06/banner_ctrl.ts
@@ -38,6 +38,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_06/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_06/banner_var.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_07/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_07/banner_ctrl.ts
@@ -38,6 +38,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_07/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_07/banner_var.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_08/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_08/banner_ctrl.ts
@@ -38,6 +38,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_08/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_08/banner_var.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_09/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_09/banner_ctrl.ts
@@ -38,6 +38,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_09/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_09/banner_var.ts
@@ -38,6 +38,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_10/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_10/banner_ctrl.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_10/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_10/banner_var.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_11/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_11/banner_ctrl.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_11/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_11/banner_var.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_12/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_12/banner_ctrl.ts
@@ -40,6 +40,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_12/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_12/banner_var.ts
@@ -41,6 +41,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_13/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_13/banner_ctrl.ts
@@ -41,6 +41,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_13/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_13/banner_var.ts
@@ -41,6 +41,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_14/banner_ctrl.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_14/banner_ctrl.ts
@@ -41,6 +41,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile/C24_WMDE_Mobile_DE_14/banner_var.ts
+++ b/banners/mobile/C24_WMDE_Mobile_DE_14/banner_var.ts
@@ -41,6 +41,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile_english/C24_WMDE_Mobile_EN_00/banner_ctrl.ts
+++ b/banners/mobile_english/C24_WMDE_Mobile_EN_00/banner_ctrl.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile_english/C24_WMDE_Mobile_EN_00/banner_var.ts
+++ b/banners/mobile_english/C24_WMDE_Mobile_EN_00/banner_var.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile_english/C24_WMDE_Mobile_EN_01/banner_ctrl.ts
+++ b/banners/mobile_english/C24_WMDE_Mobile_EN_01/banner_ctrl.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/mobile_english/C24_WMDE_Mobile_EN_01/banner_var.ts
+++ b/banners/mobile_english/C24_WMDE_Mobile_EN_01/banner_var.ts
@@ -39,6 +39,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/pad/C24_WMDE_iPad_00/banner_ctrl.ts
+++ b/banners/pad/C24_WMDE_iPad_00/banner_ctrl.ts
@@ -36,6 +36,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'pad' ) )

--- a/banners/pad/C24_WMDE_iPad_DE_01/banner_ctrl.ts
+++ b/banners/pad/C24_WMDE_iPad_DE_01/banner_ctrl.ts
@@ -36,6 +36,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'pad' ) )

--- a/banners/pad/C24_WMDE_iPad_DE_01/banner_var.ts
+++ b/banners/pad/C24_WMDE_iPad_DE_01/banner_var.ts
@@ -36,6 +36,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 7500 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'pad' ) )

--- a/banners/thank_you/banner_ctrl.de.ts
+++ b/banners/thank_you/banner_ctrl.de.ts
@@ -36,6 +36,7 @@ const app = createVueApp( BannerConductor, {
 		delay: 0,
 		transitionDuration: 0
 	},
+	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
 		settings: createThankYouSettings( new IntegerDe(), page.getCampaignParameters().thankYouCampaign ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, Locales.DE ),

--- a/banners/thank_you/banner_ctrl.en.ts
+++ b/banners/thank_you/banner_ctrl.en.ts
@@ -36,6 +36,7 @@ const app = createVueApp( BannerConductor, {
 		delay: 0,
 		transitionDuration: 0
 	},
+	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
 		settings: createThankYouSettings( new IntegerEn(), page.getCampaignParameters().thankYouCampaign ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, Locales.EN ),

--- a/banners/thank_you/banner_ctrl.wpde.ts
+++ b/banners/thank_you/banner_ctrl.wpde.ts
@@ -38,6 +38,7 @@ const app = createVueApp( BannerConductor, {
 		delay: 0,
 		transitionDuration: 0
 	},
+	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
 		settings: createThankYouSettings( new IntegerDe(), page.getCampaignParameters().thankYouCampaign ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, Locales.DE ),

--- a/banners/thank_you/banner_var.de.ts
+++ b/banners/thank_you/banner_var.de.ts
@@ -36,6 +36,7 @@ const app = createVueApp( BannerConductor, {
 		delay: 0,
 		transitionDuration: 0
 	},
+	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
 		settings: createThankYouSettings( new IntegerDe(), page.getCampaignParameters().thankYouCampaign ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, Locales.DE ),

--- a/banners/thank_you/banner_var.en.ts
+++ b/banners/thank_you/banner_var.en.ts
@@ -36,6 +36,7 @@ const app = createVueApp( BannerConductor, {
 		delay: 0,
 		transitionDuration: 0
 	},
+	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
 		settings: createThankYouSettings( new IntegerEn(), page.getCampaignParameters().thankYouCampaign ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, Locales.EN ),

--- a/banners/thank_you/banner_var.wpde.ts
+++ b/banners/thank_you/banner_var.wpde.ts
@@ -38,6 +38,7 @@ const app = createVueApp( BannerConductor, {
 		delay: 0,
 		transitionDuration: 0
 	},
+	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
 		settings: createThankYouSettings( new IntegerDe(), page.getCampaignParameters().thankYouCampaign ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, Locales.DE ),

--- a/banners/thank_you_2024/banner_ctrl.de.ts
+++ b/banners/thank_you_2024/banner_ctrl.de.ts
@@ -35,6 +35,7 @@ const app = createVueApp( BannerConductor, {
 		delay: 0,
 		transitionDuration: 0
 	},
+	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
 		settings: createThankYouSettings( new IntegerDe(), page.getCampaignParameters().thankYouCampaign ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, { locale: Locales.DE } ),

--- a/banners/thank_you_2024/banner_ctrl.en.ts
+++ b/banners/thank_you_2024/banner_ctrl.en.ts
@@ -35,6 +35,7 @@ const app = createVueApp( BannerConductor, {
 		delay: 0,
 		transitionDuration: 0
 	},
+	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
 		settings: createThankYouSettings( new IntegerEn(), page.getCampaignParameters().thankYouCampaign ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, { locale: Locales.EN } ),

--- a/banners/thank_you_2024/banner_ctrl.wpde.ts
+++ b/banners/thank_you_2024/banner_ctrl.wpde.ts
@@ -37,6 +37,7 @@ const app = createVueApp( BannerConductor, {
 		delay: 0,
 		transitionDuration: 0
 	},
+	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
 		settings: createThankYouSettings( new IntegerDe(), page.getCampaignParameters().thankYouCampaign ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, { locale: Locales.DE } ),

--- a/banners/thank_you_2024/banner_var.de.ts
+++ b/banners/thank_you_2024/banner_var.de.ts
@@ -35,6 +35,7 @@ const app = createVueApp( BannerConductor, {
 		delay: 0,
 		transitionDuration: 0
 	},
+	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
 		settings: createThankYouSettings( new IntegerDe(), page.getCampaignParameters().thankYouCampaign ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, { locale: Locales.DE } ),

--- a/banners/thank_you_2024/banner_var.en.ts
+++ b/banners/thank_you_2024/banner_var.en.ts
@@ -35,6 +35,7 @@ const app = createVueApp( BannerConductor, {
 		delay: 0,
 		transitionDuration: 0
 	},
+	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
 		settings: createThankYouSettings( new IntegerEn(), page.getCampaignParameters().thankYouCampaign ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, { locale: Locales.EN } ),

--- a/banners/thank_you_2024/banner_var.wpde.ts
+++ b/banners/thank_you_2024/banner_var.wpde.ts
@@ -37,6 +37,7 @@ const app = createVueApp( BannerConductor, {
 		delay: 0,
 		transitionDuration: 0
 	},
+	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
 		settings: createThankYouSettings( new IntegerDe(), page.getCampaignParameters().thankYouCampaign ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, { locale: Locales.DE } ),

--- a/banners/wpde_desktop/C24_WPDE_Desktop_00/banner_ctrl.ts
+++ b/banners/wpde_desktop/C24_WPDE_Desktop_00/banner_ctrl.ts
@@ -41,6 +41,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 0 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions() )

--- a/banners/wpde_desktop/C24_WPDE_Desktop_00/banner_var.ts
+++ b/banners/wpde_desktop/C24_WPDE_Desktop_00/banner_var.ts
@@ -41,6 +41,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 0 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions() )

--- a/banners/wpde_desktop/C24_WPDE_Desktop_01/banner_ctrl.ts
+++ b/banners/wpde_desktop/C24_WPDE_Desktop_01/banner_ctrl.ts
@@ -41,6 +41,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 0 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions() )

--- a/banners/wpde_desktop/C24_WPDE_Desktop_01/banner_var.ts
+++ b/banners/wpde_desktop/C24_WPDE_Desktop_01/banner_var.ts
@@ -41,6 +41,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 0 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions() )

--- a/banners/wpde_mobile/C24_WPDE_Mobile_00/banner_ctrl.ts
+++ b/banners/wpde_mobile/C24_WPDE_Mobile_00/banner_ctrl.ts
@@ -41,6 +41,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 0 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/wpde_mobile/C24_WPDE_Mobile_00/banner_var.ts
+++ b/banners/wpde_mobile/C24_WPDE_Mobile_00/banner_var.ts
@@ -41,6 +41,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 0 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/wpde_mobile/C24_WPDE_Mobile_01/banner_ctrl.ts
+++ b/banners/wpde_mobile/C24_WPDE_Mobile_01/banner_ctrl.ts
@@ -41,6 +41,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 0 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/banners/wpde_mobile/C24_WPDE_Mobile_01/banner_var.ts
+++ b/banners/wpde_mobile/C24_WPDE_Mobile_01/banner_var.ts
@@ -41,6 +41,7 @@ const app = createVueApp( BannerConductor, {
 		delay: runtimeEnvironment.getBannerDelay( 0 ),
 		transitionDuration: 1000
 	},
+	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
 		pageScroller: new WindowPageScroller(),

--- a/campaign_info.thank_you.toml
+++ b/campaign_info.thank_you.toml
@@ -11,6 +11,7 @@ campaign_tracking = "ty01-250101"
 description = "Thank you banner"
 preview_link = "/wiki/Wikipedia:Hauptseite?devbanner={{banner}}&banner=B22_WMDE_local_prototype"
 preview_link_darkmode = "/wiki/Wikipedia:Hauptseite?devbanner={{banner}}&banner=B22_WMDE_local_prototype&vectornightmode=1"
+preview_link_offline = ""
 preview_url = 'https://de.wikipedia.org/wiki/Wikipedia:Hauptseite?banner={{banner}}&devMode'
 wrapper_template = "wikipedia_org"
 
@@ -37,6 +38,7 @@ campaign_tracking = "ty01-250101"
 description = "Thank you banner"
 preview_link = "/wiki/Main_Page?devbanner={{banner}}&banner=B22_WMDE_local_prototype"
 preview_link_darkmode = "/wiki/Main_Page?devbanner={{banner}}&banner=B22_WMDE_local_prototype&vectornightmode=1"
+preview_link_offline = ""
 preview_url = 'https://en.wikipedia.org/wiki/Main_Page?banner={{banner}}&devMode'
 wrapper_template = "wikipedia_org"
 
@@ -63,6 +65,7 @@ campaign_tracking = "ty01-mob-250101"
 description = "Thank you banner"
 preview_link = "/mobile/wiki/Wikipedia:Hauptseite?devbanner={{banner}}&useskin=minerva&banner=B22_WMDE_local_prototype"
 preview_link_darkmode = "/mobile/wiki/Wikipedia:Hauptseite?devbanner={{banner}}&useskin=minerva&banner=B22_WMDE_local_prototype&minervanightmode=1"
+preview_link_offline = ""
 preview_url = 'https://de.m.wikipedia.org/wiki/Wikipedia:Hauptseite?banner={{banner}}&devMode'
 wrapper_template = "wikipedia_org"
 
@@ -89,6 +92,7 @@ campaign_tracking = "ty01-mob-en-250101"
 description = "Thank you banner"
 preview_link = "/en-mobile/wiki/Main_Page?devbanner={{banner}}&useskin=minerva&banner=B22_WMDE_local_prototype"
 preview_link_darkmode = "/en-mobile/wiki/Main_Page?devbanner={{banner}}&useskin=minerva&banner=B22_WMDE_local_prototype&minervanightmode=1"
+preview_link_offline = ""
 preview_url = 'https://en.m.wikipedia.org/wiki/Main_Page?banner={{banner}}&devMode'
 wrapper_template = "wikipedia_org"
 
@@ -115,6 +119,7 @@ campaign_tracking = "ty01-ipad-250101"
 description = "Thank you banner"
 preview_link = "/wiki/Wikipedia:Hauptseite?devbanner={{banner}}&banner=B22_WMDE_local_prototype"
 preview_link_darkmode = "/wiki/Wikipedia:Hauptseite?devbanner={{banner}}&banner=B22_WMDE_local_prototype&vectornightmode=1"
+preview_link_offline = ""
 preview_url = 'https://de.wikipedia.org/wiki/Wikipedia:Hauptseite?banner={{banner}}&devMode'
 wrapper_template = "wikipedia_org"
 
@@ -141,6 +146,7 @@ campaign_tracking = "ty01-wpde-250101"
 description = "Thank you banner"
 preview_link = "/wikipedia.de?devbanner={{banner}}&banner=dev-mode-wpde"
 preview_link_darkmode = "/wikipedia.de?devbanner={{banner}}&banner=dev-mode-wpde"
+preview_link_offline = ""
 preview_url = 'https://www.wikipedia.de/?banner={{banner}}&devMode'
 wrapper_template = "wikipedia_de"
 wrap_in_wikitext = false
@@ -163,6 +169,7 @@ campaign_tracking = "ty01-wpde-mob-250101"
 description = "Thank you banner"
 preview_link = "/wikipedia.de?devbanner={{banner}}&banner=dev-mode-wpde"
 preview_link_darkmode = "/wikipedia.de?devbanner={{banner}}&banner=dev-mode-wpde"
+preview_link_offline = ""
 preview_url = 'https://www.wikipedia.de/?banner={{banner}}&devMode'
 wrapper_template = "wikipedia_de"
 wrap_in_wikitext = false

--- a/src/components/BannerConductor/BannerCategory.ts
+++ b/src/components/BannerConductor/BannerCategory.ts
@@ -1,0 +1,2 @@
+// these categories come from the CentralNotice banner settings ("categories")
+export type BannerCategory = 'fundraising'|'fundraisingThankyou';

--- a/src/components/BannerConductor/BannerConductor.vue
+++ b/src/components/BannerConductor/BannerConductor.vue
@@ -32,6 +32,7 @@ import { TrackingEvent } from '@src/tracking/TrackingEvent';
 import { CloseEvent } from '@src/tracking/events/CloseEvent';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
 import { Timer } from '@src/utils/Timer';
+import { BannerCategory } from '@src/components/BannerConductor/BannerCategory';
 
 interface Props {
 	page: Page,
@@ -40,6 +41,7 @@ interface Props {
 	banner: Object,
 	bannerProps?: Object,
 	impressionCount: ImpressionCount,
+	bannerCategory: BannerCategory
 }
 
 const props = withDefaults( defineProps<Props>(), {
@@ -49,7 +51,7 @@ const tracker = inject<Tracker>( 'tracker' );
 const timer = inject<Timer>( 'timer' );
 
 const bannerRef = ref( null );
-const stateFactory = newStateFactory( props.bannerConfig, props.page, tracker, props.resizeHandler, props.impressionCount, timer );
+const stateFactory = newStateFactory( props.bannerConfig, props.page, tracker, props.resizeHandler, props.impressionCount, timer, props.bannerCategory );
 const bannerState = ref<BannerState>( stateFactory.newInitialState() );
 const stateMachine = newBannerStateMachine( bannerState );
 

--- a/src/components/BannerConductor/FallbackBannerConductor.vue
+++ b/src/components/BannerConductor/FallbackBannerConductor.vue
@@ -33,6 +33,7 @@ import { CloseEvent } from '@src/tracking/events/CloseEvent';
 import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
 import { BannerNotShownReasons } from '@src/page/BannerNotShownReasons';
 import { Timer } from '@src/utils/Timer';
+import { BannerCategory } from '@src/components/BannerConductor/BannerCategory';
 
 interface Props {
 	page: Page,
@@ -43,6 +44,7 @@ interface Props {
 	minWidthForMainBanner: number,
 	bannerProps?: Object,
 	impressionCount: ImpressionCount,
+	bannerCategory: BannerCategory
 }
 
 const props = withDefaults( defineProps<Props>(), {
@@ -53,7 +55,7 @@ const timer = inject<Timer>( 'timer' );
 
 const banner = shallowRef<Object>( props.banner );
 const bannerRef = ref( null );
-const stateFactory = newStateFactory( props.bannerConfig, props.page, tracker, props.resizeHandler, props.impressionCount, timer );
+const stateFactory = newStateFactory( props.bannerConfig, props.page, tracker, props.resizeHandler, props.impressionCount, timer, props.bannerCategory );
 const bannerState = ref<BannerState>( stateFactory.newInitialState() );
 const stateMachine = newBannerStateMachine( bannerState );
 

--- a/src/components/BannerConductor/StateMachine/states/ClosedState.ts
+++ b/src/components/BannerConductor/StateMachine/states/ClosedState.ts
@@ -5,10 +5,12 @@ import { Tracker } from '@src/tracking/Tracker';
 import { ResizeHandler } from '@src/utils/ResizeHandler';
 import { TrackingEvent } from '@src/tracking/TrackingEvent';
 import { Timer } from '@src/utils/Timer';
+import { BannerCategory } from '@src/components/BannerConductor/BannerCategory';
 
 export class ClosedState extends BannerState {
 	public readonly stateName: BannerStates = BannerStates.Closed;
 	private readonly _closeEvent: TrackingEvent<void>;
+	private readonly _bannerCategory: BannerCategory;
 	private _page: Page;
 	private _tracker: Tracker;
 	private _resizeHandler: ResizeHandler;
@@ -16,6 +18,7 @@ export class ClosedState extends BannerState {
 
 	public constructor(
 		closeEvent: TrackingEvent<void>,
+		bannerCategory: BannerCategory,
 		page: Page,
 		tracker: Tracker,
 		resizeHandler: ResizeHandler,
@@ -23,6 +26,7 @@ export class ClosedState extends BannerState {
 	) {
 		super();
 		this._closeEvent = closeEvent;
+		this._bannerCategory = bannerCategory;
 		this._page = page;
 		this._tracker = tracker;
 		this._resizeHandler = resizeHandler;
@@ -34,7 +38,7 @@ export class ClosedState extends BannerState {
 		this._page
 			.unsetAnimated()
 			.setSpace( 0 )
-			.setCloseCookieIfNecessary( this._closeEvent )
+			.setCloseCookieIfNecessary( this._closeEvent, this._bannerCategory )
 			.removePageEventListeners();
 		this._resizeHandler.onClose();
 		this._timer.clearAll();

--- a/src/components/BannerConductor/StateMachine/states/StateFactory.ts
+++ b/src/components/BannerConductor/StateMachine/states/StateFactory.ts
@@ -13,6 +13,7 @@ import { ClosedState } from '@src/components/BannerConductor/StateMachine/states
 import { InitialState } from '@src/components/BannerConductor/StateMachine/states/InitialState';
 import { TrackingEvent, TrackingFeatureName } from '@src/tracking/TrackingEvent';
 import { Timer } from '@src/utils/Timer';
+import { BannerCategory } from '@src/components/BannerConductor/BannerCategory';
 
 export class StateFactory {
 	private readonly _bannerConfig: BannerConfig;
@@ -21,14 +22,22 @@ export class StateFactory {
 	private readonly _resizeHandler: ResizeHandler;
 	private readonly _impressionCount: ImpressionCount;
 	private readonly _timer: Timer;
+	private readonly _bannerCategory: BannerCategory;
 
-	public constructor( bannerConfig: BannerConfig, page: Page, tracker: Tracker, resizeHandler: ResizeHandler, impressionCount: ImpressionCount, timer: Timer ) {
+	public constructor(
+		bannerConfig: BannerConfig,
+		page: Page, tracker: Tracker,
+		resizeHandler: ResizeHandler,
+		impressionCount: ImpressionCount,
+		timer: Timer,
+		bannerCategory: BannerCategory ) {
 		this._bannerConfig = bannerConfig;
 		this._page = page;
 		this._tracker = tracker;
 		this._resizeHandler = resizeHandler;
 		this._impressionCount = impressionCount;
 		this._timer = timer;
+		this._bannerCategory = bannerCategory;
 	}
 
 	public newInitialState(): BannerState {
@@ -52,7 +61,7 @@ export class StateFactory {
 	}
 
 	public newClosedState( closeEvent: TrackingEvent<void> ): BannerState {
-		return new ClosedState( closeEvent, this._page, this._tracker, this._resizeHandler, this._timer );
+		return new ClosedState( closeEvent, this._bannerCategory, this._page, this._tracker, this._resizeHandler, this._timer );
 	}
 }
 
@@ -62,7 +71,8 @@ export function newStateFactory(
 	tracker: Tracker,
 	resizeHandler: ResizeHandler,
 	impressionCount: ImpressionCount,
-	timer: Timer
+	timer: Timer,
+	bannerCategory: BannerCategory
 ): StateFactory {
 	return new StateFactory(
 		bannerConfig,
@@ -70,6 +80,7 @@ export function newStateFactory(
 		tracker,
 		resizeHandler,
 		impressionCount,
-		timer
+		timer,
+		bannerCategory
 	);
 }

--- a/src/page/MediaWiki/MediaWiki.ts
+++ b/src/page/MediaWiki/MediaWiki.ts
@@ -1,6 +1,7 @@
 import { LegacyBannerEvent } from '@src/page/MediaWiki/LegacyBannerEvent';
 import { SizeIssue } from '@src/page/MediaWiki/SizeIssue';
 import { BannerEvent } from '@src/page/MediaWiki/BannerEvent';
+import { BannerCategory } from '@src/components/BannerConductor/BannerCategory';
 
 export interface MediaWiki {
 	getConfigItem( name: string ): any;
@@ -8,8 +9,8 @@ export interface MediaWiki {
 	isContentHiddenByLightbox: () => boolean;
 	isInArticleNamespace: () => boolean;
 	track: ( name: string, trackingData: BannerEvent|LegacyBannerEvent|SizeIssue ) => void;
-	preventBannerDisplayForPeriod: () => void;
-	preventBannerDisplayUntilEndOfCampaign: () => void;
-	preventBannerDisplayForHours: ( hours: number ) => void;
+	preventBannerDisplayForPeriod: ( bannerCategory: BannerCategory ) => void;
+	preventBannerDisplayUntilEndOfCampaign: ( bannerCategory: BannerCategory ) => void;
+	preventBannerDisplayForHours: ( hours: number, bannerCategory: BannerCategory ) => void;
 	setBannerLoadedButHidden: () => void;
 }

--- a/src/page/MediaWiki/WindowMediaWiki.ts
+++ b/src/page/MediaWiki/WindowMediaWiki.ts
@@ -4,6 +4,7 @@ import { SizeIssue } from '@src/page/MediaWiki/SizeIssue';
 import { BannerEvent } from '@src/page/MediaWiki/BannerEvent';
 import { setCookie } from '@src/page/MediaWiki/setCookie';
 import { createImageCookieSetter } from '@src/page/MediaWiki/createImageCookieSetter';
+import { BannerCategory } from '@src/components/BannerConductor/BannerCategory';
 
 interface MediaWikiTools {
 	config: { get: ( item: string ) => any };
@@ -53,29 +54,29 @@ export class WindowMediaWiki implements MediaWiki {
 		window.mw.track( name, trackingData );
 	}
 
-	public preventBannerDisplayForPeriod(): void {
-		this.hideBanner( 'close', this.getConfigItem( 'wgNoticeCookieDurations' ).close );
+	public preventBannerDisplayForPeriod( bannerCategory: BannerCategory ): void {
+		this.hideBanner( 'close', this.getConfigItem( 'wgNoticeCookieDurations' ).close, bannerCategory );
 	}
 
-	public preventBannerDisplayUntilEndOfCampaign(): void {
+	public preventBannerDisplayUntilEndOfCampaign( bannerCategory: BannerCategory ): void {
 		const endOfYear = new Date( new Date().getFullYear(), 11, 31, 23, 59, 59 );
 		const secondsToEndOfYear = Math.abs( ( endOfYear.getTime() - Date.now() ) / 1000 );
-		this.hideBanner( 'donate', secondsToEndOfYear );
+		this.hideBanner( 'donate', secondsToEndOfYear, bannerCategory );
 	}
 
-	public preventBannerDisplayForHours( hours: number ): void {
+	public preventBannerDisplayForHours( hours: number, bannerCategory: BannerCategory ): void {
 		const until = new Date();
 		until.setHours( until.getHours() + hours );
 		const secondsToHideBannerFor = Math.abs( ( until.getTime() - Date.now() ) / 1000 );
-		this.hideBanner( 'donate', secondsToHideBannerFor );
+		this.hideBanner( 'donate', secondsToHideBannerFor, bannerCategory );
 	}
 
 	public setBannerLoadedButHidden(): void {
 		window.mw.centralNotice.setBannerLoadedButHidden();
 	}
 
-	private hideBanner( reason: string, durationInSeconds: number ): void {
-		setCookie( reason, new Date(), durationInSeconds );
+	private hideBanner( reason: string, durationInSeconds: number, bannerCategory: BannerCategory ): void {
+		setCookie( reason, new Date(), durationInSeconds, bannerCategory );
 		createImageCookieSetter( reason, durationInSeconds, this.getConfigItem( 'wgNoticeHideUrls' )[ 0 ] );
 	}
 }

--- a/src/page/MediaWiki/setCookie.ts
+++ b/src/page/MediaWiki/setCookie.ts
@@ -1,6 +1,8 @@
-const COOKIE_NAME = 'centralnotice_hide_fundraising';
+import { BannerCategory } from '@src/components/BannerConductor/BannerCategory';
 
-export function setCookie( reason: string, created: Date, durationInSeconds: number ): void {
+const COOKIE_NAME = 'centralnotice_hide_';
+
+export function setCookie( reason: string, created: Date, durationInSeconds: number, cookieNameSuffix: BannerCategory ): void {
 	const expiryDate = new Date( created.getTime() );
 	expiryDate.setSeconds( created.getSeconds() + durationInSeconds );
 
@@ -10,5 +12,6 @@ export function setCookie( reason: string, created: Date, durationInSeconds: num
 		reason: reason
 	};
 
-	document.cookie = `${ COOKIE_NAME }=${ encodeURIComponent( JSON.stringify( hideData ) ) }; expires=${ expiryDate.toUTCString() }; path=/; SameSite=None;`;
+	const fullCookieName = COOKIE_NAME + cookieNameSuffix;
+	document.cookie = `${ fullCookieName }=${ encodeURIComponent( JSON.stringify( hideData ) ) }; expires=${ expiryDate.toUTCString() }; path=/; SameSite=None;`;
 }

--- a/src/page/Page.ts
+++ b/src/page/Page.ts
@@ -3,6 +3,7 @@ import { BannerNotShownReasons } from '@src/page/BannerNotShownReasons';
 import { Vector2 } from '@src/utils/Vector2';
 import { TrackingParameters } from '@src/domain/TrackingParameters';
 import { TrackingEvent } from '@src/tracking/TrackingEvent';
+import { BannerCategory } from '@src/components/BannerConductor/BannerCategory';
 
 export interface Page {
 	getReasonToNotShowBanner: ( bannerDimensions: Vector2 ) => BannerNotShownReasons|null;
@@ -15,7 +16,7 @@ export interface Page {
 	unsetAnimated: () => Page;
 	showBanner: () => Page;
 	preventImpressionCountForHiddenBanner: () => Page;
-	setCloseCookieIfNecessary: ( closeEvent: TrackingEvent<void> ) => Page;
+	setCloseCookieIfNecessary: ( closeEvent: TrackingEvent<void>, bannerCategory: BannerCategory ) => Page;
 	getCampaignParameters: () => CampaignParameters;
 	getTracking: () => TrackingParameters;
 	setModalOpened: () => void;

--- a/src/page/PageWPORG.ts
+++ b/src/page/PageWPORG.ts
@@ -10,6 +10,7 @@ import { TrackingParameters } from '@src/domain/TrackingParameters';
 import { CloseChoices } from '@src/domain/CloseChoices';
 import { TrackingEvent } from '@src/tracking/TrackingEvent';
 import { ChannelNameWPORG } from '@src/page/ChannelNameWPORG';
+import { BannerCategory } from '@src/components/BannerConductor/BannerCategory';
 
 export const bannerAppId = 'wmde-banner-app';
 export const bannerAnimatedClass = 'wmde-animate-banner';
@@ -113,7 +114,7 @@ class PageWPORG implements Page {
 		return this;
 	}
 
-	public setCloseCookieIfNecessary( closeEvent: TrackingEvent<void> ): Page {
+	public setCloseCookieIfNecessary( closeEvent: TrackingEvent<void>, bannerCategory: BannerCategory ): Page {
 
 		// remove banner class (and changes to the wikipedia skin) when the banner hides
 		document.body.classList.remove( showBannerClass );
@@ -121,16 +122,16 @@ class PageWPORG implements Page {
 		switch ( closeEvent.userChoice ) {
 			case CloseChoices.Close:
 			case CloseChoices.TimeOut:
-				this._mediaWiki.preventBannerDisplayForPeriod();
+				this._mediaWiki.preventBannerDisplayForPeriod( bannerCategory );
 				break;
 			case CloseChoices.NoMoreBannersForCampaign:
-				this._mediaWiki.preventBannerDisplayUntilEndOfCampaign();
+				this._mediaWiki.preventBannerDisplayUntilEndOfCampaign( bannerCategory );
 				break;
 			case CloseChoices.MaybeLater:
-				this._mediaWiki.preventBannerDisplayForHours( 6 );
+				this._mediaWiki.preventBannerDisplayForHours( 6, bannerCategory );
 				break;
 			case CloseChoices.AlreadyDonated:
-				this._mediaWiki.preventBannerDisplayForHours( 4 * 7 * 24 );
+				this._mediaWiki.preventBannerDisplayForHours( 4 * 7 * 24, bannerCategory );
 				break;
 			case CloseChoices.Hide:
 				// Don't add cookie

--- a/test/components/BannerConductor/BannerConductor.spec.ts
+++ b/test/components/BannerConductor/BannerConductor.spec.ts
@@ -60,7 +60,8 @@ describe( 'BannerConductor.vue', () => {
 				bannerConfig: { delay: 42, transitionDuration: 5 },
 				resizeHandler: resizeHandler ?? new ResizeHandlerStub(),
 				banner: markRaw( banner ),
-				impressionCount: new ImpressionCountStub()
+				impressionCount: new ImpressionCountStub(),
+				bannerCategory: 'fundraising'
 			},
 			global: {
 				provide: {
@@ -193,7 +194,7 @@ describe( 'BannerConductor.vue', () => {
 		const wrapper = await getShownBannerWrapper( page );
 		await wrapper.find( '.emit-banner-closed' ).trigger( 'click' );
 
-		expect( page.setCloseCookieIfNecessary ).toHaveBeenCalledWith( new CloseEvent( 'MainBanner', 'closed' ) );
+		expect( page.setCloseCookieIfNecessary ).toHaveBeenCalledWith( new CloseEvent( 'MainBanner', 'closed' ), 'fundraising' );
 	} );
 
 	it( 'moves to closed state when an page event that should hide the banner happens', async () => {

--- a/test/components/BannerConductor/FallbackBannerConductor.spec.ts
+++ b/test/components/BannerConductor/FallbackBannerConductor.spec.ts
@@ -68,7 +68,8 @@ describe( 'FallbackBannerConductor.vue', () => {
 				banner: markRaw( banner ),
 				fallbackBanner: markRaw( fallbackBanner ),
 				minWidthForMainBanner: 800,
-				impressionCount: new ImpressionCountStub()
+				impressionCount: new ImpressionCountStub(),
+				bannerCategory: 'fundraising'
 			},
 			global: {
 				provide: {
@@ -264,7 +265,7 @@ describe( 'FallbackBannerConductor.vue', () => {
 		const wrapper = await getShownBannerWrapper( page );
 		await wrapper.find( '.emit-banner-closed' ).trigger( 'click' );
 
-		expect( page.setCloseCookieIfNecessary ).toHaveBeenCalledWith( new CloseEvent( 'MainBanner', 'closed' ) );
+		expect( page.setCloseCookieIfNecessary ).toHaveBeenCalledWith( new CloseEvent( 'MainBanner', 'closed' ), 'fundraising' );
 	} );
 
 	it( 'moves to closed state when an page event that should hide the banner happens', async () => {

--- a/test/components/BannerConductor/StateMachine/states/ClosedState.spec.ts
+++ b/test/components/BannerConductor/StateMachine/states/ClosedState.spec.ts
@@ -14,6 +14,7 @@ describe( 'ClosedState', function () {
 		const closeEvent = new CloseEvent( 'MainBanner', CloseChoices.Close );
 		const state = new ClosedState(
 			closeEvent,
+			'fundraising',
 			new PageStub(),
 			tracker,
 			new ResizeHandlerStub(),
@@ -31,6 +32,7 @@ describe( 'ClosedState', function () {
 		page.unsetAnimated = vitest.fn( () => page );
 		const state = new ClosedState(
 			new CloseEvent( 'MainBanner', CloseChoices.Close ),
+			'fundraising',
 			page,
 			new TrackerStub(),
 			new ResizeHandlerStub(),
@@ -49,6 +51,7 @@ describe( 'ClosedState', function () {
 		const closeEvent = new CloseEvent( 'MainBanner', CloseChoices.Close );
 		const state = new ClosedState(
 			closeEvent,
+			'fundraising',
 			page,
 			new TrackerStub(),
 			new ResizeHandlerStub(),
@@ -58,7 +61,7 @@ describe( 'ClosedState', function () {
 		state.enter();
 
 		expect( page.setCloseCookieIfNecessary ).toHaveBeenCalledOnce();
-		expect( page.setCloseCookieIfNecessary ).toHaveBeenCalledWith( closeEvent );
+		expect( page.setCloseCookieIfNecessary ).toHaveBeenCalledWith( closeEvent, 'fundraising' );
 	} );
 
 	it( 'removes the event listeners', function () {
@@ -68,6 +71,7 @@ describe( 'ClosedState', function () {
 		resizeHandler.onClose = vitest.fn();
 		const state = new ClosedState(
 			new CloseEvent( 'MainBanner', CloseChoices.Close ),
+			'fundraising',
 			page,
 			new TrackerStub(),
 			resizeHandler,
@@ -84,6 +88,7 @@ describe( 'ClosedState', function () {
 		const timer = new TimerSpy();
 		const state = new ClosedState(
 			new CloseEvent( 'MainBanner', CloseChoices.Close ),
+			'fundraising',
 			new PageStub(),
 			new TrackerStub(),
 			new ResizeHandlerStub(),
@@ -98,6 +103,7 @@ describe( 'ClosedState', function () {
 	it( 'throws error on exit', function () {
 		const state = new ClosedState(
 			new CloseEvent( 'MainBanner', CloseChoices.Close ),
+			'fundraising',
 			new PageStub(),
 			new TrackerStub(),
 			new ResizeHandlerStub(),

--- a/test/integration/page/MediaWiki/setCookie.spec.ts
+++ b/test/integration/page/MediaWiki/setCookie.spec.ts
@@ -2,14 +2,38 @@ import { describe, expect, it } from 'vitest';
 import { setCookie } from '@src/page/MediaWiki/setCookie';
 
 describe( 'setCookie', () => {
-	it( 'sets the cookie', () => {
+	it( 'sets the cookie for fundraising banners', () => {
 		const tenDaysInSeconds = 60 * 60 * 24 * 10;
 		Object.defineProperty( document, 'cookie', { writable: true, configurable: true, value: '' } );
 
-		setCookie( 'testReason', new Date( 'August 29, 1997 02:14:00 GMT' ), tenDaysInSeconds );
+		setCookie(
+			'testReason',
+			new Date( 'August 29, 1997 02:14:00 GMT' ),
+			tenDaysInSeconds,
+			'fundraising'
+		);
 
 		expect( document.cookie ).toBe( [
 			'centralnotice_hide_fundraising=%7B%22v%22%3A1%2C%22created%22%3A872820840%2C%22reason%22%3A%22testReason%22%7D;',
+			'expires=Mon, 08 Sep 1997 02:14:00 GMT;',
+			'path=/;',
+			'SameSite=None;'
+		].join( ' ' ) );
+	} );
+
+	it( 'sets the cookie for thankyou banners', () => {
+		const tenDaysInSeconds = 60 * 60 * 24 * 10;
+		Object.defineProperty( document, 'cookie', { writable: true, configurable: true, value: '' } );
+
+		setCookie(
+			'testReason',
+			new Date( 'August 29, 1997 02:14:00 GMT' ),
+			tenDaysInSeconds,
+			'fundraisingThankyou'
+		);
+
+		expect( document.cookie ).toBe( [
+			'centralnotice_hide_fundraisingThankyou=%7B%22v%22%3A1%2C%22created%22%3A872820840%2C%22reason%22%3A%22testReason%22%7D;',
 			'expires=Mon, 08 Sep 1997 02:14:00 GMT;',
 			'path=/;',
 			'SameSite=None;'

--- a/test/integration/page/PageWPORG.spec.ts
+++ b/test/integration/page/PageWPORG.spec.ts
@@ -12,6 +12,8 @@ import { CloseEvent } from '@src/tracking/events/CloseEvent';
 describe( 'PageWPORG', function () {
 	let mediaWiki: MediaWiki;
 
+	const bannerTestCategory = 'fundraising';
+
 	beforeEach( () => {
 		mediaWiki = {
 			isInArticleNamespace(): boolean {
@@ -88,7 +90,10 @@ describe( 'PageWPORG', function () {
 	it( 'stores "close" cookie for already donated "enough for this year" events', () => {
 		const page = new PageWPORG( mediaWiki, new SkinStub(), new SizeIssueCheckerStub() );
 
-		page.setCloseCookieIfNecessary( new CloseEvent( 'AlreadyDonated', CloseChoices.NoMoreBannersForCampaign ) );
+		page.setCloseCookieIfNecessary(
+			new CloseEvent( 'AlreadyDonated', CloseChoices.NoMoreBannersForCampaign ),
+			bannerTestCategory
+		);
 
 		expect( mediaWiki.preventBannerDisplayUntilEndOfCampaign ).toHaveBeenCalledOnce();
 	} );
@@ -96,7 +101,10 @@ describe( 'PageWPORG', function () {
 	it( 'does not store cookie for the AlreadyDonated "Maybe Later" event', () => {
 		const page = new PageWPORG( mediaWiki, new SkinStub(), new SizeIssueCheckerStub() );
 
-		page.setCloseCookieIfNecessary( new CloseEvent( 'AlreadyDonated', CloseChoices.MaybeLater ) );
+		page.setCloseCookieIfNecessary(
+			new CloseEvent( 'AlreadyDonated', CloseChoices.MaybeLater ),
+			bannerTestCategory
+		);
 
 		expect( mediaWiki.preventBannerDisplayUntilEndOfCampaign ).not.toHaveBeenCalledOnce();
 	} );
@@ -104,7 +112,10 @@ describe( 'PageWPORG', function () {
 	it( 'does not store cookie for the "Hide" event', () => {
 		const page = new PageWPORG( mediaWiki, new SkinStub(), new SizeIssueCheckerStub() );
 
-		page.setCloseCookieIfNecessary( new CloseEvent( 'FullPageBanner', CloseChoices.Hide ) );
+		page.setCloseCookieIfNecessary(
+			new CloseEvent( 'FullPageBanner', CloseChoices.Hide ),
+			bannerTestCategory
+		);
 
 		expect( mediaWiki.preventBannerDisplayUntilEndOfCampaign ).not.toHaveBeenCalledOnce();
 	} );
@@ -112,7 +123,10 @@ describe( 'PageWPORG', function () {
 	it( 'stores close cookie when user closes soft close', () => {
 		const page = new PageWPORG( mediaWiki, new SkinStub(), new SizeIssueCheckerStub() );
 
-		page.setCloseCookieIfNecessary( new CloseEvent( 'SoftClose', CloseChoices.Close ) );
+		page.setCloseCookieIfNecessary(
+			new CloseEvent( 'SoftClose', CloseChoices.Close ),
+			bannerTestCategory
+		);
 
 		expect( mediaWiki.preventBannerDisplayForPeriod ).toHaveBeenCalledOnce();
 	} );
@@ -120,7 +134,10 @@ describe( 'PageWPORG', function () {
 	it( 'stores close cookie when user ignores soft close', () => {
 		const page = new PageWPORG( mediaWiki, new SkinStub(), new SizeIssueCheckerStub() );
 
-		page.setCloseCookieIfNecessary( new CloseEvent( 'SoftClose', CloseChoices.TimeOut ) );
+		page.setCloseCookieIfNecessary(
+			new CloseEvent( 'SoftClose', CloseChoices.TimeOut ),
+			bannerTestCategory
+		);
 
 		expect( mediaWiki.preventBannerDisplayForPeriod ).toHaveBeenCalledOnce();
 	} );
@@ -128,7 +145,10 @@ describe( 'PageWPORG', function () {
 	it( 'stores close cookie when user closes main banner', () => {
 		const page = new PageWPORG( mediaWiki, new SkinStub(), new SizeIssueCheckerStub() );
 
-		page.setCloseCookieIfNecessary( new CloseEvent( 'MainBanner', CloseChoices.Close ) );
+		page.setCloseCookieIfNecessary(
+			new CloseEvent( 'MainBanner', CloseChoices.Close ),
+			bannerTestCategory
+		);
 
 		expect( mediaWiki.preventBannerDisplayForPeriod ).toHaveBeenCalledOnce();
 	} );
@@ -136,7 +156,10 @@ describe( 'PageWPORG', function () {
 	it( 'stores close cookie when user closes mini banner', () => {
 		const page = new PageWPORG( mediaWiki, new SkinStub(), new SizeIssueCheckerStub() );
 
-		page.setCloseCookieIfNecessary( new CloseEvent( 'MiniBanner', CloseChoices.Close ) );
+		page.setCloseCookieIfNecessary(
+			new CloseEvent( 'MiniBanner', CloseChoices.Close ),
+			bannerTestCategory
+		);
 
 		expect( mediaWiki.preventBannerDisplayForPeriod ).toHaveBeenCalledOnce();
 	} );
@@ -144,10 +167,13 @@ describe( 'PageWPORG', function () {
 	it( 'stores close cookie when user closes with maybe later', () => {
 		const page = new PageWPORG( mediaWiki, new SkinStub(), new SizeIssueCheckerStub() );
 
-		page.setCloseCookieIfNecessary( new CloseEvent( 'SoftClose', CloseChoices.MaybeLater ) );
+		page.setCloseCookieIfNecessary(
+			new CloseEvent( 'SoftClose', CloseChoices.MaybeLater ),
+			bannerTestCategory
+		);
 
 		expect( mediaWiki.preventBannerDisplayForHours ).toHaveBeenCalledOnce();
-		expect( mediaWiki.preventBannerDisplayForHours ).toHaveBeenCalledWith( 6 );
+		expect( mediaWiki.preventBannerDisplayForHours ).toHaveBeenCalledWith( 6, bannerTestCategory );
 	} );
 
 	it( 'returns campaign parameters', () => {


### PR DESCRIPTION
Add parameter for close cookie name suffix
    
    - this allows to differ betweet close cookies caused by thankyou banners vs. usual fundraising banners

- [x] Thank you banners are displayed if a fundraising banner was closed before.
- [x] Thank you banners can be assigned a category other than "fundraising".


- CentralNotice categorizes the banners into `fundraising` vs. `fr-thankyou` and checks the cookie for that string.

    
https://phabricator.wikimedia.org/T383110
