### PR TITLE
Add Secure; attribute to cookies

### DIFF
--- a/src/page/MediaWiki/setCookie.ts
+++ b/src/page/MediaWiki/setCookie.ts
@@ -13,5 +13,5 @@ export function setCookie( reason: string, created: Date, durationInSeconds: num
 	};
 
 	const fullCookieName = COOKIE_NAME + cookieNameSuffix;
-	document.cookie = `${ fullCookieName }=${ encodeURIComponent( JSON.stringify( hideData ) ) }; expires=${ expiryDate.toUTCString() }; path=/; SameSite=None;`;
+	document.cookie = `${ fullCookieName }=${ encodeURIComponent( JSON.stringify( hideData ) ) }; expires=${ expiryDate.toUTCString() }; path=/; SameSite=None; Secure;`;
 }

--- a/test/integration/page/MediaWiki/setCookie.spec.ts
+++ b/test/integration/page/MediaWiki/setCookie.spec.ts
@@ -17,7 +17,8 @@ describe( 'setCookie', () => {
 			'centralnotice_hide_fundraising=%7B%22v%22%3A1%2C%22created%22%3A872820840%2C%22reason%22%3A%22testReason%22%7D;',
 			'expires=Mon, 08 Sep 1997 02:14:00 GMT;',
 			'path=/;',
-			'SameSite=None;'
+			'SameSite=None;',
+			'Secure;'
 		].join( ' ' ) );
 	} );
 
@@ -36,7 +37,8 @@ describe( 'setCookie', () => {
 			'centralnotice_hide_fundraisingThankyou=%7B%22v%22%3A1%2C%22created%22%3A872820840%2C%22reason%22%3A%22testReason%22%7D;',
 			'expires=Mon, 08 Sep 1997 02:14:00 GMT;',
 			'path=/;',
-			'SameSite=None;'
+			'SameSite=None;',
+			'Secure;'
 		].join( ' ' ) );
 	} );
 } );


### PR DESCRIPTION
Firefox is showing a warning when we set a cookie because
it now requires cookies set with `SameSite=None;` to also
have the `Secure;` attribute.