### PR TITLE
Introduce CODEOWNERS, remove deprecated reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# This marks the default owner group of all files in this repository
+*	@wmde/funtech-core

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    reviewers:
-      - "wmde/funtech-core"
     groups:
       patch-updates:
         update-types:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6382,7 +6382,7 @@
     },
     "node_modules/fundraising-frontend-content": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/wmde/fundraising-frontend-content.git#4830c73e731da9fadbe5289dc485fea374117fb5",
+      "resolved": "git+ssh://git@github.com/wmde/fundraising-frontend-content.git#dddd2176d486e6ef68872e11644a1963a09b7f01",
       "license": "CC0-1.0"
     },
     "node_modules/get-intrinsic": {


### PR DESCRIPTION
Dependabot has deprecated the `reviewers` key and wants a `CODEOWNERS` file instead.

See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

Ticket: https://phabricator.wikimedia.org/T393569
