### PR TITLE
Output ECMAScript 6 from Typescript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,12 @@
 {
 	"compilerOptions": {
-		"target": "es5",
+		"target": "es6",
 		"skipLibCheck": true,
 		"outDir": "./dist/",
 		"noImplicitAny": true,
 		"baseUrl": ".",
 		"resolveJsonModule": true,
+		"moduleResolution": "node",
 		"paths": {
 			"@banners/*": [ "banners/*" ],
 			"@src/*": [ "src/*" ],
@@ -14,9 +15,9 @@
 		},
 		"lib": [
 			"dom",
-			"es5",
+			"dom.iterable",
+			"es6",
 			"scripthost",
-			"es2015.promise"
 		]
 	}
 }


### PR DESCRIPTION
This commit updates the ESLint target of compiled TypeScript code
to `es6`. This is a more reasonable target that includes all browsers
since 2015 and just drops some really old browsers. It will avoid
about 50KB of unnecessary polyfills in the compiled banner code.

This change is in line with the browser support list of the MediaWiki
project, see https://www.mediawiki.org/wiki/Compatibility#Browser_support_matrix

The new "lib" values reflect the default "lib" values of ES6.
