### PR TITLE
Improve vitest configuration

### DIFF
--- a/test/banners/desktop/C25_WMDE_Desktop_DE_00/components/FallbackBanner.spec.ts
+++ b/test/banners/desktop/C25_WMDE_Desktop_DE_00/components/FallbackBanner.spec.ts
@@ -29,6 +29,7 @@ describe( 'FallbackBanner.vue', () => {
 				provide: {
 					translator: { translate: translator },
 					dynamicCampaignText: dynamicContent ?? newDynamicContent(),
+					currentCampaignTimePercentage: 42,
 					tracker: tracker ?? new TrackerStub(),
 					timer: timer ?? new TimerStub()
 				}

--- a/test/components/DonationForm/StepControllers/SubmittableMainDonationForm.spec.ts
+++ b/test/components/DonationForm/StepControllers/SubmittableMainDonationForm.spec.ts
@@ -77,6 +77,6 @@ describe( 'SubmittableMainDonationForm', () => {
 	it( 'rejects calls to previous', async () => {
 		const donationForm = createSubmittableMainDonationForm( formModel, 'yearly' );
 
-		expect( donationForm.previous( stepNavigation ) ).rejects.toEqual( 'we can\'t go to previous! This should never happen' );
+		await expect( donationForm.previous( stepNavigation ) ).rejects.toEqual( 'we can\'t go to previous! This should never happen' );
 	} );
 } );

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -7,11 +7,35 @@ export default defineConfig( {
 
 	test: {
 		globals: false,
-		environmentMatchGlobs: [
-			[ 'test/unit/**', 'node' ],
-			[ 'test/integration/**', 'jsdom' ],
-			[ 'test/components/**', 'jsdom' ],
-			[ 'test/banners/**', 'jsdom' ]
+		workspace: [
+			// The `just-the-defaults` directory is a "workspace" that does not exist.
+			// We only use it to define the shared defaults (coverage and resolve aliases) for the others
+			// See https://vitest.dev/guide/workspace.html
+			'just-the-defaults/*',
+			{
+				extends: true,
+				test: {
+					include: [ 'test/unit/**/*.spec.ts' ],
+					name: 'unit',
+					environment: 'node',
+				},
+			},
+			{
+				extends: true,
+				test: {
+					include: [ 'test/components/**/*.spec.ts', 'test/integration/**/*.spec.ts' ],
+					name: 'integration',
+					environment: 'jsdom',
+				},
+			},
+			{
+				extends: true,
+				test: {
+					include: [ 'test/banners/**/*.spec.ts' ],
+					name: 'banners',
+					environment: 'jsdom',
+				},
+			},
 		],
 		coverage: {
 			exclude: [
@@ -20,14 +44,14 @@ export default defineConfig( {
 				// Ignore entry points, form items, event mappings and translations in each banner.
 				// The entry points are just factories, the other files are configurations written in TypeScript
 				'banners/*/*/{banner_ctrl,banner_var,form_items,form_items_var,event_map,event_map_var,messages,messages_var}.ts',
-				
+
 				// Ignore translation files and Locale Factories
 				'src/**/messages/*',
 				'src/utils/LocaleFactory/*',
-				
+
 				// Ignore environment-specific setup files
 				'src/environment/*',
-				
+
 				// Additional non-banner files that are not relevant for coverage
 				'dashboard/*',
 				'dist/*',
@@ -38,15 +62,15 @@ export default defineConfig( {
 				'webpack.common.js',
 				'webpack.production.js',
 				'webpack.config.js',
-			]
-		}
+			],
+		},
 	},
 	resolve: {
 		alias: {
 			'@banners': path.resolve( __dirname, './banners' ),
 			'@src': path.resolve( __dirname, './src' ),
 			'@environment': path.resolve( __dirname, './src/environment/prod' ),
-			'@test': path.resolve( __dirname, './test' )
-		}
-	}
+			'@test': path.resolve( __dirname, './test' ),
+		},
+	},
 } );


### PR DESCRIPTION
Remove warnings from test:

- deprecated vitest configuration options
- deprecated behavior (missing `await` in test that calls an async function)
- missing injection in fallback banner test

Ticket: https://phabricator.wikimedia.org/T385555