### PR TITLE
Separate "campaign parameters" and "thankyou campaign parameters"

### DIFF
--- a/banners/thank_you/banner_ctrl.de.ts
+++ b/banners/thank_you/banner_ctrl.de.ts
@@ -38,7 +38,7 @@ const app = createVueApp( BannerConductor, {
 	},
 	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
-		settings: createThankYouSettings( new IntegerDe(), page.getCampaignParameters().thankYouCampaign ),
+		settings: createThankYouSettings( new IntegerDe(), page.getThankYouCampaignParameters() ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, Locales.DE ),
 		useOfFundsURL: createTrackedURL( USE_OF_FUNDS_URL, page.getTracking(), impressionCount, Locales.DE )
 	},

--- a/banners/thank_you/banner_ctrl.en.ts
+++ b/banners/thank_you/banner_ctrl.en.ts
@@ -38,7 +38,7 @@ const app = createVueApp( BannerConductor, {
 	},
 	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
-		settings: createThankYouSettings( new IntegerEn(), page.getCampaignParameters().thankYouCampaign ),
+		settings: createThankYouSettings( new IntegerEn(), page.getThankYouCampaignParameters() ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, Locales.EN ),
 		useOfFundsURL: createTrackedURL( USE_OF_FUNDS_URL, page.getTracking(), impressionCount, Locales.EN )
 	},

--- a/banners/thank_you/banner_ctrl.wpde.ts
+++ b/banners/thank_you/banner_ctrl.wpde.ts
@@ -40,7 +40,7 @@ const app = createVueApp( BannerConductor, {
 	},
 	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
-		settings: createThankYouSettings( new IntegerDe(), page.getCampaignParameters().thankYouCampaign ),
+		settings: createThankYouSettings( new IntegerDe(), page.getThankYouCampaignParameters() ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, Locales.DE ),
 		useOfFundsURL: createTrackedURL( USE_OF_FUNDS_URL, page.getTracking(), impressionCount, Locales.DE )
 	},

--- a/banners/thank_you/banner_var.de.ts
+++ b/banners/thank_you/banner_var.de.ts
@@ -38,7 +38,7 @@ const app = createVueApp( BannerConductor, {
 	},
 	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
-		settings: createThankYouSettings( new IntegerDe(), page.getCampaignParameters().thankYouCampaign ),
+		settings: createThankYouSettings( new IntegerDe(), page.getThankYouCampaignParameters() ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, Locales.DE ),
 		useOfFundsURL: createTrackedURL( USE_OF_FUNDS_URL, page.getTracking(), impressionCount, Locales.DE )
 	},

--- a/banners/thank_you/banner_var.en.ts
+++ b/banners/thank_you/banner_var.en.ts
@@ -38,7 +38,7 @@ const app = createVueApp( BannerConductor, {
 	},
 	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
-		settings: createThankYouSettings( new IntegerEn(), page.getCampaignParameters().thankYouCampaign ),
+		settings: createThankYouSettings( new IntegerEn(), page.getThankYouCampaignParameters() ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, Locales.EN ),
 		useOfFundsURL: createTrackedURL( USE_OF_FUNDS_URL, page.getTracking(), impressionCount, Locales.EN )
 	},

--- a/banners/thank_you/banner_var.wpde.ts
+++ b/banners/thank_you/banner_var.wpde.ts
@@ -40,7 +40,7 @@ const app = createVueApp( BannerConductor, {
 	},
 	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
-		settings: createThankYouSettings( new IntegerDe(), page.getCampaignParameters().thankYouCampaign ),
+		settings: createThankYouSettings( new IntegerDe(), page.getThankYouCampaignParameters() ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, Locales.DE ),
 		useOfFundsURL: createTrackedURL( USE_OF_FUNDS_URL, page.getTracking(), impressionCount, Locales.DE )
 	},

--- a/banners/thank_you/settings.ts
+++ b/banners/thank_you/settings.ts
@@ -1,5 +1,5 @@
 import { Integer } from '@src/utils/DynamicContent/formatters/Integer';
-import { ThankYouCampaignParameters } from '@src/domain/CampaignParameters';
+import { ThankYouCampaignParameters } from '@src/domain/ThankYouCampaignParameters';
 
 export interface ThankYouSettings {
 	numberOfDonors: string;

--- a/banners/thank_you_2024/banner_ctrl.de.ts
+++ b/banners/thank_you_2024/banner_ctrl.de.ts
@@ -37,7 +37,7 @@ const app = createVueApp( BannerConductor, {
 	},
 	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
-		settings: createThankYouSettings( new IntegerDe(), page.getCampaignParameters().thankYouCampaign ),
+		settings: createThankYouSettings( new IntegerDe(), page.getThankYouCampaignParameters() ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, { locale: Locales.DE } ),
 		useOfFundsURL: createTrackedURL( USE_OF_FUNDS_URL, page.getTracking(), impressionCount, { locale: Locales.DE } ),
 		membershipWithAmountURL: createTrackedURL( MEMBERSHIP_FORM_URL, page.getTracking(), impressionCount, {

--- a/banners/thank_you_2024/banner_ctrl.en.ts
+++ b/banners/thank_you_2024/banner_ctrl.en.ts
@@ -37,7 +37,7 @@ const app = createVueApp( BannerConductor, {
 	},
 	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
-		settings: createThankYouSettings( new IntegerEn(), page.getCampaignParameters().thankYouCampaign ),
+		settings: createThankYouSettings( new IntegerEn(), page.getThankYouCampaignParameters() ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, { locale: Locales.EN } ),
 		useOfFundsURL: createTrackedURL( USE_OF_FUNDS_URL, page.getTracking(), impressionCount, { locale: Locales.EN } ),
 		membershipWithAmountURL: createTrackedURL( MEMBERSHIP_FORM_URL, page.getTracking(), impressionCount, {

--- a/banners/thank_you_2024/banner_ctrl.wpde.ts
+++ b/banners/thank_you_2024/banner_ctrl.wpde.ts
@@ -39,7 +39,7 @@ const app = createVueApp( BannerConductor, {
 	},
 	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
-		settings: createThankYouSettings( new IntegerDe(), page.getCampaignParameters().thankYouCampaign ),
+		settings: createThankYouSettings( new IntegerDe(), page.getThankYouCampaignParameters() ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, { locale: Locales.DE } ),
 		useOfFundsURL: createTrackedURL( USE_OF_FUNDS_URL, page.getTracking(), impressionCount, { locale: Locales.DE } ),
 		membershipWithAmountURL: createTrackedURL( MEMBERSHIP_FORM_URL, page.getTracking(), impressionCount, {

--- a/banners/thank_you_2024/banner_var.de.ts
+++ b/banners/thank_you_2024/banner_var.de.ts
@@ -37,7 +37,7 @@ const app = createVueApp( BannerConductor, {
 	},
 	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
-		settings: createThankYouSettings( new IntegerDe(), page.getCampaignParameters().thankYouCampaign ),
+		settings: createThankYouSettings( new IntegerDe(), page.getThankYouCampaignParameters() ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, { locale: Locales.DE } ),
 		useOfFundsURL: createTrackedURL( USE_OF_FUNDS_URL, page.getTracking(), impressionCount, { locale: Locales.DE } ),
 		membershipWithAmountURL: createTrackedURL( MEMBERSHIP_FORM_URL, page.getTracking(), impressionCount, {

--- a/banners/thank_you_2024/banner_var.en.ts
+++ b/banners/thank_you_2024/banner_var.en.ts
@@ -37,7 +37,7 @@ const app = createVueApp( BannerConductor, {
 	},
 	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
-		settings: createThankYouSettings( new IntegerEn(), page.getCampaignParameters().thankYouCampaign ),
+		settings: createThankYouSettings( new IntegerEn(), page.getThankYouCampaignParameters() ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, { locale: Locales.EN } ),
 		useOfFundsURL: createTrackedURL( USE_OF_FUNDS_URL, page.getTracking(), impressionCount, { locale: Locales.EN } ),
 		membershipWithAmountURL: createTrackedURL( MEMBERSHIP_FORM_URL, page.getTracking(), impressionCount, {

--- a/banners/thank_you_2024/banner_var.wpde.ts
+++ b/banners/thank_you_2024/banner_var.wpde.ts
@@ -39,7 +39,7 @@ const app = createVueApp( BannerConductor, {
 	},
 	bannerCategory: 'fundraisingThankyou',
 	bannerProps: {
-		settings: createThankYouSettings( new IntegerDe(), page.getCampaignParameters().thankYouCampaign ),
+		settings: createThankYouSettings( new IntegerDe(), page.getThankYouCampaignParameters() ),
 		subscribeURL: createTrackedURL( SUBSCRIBE_URL, page.getTracking(), impressionCount, { locale: Locales.DE } ),
 		useOfFundsURL: createTrackedURL( USE_OF_FUNDS_URL, page.getTracking(), impressionCount, { locale: Locales.DE } ),
 		membershipWithAmountURL: createTrackedURL( MEMBERSHIP_FORM_URL, page.getTracking(), impressionCount, {

--- a/banners/thank_you_2024/settings.ts
+++ b/banners/thank_you_2024/settings.ts
@@ -1,5 +1,5 @@
 import { Integer } from '@src/utils/DynamicContent/formatters/Integer';
-import { ThankYouCampaignParameters } from '@src/domain/CampaignParameters';
+import { ThankYouCampaignParameters } from '@src/domain/ThankYouCampaignParameters';
 
 export interface ThankYouSettings {
 	numberOfDonors: string;

--- a/dashboard/wpde-offline/index.html
+++ b/dashboard/wpde-offline/index.html
@@ -80,11 +80,13 @@
 		endDate: '2024-12-31',
 		numberOfMembers: 73832,
 		isLateProgress: true,
-		dramaTextIsVisible: false,
-		thankYouCampaign: {
-			numberOfDonors: 350000,
-			progressBarPercentage: 100
-		}
+		dramaTextIsVisible: false
+	};
+
+	window.thankYouCampaignParameters = {
+		numberOfDonors: 350000,
+		numberOfMembers: 73832,
+		progressBarPercentage: 100
 	};
 
 	// drop-in replacement for dev-mode-wpde.js "banner" from bruce, without jQuery

--- a/src/domain/CampaignParameters.ts
+++ b/src/domain/CampaignParameters.ts
@@ -14,12 +14,6 @@ export interface CampaignProjectionParameters {
 	averageAmountPerDonation: number
 }
 
-export interface ThankYouCampaignParameters {
-	numberOfDonors: number;
-	numberOfMembers: number;
-	progressBarPercentage: number;
-}
-
 /**
  * Campaign parameters is a value object with string and number primitives used to pass values from
  * the "environment" of the banner (i.e. wikipedia.org or wikipedia.de) to the dynamic text rendering.
@@ -41,6 +35,4 @@ export interface CampaignParameters {
 	isLateProgress: boolean,
 	dramaTextIsVisible: boolean,
 	urgencyMessageDaysLeft: number,
-
-	thankYouCampaign: ThankYouCampaignParameters
 }

--- a/src/domain/ThankYouCampaignParameters.ts
+++ b/src/domain/ThankYouCampaignParameters.ts
@@ -1,0 +1,5 @@
+export interface ThankYouCampaignParameters {
+	numberOfDonors: number;
+	numberOfMembers: number;
+	progressBarPercentage: number;
+}

--- a/src/page/PageWPDE.ts
+++ b/src/page/PageWPDE.ts
@@ -1,6 +1,7 @@
 import { Page } from '@src/page/Page';
 import { BannerNotShownReasons } from './BannerNotShownReasons';
 import { CampaignParameters } from '@src/domain/CampaignParameters';
+import { ThankYouCampaignParameters } from '@src/domain/ThankYouCampaignParameters';
 import { TrackingParameters } from '@src/domain/TrackingParameters';
 import { getCampaignParameterOverride } from '@environment/CampaignParameterOverride';
 
@@ -9,6 +10,7 @@ export const showBannerClass = 'wmde-show-banner';
 
 export interface WpdeWindow extends Window {
 	campaignParameters: CampaignParameters;
+	thankYouCampaignParameters: ThankYouCampaignParameters;
 }
 
 declare let window: WpdeWindow;
@@ -79,6 +81,14 @@ class PageWPDE implements Page {
 		}
 
 		return getCampaignParameterOverride( window.campaignParameters );
+	}
+
+	public getThankYouCampaignParameters(): ThankYouCampaignParameters {
+		if ( !window.thankYouCampaignParameters ) {
+			throw new Error( 'Campaign parameters are not set globally' );
+		}
+
+		return window.thankYouCampaignParameters;
 	}
 
 	public getTracking(): TrackingParameters {

--- a/src/page/PageWPORG.ts
+++ b/src/page/PageWPORG.ts
@@ -5,6 +5,7 @@ import { BannerNotShownReasons } from '@src/page/BannerNotShownReasons';
 import { SizeIssueChecker } from '@src/utils/SizeIssueChecker/SizeIssueChecker';
 import { Vector2 } from '@src/utils/Vector2';
 import { CampaignParameters } from '@src/domain/CampaignParameters';
+import { ThankYouCampaignParameters } from '@src/domain/ThankYouCampaignParameters';
 import { getCampaignParameterOverride } from '@environment/CampaignParameterOverride';
 import { TrackingParameters } from '@src/domain/TrackingParameters';
 import { CloseChoices } from '@src/domain/CloseChoices';
@@ -172,15 +173,22 @@ class PageWPORG implements Page {
 			numberOfMembers: Number( data.numberOfMembers ),
 			isLateProgress: data.isLateProgress === 'true',
 			dramaTextIsVisible: data.dramaTextIsVisible === 'true',
-			urgencyMessageDaysLeft: Number( data.urgencyMessageDaysLeft ),
-			thankYouCampaign: {
-				numberOfDonors: Number( data.tyNumberOfDonors ),
-				numberOfMembers: Number( data.tyNumberOfMembers ),
-				progressBarPercentage: Number( data.tyProgressBarPercentage )
-			}
+			urgencyMessageDaysLeft: Number( data.urgencyMessageDaysLeft )
 		};
 
 		return getCampaignParameterOverride( campaignParameters );
+	}
+
+	public getThankYouCampaignParameters(): ThankYouCampaignParameters {
+		const data = this.getCampaignData();
+
+		const thankYouCampaignParameters = {
+			numberOfDonors: Number( data.tyNumberOfDonors ),
+			numberOfMembers: Number( data.tyNumberOfMembers ),
+			progressBarPercentage: Number( data.tyProgressBarPercentage )
+		};
+
+		return thankYouCampaignParameters;
 	}
 
 	public getTracking(): TrackingParameters {

--- a/test/fixtures/PageStub.ts
+++ b/test/fixtures/PageStub.ts
@@ -1,6 +1,7 @@
 import { Page } from '@src/page/Page';
 import { BannerNotShownReasons } from '@src/page/BannerNotShownReasons';
 import { CampaignParameters } from '@src/domain/CampaignParameters';
+import { ThankYouCampaignParameters } from '@src/domain/ThankYouCampaignParameters';
 import { TrackingParameters } from '@src/domain/TrackingParameters';
 
 export class PageStub implements Page {
@@ -70,12 +71,15 @@ export class PageStub implements Page {
 			startDate: '',
 			isLateProgress: false,
 			dramaTextIsVisible: false,
-			urgencyMessageDaysLeft: 0,
-			thankYouCampaign: {
-				progressBarPercentage: 0,
-				numberOfDonors: 0,
-				numberOfMembers: 0
-			}
+			urgencyMessageDaysLeft: 0
+		};
+	}
+
+	public getThankYouCampaignParameters(): ThankYouCampaignParameters {
+		return {
+			progressBarPercentage: 0,
+			numberOfDonors: 0,
+			numberOfMembers: 0
 		};
 	}
 

--- a/test/integration/page/PageWPDE.spec.ts
+++ b/test/integration/page/PageWPDE.spec.ts
@@ -22,18 +22,26 @@ describe( 'PageWPDE', function () {
 			startDate: '2023-11-01',
 			isLateProgress: false,
 			dramaTextIsVisible: false,
-			urgencyMessageDaysLeft: 10,
-			thankYouCampaign: {
-				progressBarPercentage: 80,
-				numberOfDonors: 42,
-				numberOfMembers: 23
-			}
+			urgencyMessageDaysLeft: 10
 		};
 		const page = new PageWPDE( tracking );
 
 		const retrievedCampaignParameters = page.getCampaignParameters();
 
 		expect( retrievedCampaignParameters.startDate ).toBe( '2023-11-01' );
+	} );
+
+	it( 'returns campaign parameters for thankyou banners', () => {
+		window.thankYouCampaignParameters = {
+			progressBarPercentage: 80,
+			numberOfDonors: 42,
+			numberOfMembers: 23
+		};
+		const page = new PageWPDE( tracking );
+
+		const retrievedCampaignParameters = page.getThankYouCampaignParameters();
+
+		expect( retrievedCampaignParameters ).toEqual( window.thankYouCampaignParameters );
 	} );
 
 	it( 'throws error if campaign parameters are not set in global namespace', () => {

--- a/test/unit/environment/prod/CampaignOverride.spec.ts
+++ b/test/unit/environment/prod/CampaignOverride.spec.ts
@@ -20,12 +20,7 @@ describe( 'getCampaignParameterOverride (prod version)', () => {
 			startDate: '',
 			isLateProgress: false,
 			dramaTextIsVisible: false,
-			urgencyMessageDaysLeft: 0,
-			thankYouCampaign: {
-				progressBarPercentage: 0,
-				numberOfDonors: 0,
-				numberOfMembers: 0
-			}
+			urgencyMessageDaysLeft: 0
 		};
 
 		const modifiedParams = getCampaignParameterOverride( params );

--- a/test/unit/utils/DynamicContent/DynamicCampaignText.spec.ts
+++ b/test/unit/utils/DynamicContent/DynamicCampaignText.spec.ts
@@ -41,12 +41,7 @@ const campaignParameters: CampaignParameters = {
 	startDate: '2023-11-03',
 	urgencyMessageDaysLeft: 10,
 	isLateProgress: false,
-	dramaTextIsVisible: false,
-	thankYouCampaign: {
-		progressBarPercentage: 80,
-		numberOfDonors: 42,
-		numberOfMembers: 23
-	}
+	dramaTextIsVisible: false
 };
 const impressionCount: ImpressionCount = {
 	bannerCount: 42,


### PR DESCRIPTION
- the usual banner campaign parameters should not have to care about thankyou campaign related things

- [x] Adapt stats.js in the wpde banners repo accordingly https://github.com/wmde/wikipedia.de-banners/pull/4


https://phabricator.wikimedia.org/T384693