### PR TITLE
Disallow absolute banner directory imports

### DIFF
--- a/banners/thank_you/components/BannerCtrl.de.vue
+++ b/banners/thank_you/components/BannerCtrl.de.vue
@@ -37,14 +37,14 @@
 <script setup lang="ts">
 
 import { inject, ref } from 'vue';
-import { ThankYouSettings } from '@banners/thank_you/settings';
+import { ThankYouSettings } from '../settings';
 import { Tracker } from '@src/tracking/Tracker';
 import { CloseEvent } from '@src/tracking/events/CloseEvent';
 import { CloseChoices } from '@src/domain/CloseChoices';
 import { ThankYouModalShownEvent } from '@src/tracking/events/ThankYouModalShownEvent';
 import { BannerSubmitEvent } from '@src/tracking/events/BannerSubmitEvent';
-import MiniBanner from '@banners/thank_you/components/MiniBanner.vue';
-import FullPageBanner from '@banners/thank_you/components/FullPageBanner.vue';
+import MiniBanner from '../components/MiniBanner.vue';
+import FullPageBanner from '../components/FullPageBanner.vue';
 
 import MiniBannerTextWin from '../content/win/MiniBannerText.de.vue';
 import FullPageBannerTextWin from '../content/win/FullPageBannerText.de.vue';

--- a/banners/thank_you/components/BannerCtrl.en.vue
+++ b/banners/thank_you/components/BannerCtrl.en.vue
@@ -37,14 +37,14 @@
 <script setup lang="ts">
 
 import { inject, ref } from 'vue';
-import { ThankYouSettings } from '@banners/thank_you/settings';
+import { ThankYouSettings } from '../settings';
 import { Tracker } from '@src/tracking/Tracker';
 import { CloseEvent } from '@src/tracking/events/CloseEvent';
 import { CloseChoices } from '@src/domain/CloseChoices';
 import { ThankYouModalShownEvent } from '@src/tracking/events/ThankYouModalShownEvent';
 import { BannerSubmitEvent } from '@src/tracking/events/BannerSubmitEvent';
-import MiniBanner from '@banners/thank_you/components/MiniBanner.vue';
-import FullPageBanner from '@banners/thank_you/components/FullPageBanner.vue';
+import MiniBanner from '../components/MiniBanner.vue';
+import FullPageBanner from '../components/FullPageBanner.vue';
 
 import MiniBannerTextWin from '../content/win/MiniBannerText.en.vue';
 import FullPageBannerTextWin from '../content/win/FullPageBannerText.en.vue';

--- a/banners/thank_you/components/BannerVar.de.vue
+++ b/banners/thank_you/components/BannerVar.de.vue
@@ -37,14 +37,14 @@
 <script setup lang="ts">
 
 import { inject, ref } from 'vue';
-import { ThankYouSettings } from '@banners/thank_you/settings';
+import { ThankYouSettings } from '../settings';
 import { Tracker } from '@src/tracking/Tracker';
 import { CloseEvent } from '@src/tracking/events/CloseEvent';
 import { CloseChoices } from '@src/domain/CloseChoices';
 import { ThankYouModalShownEvent } from '@src/tracking/events/ThankYouModalShownEvent';
 import { BannerSubmitEvent } from '@src/tracking/events/BannerSubmitEvent';
-import MiniBanner from '@banners/thank_you/components/MiniBanner.vue';
-import FullPageBanner from '@banners/thank_you/components/FullPageBanner.vue';
+import MiniBanner from '../components/MiniBanner.vue';
+import FullPageBanner from '../components/FullPageBanner.vue';
 
 import MiniBannerTextWin from '../content/win/MiniBannerText.de.vue';
 import FullPageBannerTextWin from '../content/win/FullPageBannerTextVar.de.vue';

--- a/banners/thank_you/components/BannerVar.en.vue
+++ b/banners/thank_you/components/BannerVar.en.vue
@@ -37,14 +37,14 @@
 <script setup lang="ts">
 
 import { inject, ref } from 'vue';
-import { ThankYouSettings } from '@banners/thank_you/settings';
+import { ThankYouSettings } from '../settings';
 import { Tracker } from '@src/tracking/Tracker';
 import { CloseEvent } from '@src/tracking/events/CloseEvent';
 import { CloseChoices } from '@src/domain/CloseChoices';
 import { ThankYouModalShownEvent } from '@src/tracking/events/ThankYouModalShownEvent';
 import { BannerSubmitEvent } from '@src/tracking/events/BannerSubmitEvent';
-import MiniBanner from '@banners/thank_you/components/MiniBanner.vue';
-import FullPageBanner from '@banners/thank_you/components/FullPageBanner.vue';
+import MiniBanner from '../components/MiniBanner.vue';
+import FullPageBanner from '../components/FullPageBanner.vue';
 
 import MiniBannerTextWin from '../content/win/MiniBannerText.en.vue';
 import FullPageBannerTextWin from '../content/win/FullPageBannerTextVar.en.vue';

--- a/banners/thank_you/content/MembershipBenefits.de.vue
+++ b/banners/thank_you/content/MembershipBenefits.de.vue
@@ -8,5 +8,5 @@
 </template>
 
 <script setup lang="ts">
-import ListTick from '@banners/thank_you/content/ListTick.vue';
+import ListTick from './ListTick.vue';
 </script>

--- a/banners/thank_you/content/MembershipBenefits.en.vue
+++ b/banners/thank_you/content/MembershipBenefits.en.vue
@@ -8,5 +8,5 @@
 </template>
 
 <script setup lang="ts">
-import ListTick from '@banners/thank_you/content/ListTick.vue';
+import ListTick from './ListTick.vue';
 </script>

--- a/banners/thank_you/content/win/FullPageBannerText.de.vue
+++ b/banners/thank_you/content/win/FullPageBannerText.de.vue
@@ -47,8 +47,8 @@
 </template>
 
 <script setup lang="ts">
-import ExecutiveDirectorsImage from '@banners/thank_you/content/ExecutiveDirectorsImage.vue';
-import StatsBox from '@banners/thank_you/components/StatsBox.vue';
+import ExecutiveDirectorsImage from '../ExecutiveDirectorsImage.vue';
+import StatsBox from '../../components/StatsBox.vue';
 interface Props {
 	numberOfPeople: string
 }

--- a/banners/thank_you/content/win/FullPageBannerText.en.vue
+++ b/banners/thank_you/content/win/FullPageBannerText.en.vue
@@ -41,8 +41,8 @@
 </template>
 
 <script setup lang="ts">
-import ExecutiveDirectorsImage from '@banners/thank_you/content/ExecutiveDirectorsImage.vue';
-import StatsBox from '@banners/thank_you/components/StatsBox.vue';
+import ExecutiveDirectorsImage from '../ExecutiveDirectorsImage.vue';
+import StatsBox from '../../components/StatsBox.vue';
 interface Props {
 	numberOfPeople: string
 }

--- a/banners/thank_you/content/win/FullPageBannerTextVar.de.vue
+++ b/banners/thank_you/content/win/FullPageBannerTextVar.de.vue
@@ -41,8 +41,8 @@
 </template>
 
 <script setup lang="ts">
-import ExecutiveDirectorsImage from '@banners/thank_you/content/ExecutiveDirectorsImage.vue';
-import StatsBox from '@banners/thank_you/components/StatsBox.vue';
+import ExecutiveDirectorsImage from '../ExecutiveDirectorsImage.vue';
+import StatsBox from '../../components/StatsBox.vue';
 interface Props {
 	numberOfPeople: string
 }

--- a/banners/thank_you/content/win/FullPageBannerTextVar.en.vue
+++ b/banners/thank_you/content/win/FullPageBannerTextVar.en.vue
@@ -37,8 +37,8 @@
 </template>
 
 <script setup lang="ts">
-import ExecutiveDirectorsImage from '@banners/thank_you/content/ExecutiveDirectorsImage.vue';
-import StatsBox from '@banners/thank_you/components/StatsBox.vue';
+import ExecutiveDirectorsImage from '../ExecutiveDirectorsImage.vue';
+import StatsBox from '../../components/StatsBox.vue';
 interface Props {
 	numberOfPeople: string
 }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"paths": {
+			"@banners/*": [ "banners/*" ]
+		}
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
 		"resolveJsonModule": true,
 		"moduleResolution": "node",
 		"paths": {
-			"@banners/*": [ "banners/*" ],
 			"@src/*": [ "src/*" ],
 			"@test/*": [ "test/*" ],
 			"@environment/*": [ "src/environment/prod/*", "src/environment/dev/*" ]

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -67,6 +67,7 @@ export default defineConfig( {
 	},
 	resolve: {
 		alias: {
+			'@banners': path.resolve( __dirname, './banners' ),
 			'@src': path.resolve( __dirname, './src' ),
 			'@environment': path.resolve( __dirname, './src/environment/prod' ),
 			'@test': path.resolve( __dirname, './test' ),

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -67,7 +67,6 @@ export default defineConfig( {
 	},
 	resolve: {
 		alias: {
-			'@banners': path.resolve( __dirname, './banners' ),
 			'@src': path.resolve( __dirname, './src' ),
 			'@environment': path.resolve( __dirname, './src/environment/prod' ),
 			'@test': path.resolve( __dirname, './test' ),

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -88,7 +88,6 @@ module.exports = ( env ) => {
 		resolve: {
 			extensions: [ '.ts', '.js', '.json' ],
 			alias: {
-				'@banners': path.resolve( __dirname, 'banners' ),
 				'@src': path.resolve( __dirname, 'src' )
 			},
 			fallback: {


### PR DESCRIPTION
- remove the `banners` alias from the config
- the absolute imports caused issues in banners because they were overlooked

https://phabricator.wikimedia.org/T384703