### PR TITLE
Remove deprecated urgencyMessageDaysLeft parameter

### DIFF
--- a/banners/mobile/C25_WMDE_Mobile_DE_00/banner_ctrl.ts
+++ b/banners/mobile/C25_WMDE_Mobile_DE_00/banner_ctrl.ts
@@ -59,8 +59,7 @@ app.use( DynamicTextPlugin, {
 	date,
 	formatters: localeFactory.getFormatters(),
 	impressionCount,
-	translator,
-	urgencyMessageDaysLeft: 45
+	translator
 } );
 
 app.provide( 'currencyFormatter', currencyFormatter );

--- a/banners/mobile/C25_WMDE_Mobile_DE_00/banner_var.ts
+++ b/banners/mobile/C25_WMDE_Mobile_DE_00/banner_var.ts
@@ -59,8 +59,7 @@ app.use( DynamicTextPlugin, {
 	date,
 	formatters: localeFactory.getFormatters(),
 	impressionCount,
-	translator,
-	urgencyMessageDaysLeft: 45
+	translator
 } );
 
 app.provide( 'currencyFormatter', currencyFormatter );

--- a/src/DynamicTextPlugin.ts
+++ b/src/DynamicTextPlugin.ts
@@ -11,10 +11,6 @@ interface DynamicCampaignTextOptions {
 	formatters: Formatters;
 	campaignParameters: CampaignParameters;
 	impressionCount: ImpressionCount;
-	/**
-	 * @deprecated This should be removed in the 2025 campaign cleanup
-	 */
-	urgencyMessageDaysLeft?: number;
 }
 
 export default {


### PR DESCRIPTION
- removes the parameter from the DynamicTextPlugin
- the value comes from the CampaignParameters nowadays

https://phabricator.wikimedia.org/T384684