### PR TITLE
C25_WPDE_Desktop_01

### DIFF
--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_01/components/BannerCtrl.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_01/components/BannerCtrl.vue
@@ -53,7 +53,7 @@
 			<template #footer>
 				<FooterAlreadyDonated
 					@showFundsModal="onModalOpened"
-					@clickedAlreadyDonatedLink="onClose( 'AlreadyDonated', CloseChoices.AlreadyDonated )"
+					@clickedAlreadyDonatedLink="onClose( 'MainBanner', CloseChoices.AlreadyDonated )"
 				/>
 			</template>
 

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_01/components/BannerVar.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_01/components/BannerVar.vue
@@ -77,7 +77,7 @@
 			<template #footer>
 				<FooterAlreadyDonated
 					@showFundsModal="onModalOpened"
-					@clickedAlreadyDonatedLink="onClose( 'AlreadyDonated', CloseChoices.AlreadyDonated )"
+					@clickedAlreadyDonatedLink="onClose( 'MainBanner', CloseChoices.AlreadyDonated )"
 				/>
 			</template>
 

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_02/components/BannerCtrl.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_02/components/BannerCtrl.vue
@@ -77,7 +77,7 @@
 			<template #footer>
 				<FooterAlreadyDonated
 					@showFundsModal="onModalOpened"
-					@clickedAlreadyDonatedLink="onClose( 'AlreadyDonated', CloseChoices.AlreadyDonated )"
+					@clickedAlreadyDonatedLink="onClose( 'MainBanner', CloseChoices.AlreadyDonated )"
 				/>
 			</template>
 

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_02/components/BannerVar.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_02/components/BannerVar.vue
@@ -77,7 +77,7 @@
 			<template #footer>
 				<FooterAlreadyDonated
 					@showFundsModal="onModalOpened"
-					@clickedAlreadyDonatedLink="onClose( 'AlreadyDonated', CloseChoices.AlreadyDonated )"
+					@clickedAlreadyDonatedLink="onClose( 'MainBanner', CloseChoices.AlreadyDonated )"
 				/>
 			</template>
 

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_03/components/BannerCtrl.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_03/components/BannerCtrl.vue
@@ -77,7 +77,7 @@
 			<template #footer>
 				<FooterAlreadyDonated
 					@showFundsModal="onModalOpened"
-					@clickedAlreadyDonatedLink="onClose( 'AlreadyDonated', CloseChoices.AlreadyDonated )"
+					@clickedAlreadyDonatedLink="onClose( 'MainBanner', CloseChoices.AlreadyDonated )"
 				/>
 			</template>
 

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_03/components/BannerVar.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_03/components/BannerVar.vue
@@ -77,7 +77,7 @@
 			<template #footer>
 				<FooterAlreadyDonated
 					@showFundsModal="onModalOpened"
-					@clickedAlreadyDonatedLink="onClose( 'AlreadyDonated', CloseChoices.AlreadyDonated )"
+					@clickedAlreadyDonatedLink="onClose( 'MainBanner', CloseChoices.AlreadyDonated )"
 				/>
 			</template>
 

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_04/components/BannerCtrl.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_04/components/BannerCtrl.vue
@@ -77,7 +77,7 @@
 			<template #footer>
 				<FooterAlreadyDonated
 					@showFundsModal="onModalOpened"
-					@clickedAlreadyDonatedLink="onClose( 'AlreadyDonated', CloseChoices.AlreadyDonated )"
+					@clickedAlreadyDonatedLink="onClose( 'MainBanner', CloseChoices.AlreadyDonated )"
 				/>
 			</template>
 

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_04/components/BannerVar.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_04/components/BannerVar.vue
@@ -77,7 +77,7 @@
 			<template #footer>
 				<FooterAlreadyDonated
 					@showFundsModal="onModalOpened"
-					@clickedAlreadyDonatedLink="onClose( 'AlreadyDonated', CloseChoices.AlreadyDonated )"
+					@clickedAlreadyDonatedLink="onClose( 'MainBanner', CloseChoices.AlreadyDonated )"
 				/>
 			</template>
 

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_05/components/BannerCtrl.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_05/components/BannerCtrl.vue
@@ -77,7 +77,7 @@
 			<template #footer>
 				<FooterAlreadyDonated
 					@showFundsModal="onModalOpened"
-					@clickedAlreadyDonatedLink="onClose( 'AlreadyDonated', CloseChoices.AlreadyDonated )"
+					@clickedAlreadyDonatedLink="onClose( 'MainBanner', CloseChoices.AlreadyDonated )"
 				/>
 			</template>
 

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_05/components/BannerVar.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_05/components/BannerVar.vue
@@ -77,7 +77,7 @@
 			<template #footer>
 				<FooterAlreadyDonated
 					@showFundsModal="onModalOpened"
-					@clickedAlreadyDonatedLink="onClose( 'AlreadyDonated', CloseChoices.AlreadyDonated )"
+					@clickedAlreadyDonatedLink="onClose( 'MainBanner', CloseChoices.AlreadyDonated )"
 				/>
 			</template>
 

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_06/components/BannerCtrl.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_06/components/BannerCtrl.vue
@@ -77,7 +77,7 @@
 			<template #footer>
 				<FooterAlreadyDonated
 					@showFundsModal="onModalOpened"
-					@clickedAlreadyDonatedLink="onClose( 'AlreadyDonated', CloseChoices.AlreadyDonated )"
+					@clickedAlreadyDonatedLink="onClose( 'MainBanner', CloseChoices.AlreadyDonated )"
 				/>
 			</template>
 

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_06/components/BannerVar.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_06/components/BannerVar.vue
@@ -77,7 +77,7 @@
 			<template #footer>
 				<FooterAlreadyDonated
 					@showFundsModal="onModalOpened"
-					@clickedAlreadyDonatedLink="onClose( 'AlreadyDonated', CloseChoices.AlreadyDonated )"
+					@clickedAlreadyDonatedLink="onClose( 'MainBanner', CloseChoices.AlreadyDonated )"
 				/>
 			</template>
 

--- a/banners/english/C25_WMDE_Desktop_EN_00/components/BannerCtrl.vue
+++ b/banners/english/C25_WMDE_Desktop_EN_00/components/BannerCtrl.vue
@@ -56,7 +56,7 @@
 			<template #footer>
 				<FooterAlreadyDonated
 					@showFundsModal="onOpenUseOfFunds"
-					@clickedAlreadyDonatedLink="onClose( 'AlreadyDonated', CloseChoices.AlreadyDonated )"
+					@clickedAlreadyDonatedLink="onClose( 'MainBanner', CloseChoices.AlreadyDonated )"
 				/>
 			</template>
 		</MainBanner>

--- a/banners/english/C25_WMDE_Desktop_EN_00/components/BannerVar.vue
+++ b/banners/english/C25_WMDE_Desktop_EN_00/components/BannerVar.vue
@@ -60,7 +60,7 @@
 			<template #footer>
 				<FooterAlreadyDonated
 					@showFundsModal="onOpenUseOfFunds"
-					@clickedAlreadyDonatedLink="onClose( 'AlreadyDonated', CloseChoices.AlreadyDonated )"
+					@clickedAlreadyDonatedLink="onClose( 'MainBanner', CloseChoices.AlreadyDonated )"
 				/>
 			</template>
 		</MainBanner>

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/banner_ctrl.ts
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/banner_ctrl.ts
@@ -44,7 +44,6 @@ const app = createVueApp( BannerConductor, {
 	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
-		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions() )
 	},
 	resizeHandler: new WindowResizeHandler(),
 	banner: Banner,

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/banner_ctrl.ts
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/banner_ctrl.ts
@@ -1,0 +1,70 @@
+import { createVueApp } from '@src/createVueApp';
+
+import './styles/styles.scss';
+
+import BannerConductor from '@src/components/BannerConductor/BannerConductor.vue';
+import Banner from './components/BannerCtrl.vue';
+import { UrlRuntimeEnvironment } from '@src/utils/RuntimeEnvironment';
+import { WindowResizeHandler } from '@src/utils/ResizeHandler';
+import PageWPDE from '@src/page/PageWPDE';
+import TranslationPlugin from '@src/TranslationPlugin';
+import { TrackerWPDE } from '@src/tracking/TrackerWPDE';
+import eventMap from './event_map';
+import { Translator } from '@src/Translator';
+import DynamicTextPlugin from '@src/DynamicTextPlugin';
+import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
+import { createFormItems } from './form_items';
+import { createFormActions } from '@src/createFormActions';
+import messages from './messages';
+import { LocaleFactoryWpDe } from '@src/utils/LocaleFactory/LocaleFactoryWpDe';
+import { WindowTimer } from '@src/utils/Timer';
+
+const localeFactory = new LocaleFactoryWpDe();
+const translator = new Translator( messages );
+
+// Tracking placeholders will be replaced by webpack string-replace-loader
+// using the campaign configuration ( campaign_info.toml ) for the correct values
+const tracking = {
+	campaign: '!insert-campaign-here!',
+	keyword: '!insert-keyword-here!'
+};
+
+// This is channel specific and must be changed for wp.org banners
+const page = new PageWPDE( tracking );
+const runtimeEnvironment = new UrlRuntimeEnvironment( window.location );
+const impressionCount = new LocalImpressionCount( page.getTracking().keyword, runtimeEnvironment );
+const tracker = new TrackerWPDE( 'FundraisingTracker', page.getTracking().keyword, eventMap, runtimeEnvironment );
+
+const app = createVueApp( BannerConductor, {
+	page,
+	bannerConfig: {
+		delay: runtimeEnvironment.getBannerDelay( 0 ),
+		transitionDuration: 1000
+	},
+	bannerCategory: 'fundraising',
+	bannerProps: {
+		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
+		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions() )
+	},
+	resizeHandler: new WindowResizeHandler(),
+	banner: Banner,
+	impressionCount
+} );
+
+app.use( TranslationPlugin, translator );
+app.use( DynamicTextPlugin, {
+	campaignParameters: page.getCampaignParameters(),
+	date: new Date(),
+	formatters: localeFactory.getFormatters(),
+	impressionCount,
+	translator
+} );
+
+const currencyFormatter = localeFactory.getCurrencyFormatter();
+app.provide( 'currencyFormatter', currencyFormatter );
+app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
+app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
+app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
+
+app.mount( page.getBannerContainer() );

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/banner_var.ts
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/banner_var.ts
@@ -44,7 +44,6 @@ const app = createVueApp( BannerConductor, {
 	bannerCategory: 'fundraising',
 	bannerProps: {
 		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
-		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions() )
 	},
 	resizeHandler: new WindowResizeHandler(),
 	banner: Banner,

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/banner_var.ts
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/banner_var.ts
@@ -1,6 +1,6 @@
 import { createVueApp } from '@src/createVueApp';
 
-import './styles/styles.scss';
+import './styles/styles_var.scss';
 
 import BannerConductor from '@src/components/BannerConductor/BannerConductor.vue';
 import Banner from './components/BannerVar.vue';
@@ -15,7 +15,7 @@ import DynamicTextPlugin from '@src/DynamicTextPlugin';
 import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
 import { createFormItems } from './form_items';
 import { createFormActions } from '@src/createFormActions';
-import messages from './messages';
+import messages from './messages_var';
 import { LocaleFactoryWpDe } from '@src/utils/LocaleFactory/LocaleFactoryWpDe';
 import { WindowTimer } from '@src/utils/Timer';
 

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/banner_var.ts
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/banner_var.ts
@@ -1,0 +1,70 @@
+import { createVueApp } from '@src/createVueApp';
+
+import './styles/styles.scss';
+
+import BannerConductor from '@src/components/BannerConductor/BannerConductor.vue';
+import Banner from './components/BannerVar.vue';
+import { UrlRuntimeEnvironment } from '@src/utils/RuntimeEnvironment';
+import { WindowResizeHandler } from '@src/utils/ResizeHandler';
+import PageWPDE from '@src/page/PageWPDE';
+import TranslationPlugin from '@src/TranslationPlugin';
+import { TrackerWPDE } from '@src/tracking/TrackerWPDE';
+import eventMap from './event_map';
+import { Translator } from '@src/Translator';
+import DynamicTextPlugin from '@src/DynamicTextPlugin';
+import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
+import { createFormItems } from './form_items';
+import { createFormActions } from '@src/createFormActions';
+import messages from './messages';
+import { LocaleFactoryWpDe } from '@src/utils/LocaleFactory/LocaleFactoryWpDe';
+import { WindowTimer } from '@src/utils/Timer';
+
+const localeFactory = new LocaleFactoryWpDe();
+const translator = new Translator( messages );
+
+// Tracking placeholders will be replaced by webpack string-replace-loader
+// using the campaign configuration ( campaign_info.toml ) for the correct values
+const tracking = {
+	campaign: '!insert-campaign-here!',
+	keyword: '!insert-keyword-here!'
+};
+
+// This is channel specific and must be changed for wp.org banners
+const page = new PageWPDE( tracking );
+const runtimeEnvironment = new UrlRuntimeEnvironment( window.location );
+const impressionCount = new LocalImpressionCount( page.getTracking().keyword, runtimeEnvironment );
+const tracker = new TrackerWPDE( 'FundraisingTracker', page.getTracking().keyword, eventMap, runtimeEnvironment );
+
+const app = createVueApp( BannerConductor, {
+	page,
+	bannerConfig: {
+		delay: runtimeEnvironment.getBannerDelay( 0 ),
+		transitionDuration: 1000
+	},
+	bannerCategory: 'fundraising',
+	bannerProps: {
+		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
+		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions() )
+	},
+	resizeHandler: new WindowResizeHandler(),
+	banner: Banner,
+	impressionCount
+} );
+
+app.use( TranslationPlugin, translator );
+app.use( DynamicTextPlugin, {
+	campaignParameters: page.getCampaignParameters(),
+	date: new Date(),
+	formatters: localeFactory.getFormatters(),
+	impressionCount,
+	translator
+} );
+
+const currencyFormatter = localeFactory.getCurrencyFormatter();
+app.provide( 'currencyFormatter', currencyFormatter );
+app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
+app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount ) );
+app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
+
+app.mount( page.getBannerContainer() );

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerCtrl.vue
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerCtrl.vue
@@ -91,7 +91,7 @@
 			<template #footer>
 				<FooterAlreadyDonated
 					@showFundsModal="onModalOpened"
-					@clickedAlreadyDonatedLink="onClose( 'AlreadyDonated', CloseChoices.AlreadyDonated )"
+					@clickedAlreadyDonatedLink="onClose( 'MainBanner', CloseChoices.AlreadyDonated )"
 				/>
 			</template>
 

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerCtrl.vue
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerCtrl.vue
@@ -46,8 +46,12 @@
 				>
 
 					<template #[FormStepNames.MainDonationFormStep]="{ pageIndex, submit, isCurrent, previous }: any">
-						<MainDonationForm :page-index="pageIndex" @submit="submit" :is-current="isCurrent" @previous="previous">
-
+						<MainDonationForm
+							:page-index="pageIndex"
+							@submit="submit"
+							:is-current="isCurrent"
+							@previous="previous"
+						>
 							<template #label-payment-ppl>
 								<span class="wmde-banner-select-group-label with-logos paypal"><PayPalLogo/></span>
 							</template>
@@ -111,6 +115,7 @@ import FundsModal from '@src/components/UseOfFunds/UseOfFundsModal.vue';
 import UpgradeToYearlyButtonForm from '@src/components/DonationForm/Forms/UpgradeToYearlyButtonForm.vue';
 import BannerSlides from '../content/BannerSlides.vue';
 import BannerText from '../content/BannerText.vue';
+import BannerTitle from '../content/BannerTitle.vue';
 import ProgressBar from '@src/components/ProgressBar/ProgressBar.vue';
 import MultiStepDonation from '@src/components/DonationForm/MultiStepDonation.vue';
 import MainDonationForm from '@src/components/DonationForm/Forms/MainDonationForm.vue';
@@ -136,7 +141,6 @@ import MastercardLogo from '@src/components/PaymentLogos/MastercardLogo.vue';
 import SepaLogo from '@src/components/PaymentLogos/SepaLogo.vue';
 import BankTransferIcon from '@src/components/PaymentLogos/BankTransferIcon.vue';
 import SetMaybeLaterCookieImage from '@src/components/SetWPDECookieImage/SetMaybeLaterCookieImage.vue';
-import BannerTitle from '../../../desktop/C25_WMDE_Desktop_DE_00/content/BannerTitle.vue';
 
 enum ContentStates {
 	Main = 'wmde-banner-wrapper--main'

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerCtrl.vue
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerCtrl.vue
@@ -1,0 +1,200 @@
+<template>
+	<div class="wmde-banner-wrapper" :class="contentState">
+		<SetCookieImage v-if="showSetCookieImage"/>
+		<SetAlreadyDonatedCookieImage v-if="showAlreadyDonatedCookieImage"/>
+		<SetMaybeLaterCookieImage v-if="showMaybeLaterCookieImage"/>
+		<MainBanner
+			@close="onCloseMain"
+			@form-interaction="$emit( 'bannerContentChanged' )"
+			:bannerState="bannerState"
+			v-if="contentState === ContentStates.Main"
+		>
+			<template #banner-text>
+				<BannerText/>
+			</template>
+
+			<template #banner-slides="{ play }: any">
+				<KeenSlider :with-navigation="true" :play="play" :interval="10000">
+
+					<template #slides="{ currentSlide }: any">
+						<BannerSlides :currentSlide="currentSlide"/>
+					</template>
+
+					<template #left-icon>
+						<ChevronLeftIcon :fill="'#990a00'"/>
+					</template>
+
+					<template #right-icon>
+						<ChevronRightIcon :fill="'#990a00'"/>
+					</template>
+
+				</KeenSlider>
+			</template>
+
+			<template #progress>
+				<ProgressBar amount-to-show-on-right="TARGET"/>
+			</template>
+
+			<template #donation-form="{ formInteraction }: any">
+				<MultiStepDonation :step-controllers="stepControllers" @form-interaction="formInteraction">
+
+					<template #[FormStepNames.MainDonationFormStep]="{ pageIndex, submit, isCurrent, previous }: any">
+						<MainDonationForm :page-index="pageIndex" @submit="submit" :is-current="isCurrent" @previous="previous">
+
+							<template #label-payment-ppl>
+								<span class="wmde-banner-select-group-label with-logos paypal"><PayPalLogo/></span>
+							</template>
+
+							<template #label-payment-bez>
+								<span class="wmde-banner-select-group-label with-logos sepa"><SepaLogo/></span>
+							</template>
+
+							<template #label-payment-ueb>
+								<span class="wmde-banner-select-group-label with-logos bank-transfer"><BankTransferLogo/>&nbsp;Überweisung</span>
+							</template>
+
+							<template #label-payment-mcp>
+								<span class="wmde-banner-select-group-label with-logos credit-cards">
+									<VisaLogo/>
+									<MastercardLogo/>
+								</span>
+							</template>
+
+						</MainDonationForm>
+					</template>
+
+					<template #[FormStepNames.UpgradeToYearlyFormStep]="{ pageIndex, submit, isCurrent, previous }: any">
+						<UpgradeToYearlyButtonForm
+							:page-index="pageIndex"
+							:is-current="isCurrent"
+							@submit="submit"
+							@previous="previous"
+						/>
+					</template>
+
+				</MultiStepDonation>
+			</template>
+
+			<template #footer>
+				<FooterAlreadyDonated
+					@showFundsModal="isFundsModalVisible = true"
+					@clickedAlreadyDonatedLink="onClose( 'AlreadyDonated', CloseChoices.AlreadyDonated )"
+				/>
+			</template>
+
+		</MainBanner>
+
+		<FundsModal
+			:content="useOfFundsContent"
+			:visible="isFundsModalVisible"
+			@hide="isFundsModalVisible = false"
+			@call-to-action="isFundsModalVisible = false"
+		/>
+
+		<SoftClose
+			v-if="contentState === ContentStates.SoftClosing"
+			@close="() => onClose( 'SoftClose', CloseChoices.Close )"
+			@maybe-later="() => onClose( 'SoftClose', CloseChoices.MaybeLater )"
+			@time-out-close="() => onClose( 'SoftClose', CloseChoices.TimeOut )"
+		/>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+import { ref, watch } from 'vue';
+import { UseOfFundsContent as useOfFundsContentInterface } from '@src/domain/UseOfFunds/UseOfFundsContent';
+import MainBanner from './MainBanner.vue';
+import FundsModal from '@src/components/UseOfFunds/UseOfFundsModal.vue';
+import UpgradeToYearlyButtonForm from '@src/components/DonationForm/Forms/UpgradeToYearlyButtonForm.vue';
+import BannerSlides from '../content/BannerSlides.vue';
+import BannerText from '../content/BannerText.vue';
+import ProgressBar from '@src/components/ProgressBar/ProgressBar.vue';
+import MultiStepDonation from '@src/components/DonationForm/MultiStepDonation.vue';
+import MainDonationForm from '@src/components/DonationForm/Forms/MainDonationForm.vue';
+import KeenSlider from '@src/components/Slider/KeenSlider.vue';
+import ChevronLeftIcon from '@src/components/Icons/ChevronLeftIcon.vue';
+import ChevronRightIcon from '@src/components/Icons/ChevronRightIcon.vue';
+import { useFormModel } from '@src/components/composables/useFormModel';
+import {
+	createSubmittableMainDonationForm
+} from '@src/components/DonationForm/StepControllers/SubmittableMainDonationForm';
+import {
+	createSubmittableUpgradeToYearly
+} from '@src/components/DonationForm/StepControllers/SubmittableUpgradeToYearly';
+import { CloseChoices } from '@src/domain/CloseChoices';
+import { CloseEvent } from '@src/tracking/events/CloseEvent';
+import { TrackingFeatureName } from '@src/tracking/TrackingEvent';
+import SoftClose from '@src/components/SoftClose/SoftClose.vue';
+import SetCookieImage from '@src/components/SetWPDECookieImage/SetCookieImage.vue';
+import FooterAlreadyDonated from '@src/components/Footer/FooterAlreadyDonated.vue';
+import SetAlreadyDonatedCookieImage from '@src/components/SetWPDECookieImage/SetAlreadyDonatedCookieImage.vue';
+import PayPalLogo from '@src/components/PaymentLogos/PayPalLogo.vue';
+import VisaLogo from '@src/components/PaymentLogos/VisaLogo.vue';
+import MastercardLogo from '@src/components/PaymentLogos/MastercardLogo.vue';
+import SepaLogo from '@src/components/PaymentLogos/SepaLogo.vue';
+import BankTransferLogo from '@src/components/PaymentLogos/BankTransferLogo.vue';
+import SetMaybeLaterCookieImage from '@src/components/SetWPDECookieImage/SetMaybeLaterCookieImage.vue';
+
+enum ContentStates {
+	Main = 'wmde-banner-wrapper--main',
+	SoftClosing = 'wmde-banner-wrapper--soft-closing'
+}
+
+enum FormStepNames {
+	MainDonationFormStep = 'MainDonationForm',
+	UpgradeToYearlyFormStep = 'UpgradeToYearlyForm'
+}
+
+interface Props {
+	bannerState: BannerStates;
+	useOfFundsContent: useOfFundsContentInterface;
+	remainingImpressions: number;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits( [ 'bannerClosed', 'bannerContentChanged' ] );
+
+const isFundsModalVisible = ref<boolean>( false );
+const showSetCookieImage = ref<boolean>( false );
+const showAlreadyDonatedCookieImage = ref<boolean>( false );
+const showMaybeLaterCookieImage = ref<boolean>( false );
+const contentState = ref<ContentStates>( ContentStates.Main );
+const formModel = useFormModel();
+const stepControllers = [
+	createSubmittableMainDonationForm( formModel, FormStepNames.UpgradeToYearlyFormStep ),
+	createSubmittableUpgradeToYearly( formModel, FormStepNames.MainDonationFormStep, FormStepNames.MainDonationFormStep )
+];
+
+watch( contentState, async () => {
+	emit( 'bannerContentChanged' );
+} );
+
+function onCloseMain(): void {
+	if ( props.remainingImpressions > 0 ) {
+		contentState.value = ContentStates.SoftClosing;
+	} else {
+		onClose( 'MainBanner', CloseChoices.Close );
+	}
+}
+
+function onClose( feature: TrackingFeatureName, userChoice: CloseChoices ): void {
+	emit( 'bannerClosed', new CloseEvent( feature, userChoice ) );
+
+	switch ( userChoice ) {
+		case CloseChoices.MaybeLater:
+			showMaybeLaterCookieImage.value = true;
+			break;
+		case CloseChoices.Close:
+		case CloseChoices.Hide:
+		case CloseChoices.TimeOut:
+			showSetCookieImage.value = true;
+			break;
+		case CloseChoices.AlreadyDonated:
+			showAlreadyDonatedCookieImage.value = true;
+			break;
+
+	}
+}
+
+</script>

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerVar.vue
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerVar.vue
@@ -92,7 +92,7 @@
 			<template #footer>
 				<FooterAlreadyDonated
 					@showFundsModal="onModalOpened"
-					@clickedAlreadyDonatedLink="onClose( 'AlreadyDonated', CloseChoices.AlreadyDonated )"
+					@clickedAlreadyDonatedLink="onClose( 'MainBanner', CloseChoices.AlreadyDonated )"
 				/>
 			</template>
 

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerVar.vue
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerVar.vue
@@ -46,8 +46,13 @@
 				>
 
 					<template #[FormStepNames.MainDonationFormStep]="{ pageIndex, submit, isCurrent, previous }: any">
-						<MainDonationForm :page-index="pageIndex" @submit="submit" :is-current="isCurrent" @previous="previous">
-
+						<MainDonationForm
+							:page-index="pageIndex"
+							@submit="submit"
+							:is-current="isCurrent"
+							@previous="previous"
+							:hasIntervalCheering="true"
+						>
 							<template #label-payment-ppl>
 								<span class="wmde-banner-select-group-label with-logos paypal"><PayPalLogo/></span>
 							</template>
@@ -111,9 +116,10 @@ import FundsModal from '@src/components/UseOfFunds/UseOfFundsModal.vue';
 import UpgradeToYearlyButtonForm from '@src/components/DonationForm/Forms/UpgradeToYearlyButtonForm.vue';
 import BannerSlides from '../content/BannerSlides.vue';
 import BannerText from '../content/BannerText.vue';
+import BannerTitle from '../content/BannerTitle.vue';
 import ProgressBar from '@src/components/ProgressBar/ProgressBar.vue';
 import MultiStepDonation from '@src/components/DonationForm/MultiStepDonation.vue';
-import MainDonationForm from '@src/components/DonationForm/Forms/MainDonationForm.vue';
+import MainDonationForm from '@src/components/DonationForm/Forms/MainDonationFormIntervalCheering.vue';
 import KeenSlider from '@src/components/Slider/KeenSlider.vue';
 import ChevronLeftIcon from '@src/components/Icons/ChevronLeftIcon.vue';
 import ChevronRightIcon from '@src/components/Icons/ChevronRightIcon.vue';
@@ -127,7 +133,6 @@ import {
 import { CloseChoices } from '@src/domain/CloseChoices';
 import { CloseEvent } from '@src/tracking/events/CloseEvent';
 import { TrackingFeatureName } from '@src/tracking/TrackingEvent';
-import { Tracker } from '@src/tracking/Tracker';
 import SetCookieImage from '@src/components/SetWPDECookieImage/SetCookieImage.vue';
 import FooterAlreadyDonated from '@src/components/Footer/FooterAlreadyDonated.vue';
 import SetAlreadyDonatedCookieImage from '@src/components/SetWPDECookieImage/SetAlreadyDonatedCookieImage.vue';
@@ -137,7 +142,6 @@ import MastercardLogo from '@src/components/PaymentLogos/MastercardLogo.vue';
 import SepaLogo from '@src/components/PaymentLogos/SepaLogo.vue';
 import BankTransferIcon from '@src/components/PaymentLogos/BankTransferIcon.vue';
 import SetMaybeLaterCookieImage from '@src/components/SetWPDECookieImage/SetMaybeLaterCookieImage.vue';
-import BannerTitle from '../../../desktop/C25_WMDE_Desktop_DE_00/content/BannerTitle.vue';
 
 enum ContentStates {
 	Main = 'wmde-banner-wrapper--main'
@@ -193,6 +197,7 @@ function onClose( feature: TrackingFeatureName, userChoice: CloseChoices ): void
 
 	}
 }
+
 function onHideFundsModal(): void {
 	isFundsModalVisible.value = false;
 	emit( 'modalClosed' );

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerVar.vue
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerVar.vue
@@ -1,0 +1,200 @@
+<template>
+	<div class="wmde-banner-wrapper" :class="contentState">
+		<SetCookieImage v-if="showSetCookieImage"/>
+		<SetAlreadyDonatedCookieImage v-if="showAlreadyDonatedCookieImage"/>
+		<SetMaybeLaterCookieImage v-if="showMaybeLaterCookieImage"/>
+		<MainBanner
+			@close="onCloseMain"
+			@form-interaction="$emit( 'bannerContentChanged' )"
+			:bannerState="bannerState"
+			v-if="contentState === ContentStates.Main"
+		>
+			<template #banner-text>
+				<BannerText/>
+			</template>
+
+			<template #banner-slides="{ play }: any">
+				<KeenSlider :with-navigation="true" :play="play" :interval="10000">
+
+					<template #slides="{ currentSlide }: any">
+						<BannerSlides :currentSlide="currentSlide"/>
+					</template>
+
+					<template #left-icon>
+						<ChevronLeftIcon :fill="'#990a00'"/>
+					</template>
+
+					<template #right-icon>
+						<ChevronRightIcon :fill="'#990a00'"/>
+					</template>
+
+				</KeenSlider>
+			</template>
+
+			<template #progress>
+				<ProgressBar amount-to-show-on-right="TARGET"/>
+			</template>
+
+			<template #donation-form="{ formInteraction }: any">
+				<MultiStepDonation :step-controllers="stepControllers" @form-interaction="formInteraction">
+
+					<template #[FormStepNames.MainDonationFormStep]="{ pageIndex, submit, isCurrent, previous }: any">
+						<MainDonationForm :page-index="pageIndex" @submit="submit" :is-current="isCurrent" @previous="previous">
+
+							<template #label-payment-ppl>
+								<span class="wmde-banner-select-group-label with-logos paypal"><PayPalLogo/></span>
+							</template>
+
+							<template #label-payment-bez>
+								<span class="wmde-banner-select-group-label with-logos sepa"><SepaLogo/></span>
+							</template>
+
+							<template #label-payment-ueb>
+								<span class="wmde-banner-select-group-label with-logos bank-transfer"><BankTransferLogo/>&nbsp;Überweisung</span>
+							</template>
+
+							<template #label-payment-mcp>
+								<span class="wmde-banner-select-group-label with-logos credit-cards">
+									<VisaLogo/>
+									<MastercardLogo/>
+								</span>
+							</template>
+
+						</MainDonationForm>
+					</template>
+
+					<template #[FormStepNames.UpgradeToYearlyFormStep]="{ pageIndex, submit, isCurrent, previous }: any">
+						<UpgradeToYearlyButtonForm
+							:page-index="pageIndex"
+							:is-current="isCurrent"
+							@submit="submit"
+							@previous="previous"
+						/>
+					</template>
+
+				</MultiStepDonation>
+			</template>
+
+			<template #footer>
+				<FooterAlreadyDonated
+					@showFundsModal="isFundsModalVisible = true"
+					@clickedAlreadyDonatedLink="onClose( 'AlreadyDonated', CloseChoices.AlreadyDonated )"
+				/>
+			</template>
+
+		</MainBanner>
+
+		<FundsModal
+			:content="useOfFundsContent"
+			:visible="isFundsModalVisible"
+			@hide="isFundsModalVisible = false"
+			@call-to-action="isFundsModalVisible = false"
+		/>
+
+		<SoftClose
+			v-if="contentState === ContentStates.SoftClosing"
+			@close="() => onClose( 'SoftClose', CloseChoices.Close )"
+			@maybe-later="() => onClose( 'SoftClose', CloseChoices.MaybeLater )"
+			@time-out-close="() => onClose( 'SoftClose', CloseChoices.TimeOut )"
+		/>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+import { ref, watch } from 'vue';
+import { UseOfFundsContent as useOfFundsContentInterface } from '@src/domain/UseOfFunds/UseOfFundsContent';
+import MainBanner from './MainBanner.vue';
+import FundsModal from '@src/components/UseOfFunds/UseOfFundsModal.vue';
+import UpgradeToYearlyButtonForm from '@src/components/DonationForm/Forms/UpgradeToYearlyButtonForm.vue';
+import BannerSlides from '../content/BannerSlides.vue';
+import BannerText from '../content/BannerText.vue';
+import ProgressBar from '@src/components/ProgressBar/ProgressBar.vue';
+import MultiStepDonation from '@src/components/DonationForm/MultiStepDonation.vue';
+import MainDonationForm from '@src/components/DonationForm/Forms/MainDonationForm.vue';
+import KeenSlider from '@src/components/Slider/KeenSlider.vue';
+import ChevronLeftIcon from '@src/components/Icons/ChevronLeftIcon.vue';
+import ChevronRightIcon from '@src/components/Icons/ChevronRightIcon.vue';
+import { useFormModel } from '@src/components/composables/useFormModel';
+import {
+	createSubmittableMainDonationForm
+} from '@src/components/DonationForm/StepControllers/SubmittableMainDonationForm';
+import {
+	createSubmittableUpgradeToYearly
+} from '@src/components/DonationForm/StepControllers/SubmittableUpgradeToYearly';
+import { CloseChoices } from '@src/domain/CloseChoices';
+import { CloseEvent } from '@src/tracking/events/CloseEvent';
+import { TrackingFeatureName } from '@src/tracking/TrackingEvent';
+import SoftClose from '@src/components/SoftClose/SoftClose.vue';
+import SetCookieImage from '@src/components/SetWPDECookieImage/SetCookieImage.vue';
+import FooterAlreadyDonated from '@src/components/Footer/FooterAlreadyDonated.vue';
+import SetAlreadyDonatedCookieImage from '@src/components/SetWPDECookieImage/SetAlreadyDonatedCookieImage.vue';
+import PayPalLogo from '@src/components/PaymentLogos/PayPalLogo.vue';
+import VisaLogo from '@src/components/PaymentLogos/VisaLogo.vue';
+import MastercardLogo from '@src/components/PaymentLogos/MastercardLogo.vue';
+import SepaLogo from '@src/components/PaymentLogos/SepaLogo.vue';
+import BankTransferLogo from '@src/components/PaymentLogos/BankTransferLogo.vue';
+import SetMaybeLaterCookieImage from '@src/components/SetWPDECookieImage/SetMaybeLaterCookieImage.vue';
+
+enum ContentStates {
+	Main = 'wmde-banner-wrapper--main',
+	SoftClosing = 'wmde-banner-wrapper--soft-closing'
+}
+
+enum FormStepNames {
+	MainDonationFormStep = 'MainDonationForm',
+	UpgradeToYearlyFormStep = 'UpgradeToYearlyForm'
+}
+
+interface Props {
+	bannerState: BannerStates;
+	useOfFundsContent: useOfFundsContentInterface;
+	remainingImpressions: number;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits( [ 'bannerClosed', 'bannerContentChanged' ] );
+
+const isFundsModalVisible = ref<boolean>( false );
+const showSetCookieImage = ref<boolean>( false );
+const showAlreadyDonatedCookieImage = ref<boolean>( false );
+const showMaybeLaterCookieImage = ref<boolean>( false );
+const contentState = ref<ContentStates>( ContentStates.Main );
+const formModel = useFormModel();
+const stepControllers = [
+	createSubmittableMainDonationForm( formModel, FormStepNames.UpgradeToYearlyFormStep ),
+	createSubmittableUpgradeToYearly( formModel, FormStepNames.MainDonationFormStep, FormStepNames.MainDonationFormStep )
+];
+
+watch( contentState, async () => {
+	emit( 'bannerContentChanged' );
+} );
+
+function onCloseMain(): void {
+	if ( props.remainingImpressions > 0 ) {
+		contentState.value = ContentStates.SoftClosing;
+	} else {
+		onClose( 'MainBanner', CloseChoices.Close );
+	}
+}
+
+function onClose( feature: TrackingFeatureName, userChoice: CloseChoices ): void {
+	emit( 'bannerClosed', new CloseEvent( feature, userChoice ) );
+
+	switch ( userChoice ) {
+		case CloseChoices.MaybeLater:
+			showMaybeLaterCookieImage.value = true;
+			break;
+		case CloseChoices.Close:
+		case CloseChoices.Hide:
+		case CloseChoices.TimeOut:
+			showSetCookieImage.value = true;
+			break;
+		case CloseChoices.AlreadyDonated:
+			showAlreadyDonatedCookieImage.value = true;
+			break;
+
+	}
+}
+
+</script>

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerVar.vue
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerVar.vue
@@ -9,6 +9,10 @@
 			:bannerState="bannerState"
 			v-if="contentState === ContentStates.Main"
 		>
+			<template #banner-title>
+				<BannerTitle/>
+			</template>
+
 			<template #banner-text>
 				<BannerText/>
 			</template>
@@ -36,7 +40,10 @@
 			</template>
 
 			<template #donation-form="{ formInteraction }: any">
-				<MultiStepDonation :step-controllers="stepControllers" @form-interaction="formInteraction">
+				<MultiStepDonation
+					:step-controllers="stepControllers"
+					@form-interaction="formInteraction"
+				>
 
 					<template #[FormStepNames.MainDonationFormStep]="{ pageIndex, submit, isCurrent, previous }: any">
 						<MainDonationForm :page-index="pageIndex" @submit="submit" :is-current="isCurrent" @previous="previous">
@@ -50,7 +57,9 @@
 							</template>
 
 							<template #label-payment-ueb>
-								<span class="wmde-banner-select-group-label with-logos bank-transfer"><BankTransferLogo/>&nbsp;Überweisung</span>
+								<span class="wmde-banner-select-group-label with-logos bank-transfer">
+									<BankTransferIcon/><span>Überweisung</span>
+								</span>
 							</template>
 
 							<template #label-payment-mcp>
@@ -77,7 +86,7 @@
 
 			<template #footer>
 				<FooterAlreadyDonated
-					@showFundsModal="isFundsModalVisible = true"
+					@showFundsModal="onModalOpened"
 					@clickedAlreadyDonatedLink="onClose( 'AlreadyDonated', CloseChoices.AlreadyDonated )"
 				/>
 			</template>
@@ -87,15 +96,8 @@
 		<FundsModal
 			:content="useOfFundsContent"
 			:visible="isFundsModalVisible"
-			@hide="isFundsModalVisible = false"
-			@call-to-action="isFundsModalVisible = false"
-		/>
-
-		<SoftClose
-			v-if="contentState === ContentStates.SoftClosing"
-			@close="() => onClose( 'SoftClose', CloseChoices.Close )"
-			@maybe-later="() => onClose( 'SoftClose', CloseChoices.MaybeLater )"
-			@time-out-close="() => onClose( 'SoftClose', CloseChoices.TimeOut )"
+			@hide="onHideFundsModal"
+			@call-to-action="onHideFundsModal"
 		/>
 	</div>
 </template>
@@ -125,7 +127,7 @@ import {
 import { CloseChoices } from '@src/domain/CloseChoices';
 import { CloseEvent } from '@src/tracking/events/CloseEvent';
 import { TrackingFeatureName } from '@src/tracking/TrackingEvent';
-import SoftClose from '@src/components/SoftClose/SoftClose.vue';
+import { Tracker } from '@src/tracking/Tracker';
 import SetCookieImage from '@src/components/SetWPDECookieImage/SetCookieImage.vue';
 import FooterAlreadyDonated from '@src/components/Footer/FooterAlreadyDonated.vue';
 import SetAlreadyDonatedCookieImage from '@src/components/SetWPDECookieImage/SetAlreadyDonatedCookieImage.vue';
@@ -133,12 +135,12 @@ import PayPalLogo from '@src/components/PaymentLogos/PayPalLogo.vue';
 import VisaLogo from '@src/components/PaymentLogos/VisaLogo.vue';
 import MastercardLogo from '@src/components/PaymentLogos/MastercardLogo.vue';
 import SepaLogo from '@src/components/PaymentLogos/SepaLogo.vue';
-import BankTransferLogo from '@src/components/PaymentLogos/BankTransferLogo.vue';
+import BankTransferIcon from '@src/components/PaymentLogos/BankTransferIcon.vue';
 import SetMaybeLaterCookieImage from '@src/components/SetWPDECookieImage/SetMaybeLaterCookieImage.vue';
+import BannerTitle from '../../../desktop/C25_WMDE_Desktop_DE_00/content/BannerTitle.vue';
 
 enum ContentStates {
-	Main = 'wmde-banner-wrapper--main',
-	SoftClosing = 'wmde-banner-wrapper--soft-closing'
+	Main = 'wmde-banner-wrapper--main'
 }
 
 enum FormStepNames {
@@ -149,11 +151,10 @@ enum FormStepNames {
 interface Props {
 	bannerState: BannerStates;
 	useOfFundsContent: useOfFundsContentInterface;
-	remainingImpressions: number;
 }
 
-const props = defineProps<Props>();
-const emit = defineEmits( [ 'bannerClosed', 'bannerContentChanged' ] );
+defineProps<Props>();
+const emit = defineEmits( [ 'bannerClosed', 'bannerContentChanged', 'modalOpened', 'modalClosed' ] );
 
 const isFundsModalVisible = ref<boolean>( false );
 const showSetCookieImage = ref<boolean>( false );
@@ -171,11 +172,7 @@ watch( contentState, async () => {
 } );
 
 function onCloseMain(): void {
-	if ( props.remainingImpressions > 0 ) {
-		contentState.value = ContentStates.SoftClosing;
-	} else {
-		onClose( 'MainBanner', CloseChoices.Close );
-	}
+	onClose( 'MainBanner', CloseChoices.Close );
 }
 
 function onClose( feature: TrackingFeatureName, userChoice: CloseChoices ): void {
@@ -195,6 +192,15 @@ function onClose( feature: TrackingFeatureName, userChoice: CloseChoices ): void
 			break;
 
 	}
+}
+function onHideFundsModal(): void {
+	isFundsModalVisible.value = false;
+	emit( 'modalClosed' );
+}
+
+function onModalOpened(): void {
+	isFundsModalVisible.value = true;
+	emit( 'modalOpened' );
 }
 
 </script>

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/components/MainBanner.vue
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/components/MainBanner.vue
@@ -1,0 +1,45 @@
+<template>
+	<div class="wmde-banner-main">
+		<ButtonClose @close="$emit( 'close' )"/>
+		<div class="wmde-banner-content">
+			<div class="wmde-banner-column-left">
+				<slot name="banner-text" v-if="onLargeScreen"/>
+				<slot name="banner-slides" v-else :play="slideshowShouldPlay"/>
+				<slot name="progress"/>
+			</div>
+			<div class="wmde-banner-column-right">
+				<slot name="donation-form" :form-interaction="onFormInteraction"/>
+			</div>
+		</div>
+		<slot name="footer"/>
+	</div>
+</template>
+
+<script setup lang="ts">
+
+import ButtonClose from '@src/components/ButtonClose/ButtonClose.vue';
+import { useDisplaySwitch } from '@src/components/composables/useDisplaySwitch';
+import { computed, nextTick, ref } from 'vue';
+import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+
+interface Props {
+	bannerState: BannerStates;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits( [ 'close', 'formInteraction' ] );
+
+const slideShowStopped = ref<boolean>( false );
+const slideshowShouldPlay = computed( () => props.bannerState === BannerStates.Visible && !slideShowStopped.value );
+
+const onLargeScreen = useDisplaySwitch( 1300 );
+
+const onFormInteraction = (): void => {
+	slideShowStopped.value = true;
+
+	nextTick( () => {
+		emit( 'formInteraction' );
+	} );
+};
+
+</script>

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/components/MainBanner.vue
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/components/MainBanner.vue
@@ -3,8 +3,11 @@
 		<ButtonClose @close="$emit( 'close' )"/>
 		<div class="wmde-banner-content">
 			<div class="wmde-banner-column-left">
-				<slot name="banner-text" v-if="onLargeScreen"/>
-				<slot name="banner-slides" v-else :play="slideshowShouldPlay"/>
+				<div class="wmde-banner-message-container">
+					<slot name="banner-title"/>
+					<slot name="banner-text" v-if="onLargeScreen"/>
+					<slot name="banner-slides" v-else :play="slideshowShouldPlay"/>
+				</div>
 				<slot name="progress"/>
 			</div>
 			<div class="wmde-banner-column-right">

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/content/BannerSlides.vue
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/content/BannerSlides.vue
@@ -1,33 +1,23 @@
 <template>
 	<KeenSliderSlide :is-current="currentSlide === 0">
-		<p class="headline">
-			<InfoIconStraight/>
-			<strong> An alle, die Wikipedia in Deutschland nutzen </strong>
-		</p>
-		<p>
-			An diesem {{ currentDayName }}, den {{ liveDateAndTime.currentDate }}, um {{ liveDateAndTime.currentTime }} sind
-			Sie gefragt: {{ campaignDaySentence }}
-		</p>
-	</KeenSliderSlide>
-	<KeenSliderSlide :is-current="currentSlide === 1">
 		<p>Wikipedia wird durch Spenden von durchschnittlich {{ averageDonation }} finanziert, aber 99&nbsp;% der
 			Lesenden spenden nicht. <strong>Wenn alle, die das jetzt lesen, einen kleinen Beitrag leisten, wäre unser
 				Spendenziel bereits heute erreicht.</strong></p>
 	</KeenSliderSlide>
-	<KeenSliderSlide :is-current="currentSlide === 2">
+	<KeenSliderSlide :is-current="currentSlide === 1">
 		<p>
 			Menschen spenden aus einem einfachen Grund – weil Wikipedia nützlich ist.
 			Schon der Preis einer Tasse Kaffee würde genügen.
 			<span v-if="visitorsVsDonorsSentence !== ''" class="wmde-banner-text-animated-highlight">{{ visitorsVsDonorsSentence }}</span>
 		</p>
 	</KeenSliderSlide>
-	<KeenSliderSlide :is-current="currentSlide === 3">
+	<KeenSliderSlide :is-current="currentSlide === 2">
 		<p>Wenn Wikipedia eine kommerzielle Seite
 			sein würde, wäre das ein riesiger Verlust für die Welt. Sicher könnten wir mit Werbung eine Menge Geld
 			verdienen.
 			Aber dann wäre Wikipedia komplett anders. Wir könnten ihr nicht vertrauen.</p>
 	</KeenSliderSlide>
-	<KeenSliderSlide :is-current="currentSlide === 4">
+	<KeenSliderSlide :is-current="currentSlide === 3">
 		<p>Es ist leicht, diese Nachricht zu ignorieren und die meisten werden das wohl tun. Wenn Sie Wikipedia
 			nützlich finden, nehmen Sie sich an diesem {{currentDayName }} bitte
 			eine Minute Zeit und geben Wikipedia mit Ihrer Spende etwas zurück. <em>Vielen Dank!</em></p>
@@ -36,10 +26,8 @@
 
 <script setup lang="ts">
 import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
-import { inject, onMounted, onUnmounted } from 'vue';
+import { inject } from 'vue';
 import KeenSliderSlide from '@src/components/Slider/KeenSliderSlide.vue';
-import { useLiveDateAndTime } from '@src/components/composables/useLiveDateAndTime';
-import InfoIconStraight from '@src/components/Icons/InfoIconStraight.vue';
 
 interface Props {
 	currentSlide: number
@@ -49,14 +37,8 @@ defineProps<Props>();
 
 const {
 	currentDayName,
-	getCurrentDateAndTime,
-	campaignDaySentence,
 	visitorsVsDonorsSentence,
 	averageDonation
-}: DynamicContent = inject( 'dynamicCampaignText' );
-
-const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );
-onMounted( startTimer );
-onUnmounted( stopTimer );
+} = inject<DynamicContent>( 'dynamicCampaignText' );
 
 </script>

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/content/BannerSlides.vue
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/content/BannerSlides.vue
@@ -1,0 +1,62 @@
+<template>
+	<KeenSliderSlide :is-current="currentSlide === 0">
+		<p class="headline">
+			<InfoIconStraight/>
+			<strong> An alle, die Wikipedia in Deutschland nutzen </strong>
+		</p>
+		<p>
+			An diesem {{ currentDayName }}, den {{ liveDateAndTime.currentDate }}, um {{ liveDateAndTime.currentTime }} sind
+			Sie gefragt: {{ campaignDaySentence }}
+		</p>
+	</KeenSliderSlide>
+	<KeenSliderSlide :is-current="currentSlide === 1">
+		<p>Wikipedia wird durch Spenden von durchschnittlich {{ averageDonation }} finanziert, aber 99&nbsp;% der
+			Lesenden spenden nicht. <strong>Wenn alle, die das jetzt lesen, einen kleinen Beitrag leisten, wäre unser
+				Spendenziel bereits heute erreicht.</strong></p>
+	</KeenSliderSlide>
+	<KeenSliderSlide :is-current="currentSlide === 2">
+		<p>
+			Menschen spenden aus einem einfachen Grund – weil Wikipedia nützlich ist.
+			Schon der Preis einer Tasse Kaffee würde genügen.
+			<span v-if="visitorsVsDonorsSentence !== ''" class="wmde-banner-text-animated-highlight">{{ visitorsVsDonorsSentence }}</span>
+		</p>
+	</KeenSliderSlide>
+	<KeenSliderSlide :is-current="currentSlide === 3">
+		<p>Wenn Wikipedia eine kommerzielle Seite
+			sein würde, wäre das ein riesiger Verlust für die Welt. Sicher könnten wir mit Werbung eine Menge Geld
+			verdienen.
+			Aber dann wäre Wikipedia komplett anders. Wir könnten ihr nicht vertrauen.</p>
+	</KeenSliderSlide>
+	<KeenSliderSlide :is-current="currentSlide === 4">
+		<p>Es ist leicht, diese Nachricht zu ignorieren und die meisten werden das wohl tun. Wenn Sie Wikipedia
+			nützlich finden, nehmen Sie sich an diesem {{currentDayName }} bitte
+			eine Minute Zeit und geben Wikipedia mit Ihrer Spende etwas zurück. <em>Vielen Dank!</em></p>
+	</KeenSliderSlide>
+</template>
+
+<script setup lang="ts">
+import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import { inject, onMounted, onUnmounted } from 'vue';
+import KeenSliderSlide from '@src/components/Slider/KeenSliderSlide.vue';
+import { useLiveDateAndTime } from '@src/components/composables/useLiveDateAndTime';
+import InfoIconStraight from '@src/components/Icons/InfoIconStraight.vue';
+
+interface Props {
+	currentSlide: number
+}
+
+defineProps<Props>();
+
+const {
+	currentDayName,
+	getCurrentDateAndTime,
+	campaignDaySentence,
+	visitorsVsDonorsSentence,
+	averageDonation
+}: DynamicContent = inject( 'dynamicCampaignText' );
+
+const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );
+onMounted( startTimer );
+onUnmounted( stopTimer );
+
+</script>

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/content/BannerText.vue
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/content/BannerText.vue
@@ -1,0 +1,43 @@
+<template>
+	<div class="wmde-banner-message">
+		<div>
+			<p>
+				<InfoIconStraight/> An diesem {{ currentDayName }}, den {{ liveDateAndTime.currentDate }}, um
+				{{ liveDateAndTime.currentTime }} sind Sie gefragt:
+			</p>
+			<p>
+				{{ campaignDaySentence }} Wikipedia wird durch Spenden von durchschnittlich {{ averageDonation }} finanziert, aber 99&nbsp;% der
+				Lesenden spenden nicht. <strong>Wenn alle, die das jetzt lesen, einen kleinen Beitrag leisten, wäre unser
+					Spendenziel bereits heute erreicht.</strong> Menschen spenden aus einem einfachen Grund – weil
+				Wikipedia nützlich ist. Schon der Preis einer Tasse Kaffee würde genügen.
+				<AnimatedText :content="visitorsVsDonorsSentence"/> Wenn Wikipedia eine kommerzielle Seite sein
+				würde, wäre das ein riesiger Verlust für die Welt. Sicher könnten wir mit
+				Werbung eine Menge Geld verdienen. Aber dann wäre Wikipedia komplett anders. Wir könnten ihr nicht
+				vertrauen. Es ist leicht, diese Nachricht zu ignorieren und die meisten werden das wohl tun. Wenn Sie
+				Wikipedia nützlich finden, nehmen Sie sich an diesem {{ currentDayName }} bitte eine Minute Zeit und geben
+				Wikipedia mit Ihrer Spende etwas zurück. <em>Vielen Dank!</em>
+			</p>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { inject, onMounted, onUnmounted } from 'vue';
+import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import AnimatedText from '@src/components/AnimatedText/AnimatedText.vue';
+import { useLiveDateAndTime } from '@src/components/composables/useLiveDateAndTime';
+import InfoIconStraight from '@src/components/Icons/InfoIconStraight.vue';
+
+const {
+	currentDayName,
+	getCurrentDateAndTime,
+	campaignDaySentence,
+	visitorsVsDonorsSentence,
+	averageDonation
+}: DynamicContent = inject( 'dynamicCampaignText' );
+
+const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );
+onMounted( startTimer );
+onUnmounted( stopTimer );
+
+</script>

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/content/BannerText.vue
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/content/BannerText.vue
@@ -2,10 +2,6 @@
 	<div class="wmde-banner-message">
 		<div>
 			<p>
-				<InfoIconStraight/> An diesem {{ currentDayName }}, den {{ liveDateAndTime.currentDate }}, um
-				{{ liveDateAndTime.currentTime }} sind Sie gefragt:
-			</p>
-			<p>
 				{{ campaignDaySentence }} Wikipedia wird durch Spenden von durchschnittlich {{ averageDonation }} finanziert, aber 99&nbsp;% der
 				Lesenden spenden nicht. <strong>Wenn alle, die das jetzt lesen, einen kleinen Beitrag leisten, wäre unser
 					Spendenziel bereits heute erreicht.</strong> Menschen spenden aus einem einfachen Grund – weil
@@ -22,22 +18,15 @@
 </template>
 
 <script setup lang="ts">
-import { inject, onMounted, onUnmounted } from 'vue';
+import { inject } from 'vue';
 import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 import AnimatedText from '@src/components/AnimatedText/AnimatedText.vue';
-import { useLiveDateAndTime } from '@src/components/composables/useLiveDateAndTime';
-import InfoIconStraight from '@src/components/Icons/InfoIconStraight.vue';
 
 const {
 	currentDayName,
-	getCurrentDateAndTime,
 	campaignDaySentence,
 	visitorsVsDonorsSentence,
 	averageDonation
 }: DynamicContent = inject( 'dynamicCampaignText' );
-
-const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );
-onMounted( startTimer );
-onUnmounted( stopTimer );
 
 </script>

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/content/BannerTitle.vue
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/content/BannerTitle.vue
@@ -1,0 +1,21 @@
+<template>
+	<div class="wmde-banner-message-header">
+		<InfoIconItalic/> <h2>Wikipedia ist unverkäuflich</h2>
+		<p class="headline">
+			An diesem {{ currentDayName }}, den {{ liveDateAndTime.currentDate }}, um {{ liveDateAndTime.currentTime }} sind Sie gefragt:
+		</p>
+	</div>
+</template>
+
+<script setup lang="ts">
+import InfoIconItalic from '@src/components/Icons/InfoIconItalic.vue';
+import { useLiveDateAndTime } from '@src/components/composables/useLiveDateAndTime';
+import { inject, onMounted, onUnmounted } from 'vue';
+import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+
+const { getCurrentDateAndTime, currentDayName } = inject<DynamicContent>( 'dynamicCampaignText' );
+const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );
+onMounted( startTimer );
+onUnmounted( stopTimer );
+
+</script>

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/event_map.ts
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/event_map.ts
@@ -1,0 +1,11 @@
+import { CloseEvent } from '@src/tracking/events/CloseEvent';
+import { BannerSubmitEvent } from '@src/tracking/events/BannerSubmitEvent';
+import { FormStepShownEvent } from '@src/tracking/events/FormStepShownEvent';
+import { ShownEvent } from '@src/tracking/events/ShownEvent';
+
+export default new Map( [
+	[ CloseEvent.EVENT_NAME, 0.1 ],
+	[ ShownEvent.EVENT_NAME, 1 ],
+	[ FormStepShownEvent.EVENT_NAME, 1 ],
+	[ BannerSubmitEvent.EVENT_NAME, 1 ]
+] );

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/form_items.ts
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/form_items.ts
@@ -10,7 +10,6 @@ export function createFormItems( translations: Translator, amountFormatter: Numb
 		.setIntervals(
 			Intervals.ONCE,
 			Intervals.MONTHLY,
-			Intervals.QUARTERLY,
 			Intervals.YEARLY
 		)
 		.setAmounts( 5, 10, 20, 25, 50, 100 )

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/form_items.ts
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/form_items.ts
@@ -1,0 +1,23 @@
+import FormItemsBuilder from '@src/utils/FormItemsBuilder/FormItemsBuilder';
+import { Translator } from '@src/Translator';
+import { DonationFormItems } from '@src/utils/FormItemsBuilder/DonationFormItems';
+import { Intervals } from '@src/utils/FormItemsBuilder/fields/Intervals';
+import { PaymentMethods } from '@src/utils/FormItemsBuilder/fields/PaymentMethods';
+import { NumberFormatter } from '@src/utils/DynamicContent/formatters/NumberFormatter';
+
+export function createFormItems( translations: Translator, amountFormatter: NumberFormatter ): DonationFormItems {
+	return new FormItemsBuilder( translations, amountFormatter )
+		.setIntervals(
+			Intervals.ONCE,
+			Intervals.MONTHLY,
+			Intervals.QUARTERLY,
+			Intervals.YEARLY
+		)
+		.setAmounts( 5, 10, 20, 25, 50, 100 )
+		.setPaymentMethods(
+			PaymentMethods.PAYPAL,
+			PaymentMethods.BANK_TRANSFER,
+			PaymentMethods.DIRECT_DEBIT,
+			PaymentMethods.CREDIT_CARD
+		).getItems();
+}

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/messages.ts
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/messages.ts
@@ -2,7 +2,6 @@ import DynamicCampaignTextDe from '@src/utils/DynamicContent/messages/DynamicCam
 import CloseButtonTextDe from '@src/components/ButtonClose/messages/ButtonClose.de';
 import { TranslationMessages } from '@src/Translator';
 import UpgradeToYearlyDe from '@src/components/DonationForm/Forms/messages/UpgradeToYearly.de';
-import SoftCloseDe from '@src/components/SoftClose/messages/SoftClose.de';
 import FooterDe from '@src/components/Footer/messages/Footer.de';
 import MainDonationFormDe from '@src/components/DonationForm/Forms/messages/MainDonationForm.de';
 
@@ -10,13 +9,12 @@ const messages: TranslationMessages = {
 	...DynamicCampaignTextDe,
 	...CloseButtonTextDe,
 	...UpgradeToYearlyDe,
-	...SoftCloseDe,
 	...FooterDe,
 	...MainDonationFormDe,
 	'already-donated-link': 'Habe schon gespendet',
 	'upgrade-to-yearly-copy': '<p>Jedes Jahr sind wir auf Menschen wie Sie angewiesen. Jährliche Spenden helfen uns' +
 		' besonders und ermöglichen langfristige Weiterentwicklungen.</p>' +
 		'<p>Sie gehen kein Risiko ein: Jederzeit formlos zu sofort kündbar.</p>',
+	'upgrade-to-yearly-header': 'Bitte spenden Sie {{amount}} jährlich!',
 };
-
 export default messages;

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/messages.ts
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/messages.ts
@@ -1,0 +1,22 @@
+import DynamicCampaignTextDe from '@src/utils/DynamicContent/messages/DynamicCampaignText.de';
+import CloseButtonTextDe from '@src/components/ButtonClose/messages/ButtonClose.de';
+import { TranslationMessages } from '@src/Translator';
+import UpgradeToYearlyDe from '@src/components/DonationForm/Forms/messages/UpgradeToYearly.de';
+import SoftCloseDe from '@src/components/SoftClose/messages/SoftClose.de';
+import FooterDe from '@src/components/Footer/messages/Footer.de';
+import MainDonationFormDe from '@src/components/DonationForm/Forms/messages/MainDonationForm.de';
+
+const messages: TranslationMessages = {
+	...DynamicCampaignTextDe,
+	...CloseButtonTextDe,
+	...UpgradeToYearlyDe,
+	...SoftCloseDe,
+	...FooterDe,
+	...MainDonationFormDe,
+	'already-donated-link': 'Habe schon gespendet',
+	'upgrade-to-yearly-copy': '<p>Jedes Jahr sind wir auf Menschen wie Sie angewiesen. Jährliche Spenden helfen uns' +
+		' besonders und ermöglichen langfristige Weiterentwicklungen.</p>' +
+		'<p>Sie gehen kein Risiko ein: Jederzeit formlos zu sofort kündbar.</p>',
+};
+
+export default messages;

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/messages_var.ts
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/messages_var.ts
@@ -17,6 +17,7 @@ const messages: TranslationMessages = {
 		'<p>Sie gehen kein Risiko ein: Jederzeit formlos zu sofort kündbar.</p>',
 	'upgrade-to-yearly-header': 'Bitte spenden Sie {{amount}} jährlich!',
 	'cover-transaction-costs': 'Ich übernehme gerne die Transaktionsgebühren von {{transactionCosts}}, damit 100 % meiner Spende ankommt.',
+	'recurring-interval-cheering': 'Dauerhaft etwas bewegen. '
 };
 
 export default messages;

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/messages_var.ts
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/messages_var.ts
@@ -1,0 +1,22 @@
+import DynamicCampaignTextDe from '@src/utils/DynamicContent/messages/DynamicCampaignText.de';
+import CloseButtonTextDe from '@src/components/ButtonClose/messages/ButtonClose.de';
+import { TranslationMessages } from '@src/Translator';
+import UpgradeToYearlyDe from '@src/components/DonationForm/Forms/messages/UpgradeToYearly.de';
+import FooterDe from '@src/components/Footer/messages/Footer.de';
+import MainDonationFormDe from '@src/components/DonationForm/Forms/messages/MainDonationForm.de';
+
+const messages: TranslationMessages = {
+	...DynamicCampaignTextDe,
+	...CloseButtonTextDe,
+	...UpgradeToYearlyDe,
+	...FooterDe,
+	...MainDonationFormDe,
+	'already-donated-link': 'Habe schon gespendet',
+	'upgrade-to-yearly-copy': '<p>Jedes Jahr sind wir auf Menschen wie Sie angewiesen. Jährliche Spenden helfen uns' +
+		' besonders und ermöglichen langfristige Weiterentwicklungen.</p>' +
+		'<p>Sie gehen kein Risiko ein: Jederzeit formlos zu sofort kündbar.</p>',
+	'upgrade-to-yearly-header': 'Bitte spenden Sie {{amount}} jährlich!',
+	'cover-transaction-costs': 'Ich übernehme gerne die Transaktionsgebühren von {{transactionCosts}}, damit 100 % meiner Spende ankommt.',
+};
+
+export default messages;

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/styles/Banner.scss
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/styles/Banner.scss
@@ -1,0 +1,19 @@
+@use '@src/themes/Treedip/variables/globals';
+@use '@src/themes/Treedip/variables/fonts';
+
+.wmde-banner {
+	&-wrapper {
+		font-size: 14px;
+		font-family: fonts.$ui;
+		border-bottom: 1px solid var( --main-border-bottom );
+		background-color: var( --main-background );
+		color: var( --main-color );
+		box-shadow: var( --main-box-shadow );
+	}
+
+	&--closed {
+		.wmde-banner-wrapper {
+			display: none;
+		}
+	}
+}

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/styles/MainBanner.scss
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/styles/MainBanner.scss
@@ -1,0 +1,44 @@
+$banner-height: 394px !default;
+$form-width: 300px !default;
+
+.wmde-banner {
+	&-main {
+		min-height: $banner-height;
+		display: flex;
+		flex-direction: column;
+		padding: 12px 36px 0;
+	}
+
+	&-content {
+		display: flex;
+		flex-direction: row;
+		flex-grow: 1;
+	}
+
+	&-message {
+		padding: 0 15px;
+	}
+
+	&-column-left {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		flex: 1 1 auto;
+		margin-bottom: 0;
+		overflow-y: hidden;
+		margin-right: 30px;
+		padding: 0 0 10px;
+		border: 5px solid var( --message-border );
+		border-radius: 9px;
+	}
+
+	&-column-right {
+		order: 2;
+		flex: 0 0 $form-width;
+		display: flex;
+		flex-direction: column;
+		width: $form-width;
+		min-height: 315px;
+		padding: 10px 0 0;
+	}
+}

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/styles/MainBanner.scss
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/styles/MainBanner.scss
@@ -16,7 +16,16 @@ $form-width: 300px !default;
 	}
 
 	&-message {
-		padding: 0 15px;
+		height: auto;
+	}
+
+	&-message-container {
+		display: flex;
+		flex: 1 1 auto;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		padding: 11px;
 	}
 
 	&-column-left {

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/styles/styles.scss
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/styles/styles.scss
@@ -6,7 +6,7 @@
 	$select-group-bubble: true,
 	$select-group-image-label: true,
 	$upgrade-to-yearly: true,
-	$soft-close: true,
+	$soft-close: false,
 	$fallback-banner: true,
 );
 @use '@src/themes/Treedip/variables/breakpoints';
@@ -43,4 +43,3 @@
 	$font-sizes: ( breakpoints.$extra-small: 16px, breakpoints.$extra-large + 100px: 18px )
 );
 @use '@src/themes/Treedip/Slider/KeenSlider';
-@use '@src/themes/Treedip/SoftClose/SoftClose';

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/styles/styles.scss
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/styles/styles.scss
@@ -1,0 +1,46 @@
+// This is the file where we import the theme-specific component styles
+@use '../../../../src/themes/Treedip/swatches/skin_default' with (
+	$slider: true,
+	$progress-bar: true,
+	$select-group: true,
+	$select-group-bubble: true,
+	$select-group-image-label: true,
+	$upgrade-to-yearly: true,
+	$soft-close: true,
+	$fallback-banner: true,
+);
+@use '@src/themes/Treedip/variables/breakpoints';
+@use '@src/components/BannerConductor/banner-transition';
+@use 'Banner';
+@use 'MainBanner' with (
+	$banner-height: 394px,
+	$form-width: 300px
+);
+@use '../../../../src/components/UseOfFunds/styles/swatches/skin_default' as uof-default;
+@use '../../../../src/components/UseOfFunds/styles/styles';
+@use '@src/themes/Treedip/defaults';
+@use '@src/themes/Treedip/ButtonClose/ButtonClose';
+@use '@src/themes/Treedip/ProgressBar/ProgressBar' with (
+	$progress-bar-margin: 0 15px
+);
+@use '@src/themes/Treedip/DonationForm/DonationForm';
+@use '@src/themes/Treedip/DonationForm/MultiStepDonation';
+@use '@src/themes/Treedip/DonationForm/BubbleForm/SelectGroupBubble';
+@use '@src/themes/Treedip/DonationForm/BubbleForm/SelectGroupRadioBubbles' with (
+	$height: 38px
+);
+@use '@src/themes/Treedip/DonationForm/BubbleForm/SelectCustomAmountRadioBubble' with (
+	$height: 38px
+);
+@use '@src/themes/Treedip/DonationForm/BubbleForm/SelectGroupBubbleImageLabel';
+@use '@src/themes/Treedip/DonationForm/Forms/MainDonationForm' with (
+	$padding: 0
+);
+@use '@src/themes/Treedip/DonationForm/Forms/UpgradeToYearlyButtonForm';
+@use '@src/themes/Treedip/Footer/FooterAlreadyDonated';
+@use '@src/themes/Treedip/Footer/SelectionInput';
+@use '@src/themes/Treedip/Message/Message' with (
+	$font-sizes: ( breakpoints.$extra-small: 16px, breakpoints.$extra-large + 100px: 18px )
+);
+@use '@src/themes/Treedip/Slider/KeenSlider';
+@use '@src/themes/Treedip/SoftClose/SoftClose';

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/styles/styles.scss
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/styles/styles.scss
@@ -5,6 +5,7 @@
 	$select-group: true,
 	$select-group-bubble: true,
 	$select-group-image-label: true,
+	$select-group-cheering: true,
 	$upgrade-to-yearly: true,
 	$soft-close: false,
 	$fallback-banner: true,

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/styles/styles_var.scss
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/styles/styles_var.scss
@@ -8,6 +8,7 @@
 	$upgrade-to-yearly: true,
 	$soft-close: false,
 	$fallback-banner: true,
+	$transaction-fees: true,
 );
 @use '@src/themes/Treedip/variables/breakpoints';
 @use '@src/components/BannerConductor/banner-transition';
@@ -35,6 +36,7 @@
 	$height: 38px
 );
 @use '@src/themes/Treedip/DonationForm/BubbleForm/SelectGroupBubbleImageLabel';
+@use '@src/themes/Treedip/DonationForm/SubComponents/TransactionFees';
 @use '@src/themes/Treedip/DonationForm/Forms/MainDonationForm' with (
 	$padding: 0
 );

--- a/banners/wpde_desktop/C25_WPDE_Desktop_01/styles/styles_var.scss
+++ b/banners/wpde_desktop/C25_WPDE_Desktop_01/styles/styles_var.scss
@@ -5,10 +5,10 @@
 	$select-group: true,
 	$select-group-bubble: true,
 	$select-group-image-label: true,
+	$select-group-cheering: true,
 	$upgrade-to-yearly: true,
 	$soft-close: false,
 	$fallback-banner: true,
-	$transaction-fees: true,
 );
 @use '@src/themes/Treedip/variables/breakpoints';
 @use '@src/components/BannerConductor/banner-transition';
@@ -36,7 +36,6 @@
 	$height: 38px
 );
 @use '@src/themes/Treedip/DonationForm/BubbleForm/SelectGroupBubbleImageLabel';
-@use '@src/themes/Treedip/DonationForm/SubComponents/TransactionFees';
 @use '@src/themes/Treedip/DonationForm/Forms/MainDonationForm' with (
 	$padding: 0
 );
@@ -47,3 +46,4 @@
 	$font-sizes: ( breakpoints.$extra-small: 16px, breakpoints.$extra-large + 100px: 18px )
 );
 @use '@src/themes/Treedip/Slider/KeenSlider';
+@use '@src/themes/Treedip/DonationForm/Forms/MainDonationFormIntervalCheering';

--- a/campaign_info.toml
+++ b/campaign_info.toml
@@ -92,9 +92,9 @@ orientation = [ "portrait", "landscape"]
 [wpde_desktop]
 name = "WPDE Desktop"
 icon = "desktop"
-campaign = "C25_WPDE_Desktop_00"
-description = "Based on C23_WPDE_Desktop_02 (VAR changes are already deleted, because the transaction fee feature has been deleted in a clean-up)"
-campaign_tracking = "wpde-00-250114"
+campaign = "C25_WPDE_Desktop_01"
+description = "Based on the VAR of C24_WPDE_Desktop_01; VAR highlights recurrent options in the form"
+campaign_tracking = "wpde-01-251027"
 preview_link = "/wikipedia.de?devbanner={{banner}}&banner=dev-mode-wpde"
 preview_link_darkmode = "/wikipedia.de?devbanner={{banner}}&banner=dev-mode-wpde"
 preview_link_offline = "/wpde-offline?devbanner={{banner}}"
@@ -103,14 +103,14 @@ wrap_in_wikitext = false
 preview_url = 'https://www.wikipedia.de/?banner={{banner}}'
 
 [wpde_desktop.banners.ctrl]
-filename = "./banners/wpde_desktop/C25_WPDE_Desktop_00/banner_ctrl.ts"
-pagename = "B25_WPDE_Desktop_00_ctrl"
-tracking = "wpde-00-250114-ctrl"
+filename = "./banners/wpde_desktop/C25_WPDE_Desktop_01/banner_ctrl.ts"
+pagename = "B25_WPDE_Desktop_01_ctrl"
+tracking = "wpde-01-251027-ctrl"
 
 [wpde_desktop.banners.var]
-filename = "./banners/wpde_desktop/C25_WPDE_Desktop_00/banner_var.ts"
-pagename = "B25_WPDE_Desktop_00_var"
-tracking = "wpde-00-250114-var"
+filename = "./banners/wpde_desktop/C25_WPDE_Desktop_01/banner_var.ts"
+pagename = "B25_WPDE_Desktop_01_var"
+tracking = "wpde-01-251027-var"
 
 
 [wpde_mobile]

--- a/src/components/DonationForm/Forms/MainDonationFormIntervalCheering.vue
+++ b/src/components/DonationForm/Forms/MainDonationFormIntervalCheering.vue
@@ -1,0 +1,134 @@
+<template>
+	<form
+		method="post"
+		class="wmde-banner-sub-form wmde-banner-sub-form-donation"
+		@submit.prevent="validate"
+	>
+		<fieldset class="wmde-banner-form-field-group">
+			<legend class="wmde-banner-form-field-group-legend">{{ $translate( 'intervals-header' ) }}</legend>
+			<div v-if="hasIntervalCheering" class="wmde-banner-cheering wmde-banner-cheering-top wmde-banner-cheering-interval" >
+				<em>{{ $translate( 'recurring-interval-cheering' ) }} </em><HeartIcon class="heart-icon"/>
+			</div>
+			<SelectGroup
+				:field-name="'select-interval'"
+				:selectionItems="formItems.intervals"
+				:isValid="isValidOrUnset( intervalValidity )"
+				:errorMessage="$translate( 'no-interval-message' )"
+				v-model:inputValue="interval"
+				:disabledOptions="disabledIntervals"
+			/>
+		</fieldset>
+
+		<fieldset class="wmde-banner-form-field-group">
+			<legend class="wmde-banner-form-field-group-legend">{{ $translate( 'amounts-header' ) }}</legend>
+			<SelectGroup
+				fieldName="select-amount"
+				:selectionItems="dynamicAmounts ?? formItems.amounts"
+				:isValid="isValidOrUnset( amountValidity )"
+				:errorMessage="$translate( amountValidityMessageKey( amountValidity ) )"
+				v-model:inputValue="selectedAmount"
+			>
+				<SelectCustomAmount
+					fieldName="select-amount"
+					v-model:inputValue="customAmount"
+					@focus="clearSelectedAmount"
+					@blur="formatCustomAmount"
+					:placeholder="$translate( customAmountPlaceholderKey )"
+				/>
+			</SelectGroup>
+		</fieldset>
+
+		<fieldset class="wmde-banner-form-field-group">
+			<legend class="wmde-banner-form-field-group-legend">{{ $translate( 'payments-header' ) }}</legend>
+			<SelectGroup
+				:field-name="'select-payment-method'"
+				:selectionItems="formItems.paymentMethods"
+				:isValid="isValidOrUnset( paymentMethodValidity )"
+				:errorMessage="$translate( 'no-payment-type-message' )"
+				v-model:inputValue="paymentMethod"
+				:disabledOptions="disabledPaymentMethods"
+			>
+				<template #select-group-label="{ label, slotName }: any">
+					<slot :name="'label-' + slotName" :label="label"/>
+				</template>
+			</SelectGroup>
+		</fieldset>
+
+		<div class="wmde-banner-form-button-container">
+			<slot name="button">
+				<MainDonationFormButtonMultiStep/>
+			</slot>
+			<button v-if="!isFormValid && showErrorScrollLink" class="wmde-banner-form-button-error">
+				{{ $translate( 'global-error' ) }}
+			</button>
+		</div>
+	</form>
+</template>
+
+<script lang="ts">
+// All form components must have names
+export default {
+	name: 'MainDonationForm'
+};
+</script>
+
+<script setup lang="ts">
+
+import { inject, ref } from 'vue';
+import SelectGroup from '@src/components/DonationForm/SubComponents/SelectGroup.vue';
+import { DonationFormItems } from '@src/utils/FormItemsBuilder/DonationFormItems';
+import SelectCustomAmount from '@src/components/DonationForm/SubComponents/SelectCustomAmount.vue';
+import { useFormModel } from '@src/components/composables/useFormModel';
+import { newDonationFormValidator } from '@src/validation/DonationFormValidator';
+import { amountValidityMessageKey } from '@src/utils/amountValidityMessageKey';
+import { isValidOrUnset } from '@src/components/DonationForm/Forms/isValidOrUnset';
+import { Currency } from '@src/utils/DynamicContent/formatters/Currency';
+import MainDonationFormButtonMultiStep from '@src/components/DonationForm/SubComponents/SubmitButtons/MainDonationFormButtonMultiStep.vue';
+import { FormItem } from '@src/utils/FormItemsBuilder/FormItem';
+import HeartIcon from '@src/components/Icons/HeartIcon.vue';
+
+interface Props {
+	showErrorScrollLink?: boolean;
+	customAmountPlaceholderKey?: string;
+	dynamicAmounts?: FormItem[];
+	hasIntervalCheering?: boolean;
+}
+
+withDefaults( defineProps<Props>(), {
+	showErrorScrollLink: false,
+	customAmountPlaceholderKey: 'custom-amount-placeholder',
+	hasIntervalCheering: false,
+} );
+const emit = defineEmits( [ 'submit' ] );
+
+const currencyFormatter = inject<Currency>( 'currencyFormatter' );
+const formItems = inject<DonationFormItems>( 'formItems' );
+const formModel = useFormModel();
+const validator = newDonationFormValidator( formModel );
+const isFormValid = ref<boolean>( true );
+
+const validate = (): void => {
+	isFormValid.value = validator.validate();
+
+	if ( isFormValid.value ) {
+		emit( 'submit' );
+	}
+};
+
+const {
+	interval, intervalValidity, disabledIntervals,
+	selectedAmount, customAmount, amountInCents, amountValidity,
+	paymentMethod, paymentMethodValidity, disabledPaymentMethods
+} = formModel;
+
+const clearSelectedAmount = (): void => {
+	selectedAmount.value = '';
+};
+
+const formatCustomAmount = (): void => {
+	if ( customAmount.value !== '' ) {
+		customAmount.value = currencyFormatter.customAmountInputFromCents( amountInCents.value );
+	}
+};
+
+</script>

--- a/src/themes/Treedip/DonationForm/Forms/MainDonationFormIntervalCheering.scss
+++ b/src/themes/Treedip/DonationForm/Forms/MainDonationFormIntervalCheering.scss
@@ -1,0 +1,30 @@
+@use '../../variables/globals';
+@use '../../variables/fonts';
+@use 'src/components/DonationForm/Forms/MainDonationForm';
+
+$padding: 0 !default;
+
+.wmde-banner {
+	@include MainDonationForm.layout;
+
+	&-cheering-interval {
+		display: block;
+		text-align: right;
+		margin-right: 20px;
+
+		color: var( --select-group-radio-cheering-color );
+		font-size: 14px;
+		line-height: 30px;
+
+		.heart-icon {
+			padding-top: 3px;
+			--heart-icon-fill: var( --select-group-radio-cheering-color );
+		}
+	}
+
+	&-select-group-container.select-interval {
+		.wmde-banner-select-group-option:nth-last-child( -n + 2 ) label {
+			background: var( --select-group-radio-cheering-highlighted-option-background );
+		}
+	}
+}

--- a/src/themes/Treedip/swatches/color_dark.scss
+++ b/src/themes/Treedip/swatches/color_dark.scss
@@ -20,6 +20,7 @@ $red525: #f54739;
 $red575: #dd3333;
 $red600: #e60f00;
 
+$blue050: #eaf3ff;
 $blue100: #dff1ff;
 $blue600: #547fd5;
 $blue700: #436fc7;
@@ -136,6 +137,8 @@ $yellow700: #fcd53f;
 		--select-group-radio-cheering-color: #{$blue700};
 		--cheering-background: #{$blue700};
 		--cheering-color: #{$white};
+
+		--select-group-radio-cheering-highlighted-option-background: #{$blue050};
 	}
 
 	@if $select-group-bubble {

--- a/src/themes/Treedip/swatches/color_light.scss
+++ b/src/themes/Treedip/swatches/color_light.scss
@@ -18,6 +18,7 @@ $red550: #ab150a;
 $red600: #990a00;
 $red700: #7d0a00;
 
+$blue050: #eaf3ff;
 $blue100: #dff1ff;
 $blue400: #3366cc;
 $blue600: #4465a7;
@@ -132,6 +133,8 @@ $yellow700: #fcd53f;
 		--select-group-radio-cheering-color: #{$blue400};
 		--cheering-background: #{$blue400};
 		--cheering-color: #{$white};
+
+		--select-group-radio-cheering-highlighted-option-background: #{$blue050};
 	}
 
 	@if $select-group-bubble {

--- a/test/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerCtrl.spec.ts
+++ b/test/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerCtrl.spec.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, test } from 'vitest';
+import { mount, VueWrapper } from '@vue/test-utils';
+import Banner from '@banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerCtrl.vue';
+import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+import { newDynamicContent } from '@test/banners/dynamicCampaignContent';
+import { useOfFundsContent } from '@test/banners/useOfFundsContent';
+import { formItems } from '@test/banners/formItems';
+import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
+import { desktopUseOfFundsFeatures } from '@test/features/UseOfFunds';
+import { bannerContentAnimatedTextFeatures, bannerContentDateAndTimeFeatures, bannerContentDisplaySwitchFeatures, bannerContentFeatures } from '@test/features/BannerContent';
+import { TrackerStub } from '@test/fixtures/TrackerStub';
+import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
+import { useFormModel } from '@src/components/composables/useFormModel';
+import { resetFormModel } from '@test/resetFormModel';
+import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import { bannerMainFeatures } from '@test/features/MainBanner';
+import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
+import { setCookieImageFeatures } from '@test/features/SetCookieImage';
+import { alreadyDonatedLinkFeatures } from '@test/features/AlreadyDonatedLink';
+import { TimerStub } from '@test/fixtures/TimerStub';
+import { Timer } from '@src/utils/Timer';
+import { fakeFormActions } from '@test/fixtures/FakeFormActions';
+import { paymentIconFeatures } from '@test/features/PaymentIcons';
+
+const formModel = useFormModel();
+const translator = ( key: string ): string => key;
+
+describe( 'BannerCtrl.vue', () => {
+
+	beforeEach( () => {
+		resetFormModel( formModel );
+	} );
+
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
+		return mount( Banner, {
+			props: {
+				bannerState: BannerStates.Pending,
+				useOfFundsContent,
+				remainingImpressions: 10
+			},
+			global: {
+				mocks: {
+					$translate: translator
+				},
+				provide: {
+					translator: { translate: translator },
+					dynamicCampaignText: dynamicContent ?? newDynamicContent(),
+					formActions: fakeFormActions,
+					currencyFormatter: new CurrencyEn(),
+					formItems,
+					tracker: new TrackerStub(),
+					timer: timer ?? new TimerStub()
+				}
+			},
+			// Needed for isVisible checks, see https://test-utils.vuejs.org/api/#isVisible
+			attachTo: document.body
+		} );
+	};
+
+	describe( 'Main Banner', () => {
+		test.each( [
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerMainFeatures[ testName ]( getWrapper() );
+		} );
+	} );
+
+	describe( 'Content', () => {
+		test.each( [
+			[ 'expectSlideShowPlaysWhenBecomesVisible' ],
+			[ 'expectSlideShowStopsOnFormInteraction' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerContentFeatures[ testName ]( getWrapper() );
+		} );
+
+		test.each( [
+			[ 'expectShowsSlideShowOnSmallSizes' ],
+			[ 'expectShowsMessageOnLargeSizes' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerContentDisplaySwitchFeatures[ testName ]( getWrapper, 1300 );
+		} );
+
+		test.each( [
+			[ 'expectHidesAnimatedVisitorsVsDonorsSentenceInMessage' ],
+			[ 'expectShowsAnimatedVisitorsVsDonorsSentenceInMessage' ],
+			[ 'expectHidesAnimatedVisitorsVsDonorsSentenceInSlideShow' ],
+			[ 'expectShowsAnimatedVisitorsVsDonorsSentenceInSlideShow' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerContentAnimatedTextFeatures[ testName ]( getWrapper );
+		} );
+
+		test.each( [
+			[ 'expectShowsLiveDateAndTimeInMessage' ],
+			[ 'expectShowsLiveDateAndTimeInSlideshow' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerContentDateAndTimeFeatures[ testName ]( getWrapper );
+		} );
+	} );
+
+	describe( 'Donation Form Happy Paths', () => {
+		test.each( [
+			[ 'expectMainDonationFormSubmitsWhenSofortIsSelected' ],
+			[ 'expectMainDonationFormSubmitsWhenYearlyIsSelected' ],
+			[ 'expectMainDonationFormGoesToUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsDontUpgrade' ]
+		] )( '%s', async ( testName: string ) => {
+			await donationFormFeatures[ testName ]( getWrapper() );
+		} );
+	} );
+
+	describe( 'Soft Close', () => {
+		test.each( [
+			[ 'expectShowsSoftClose' ],
+			[ 'expectEmitsSoftCloseCloseEvent' ],
+			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
+			[ 'expectEmitsSoftCloseTimeOutEvent' ],
+			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ]
+		] )( '%s', async ( testName: string ) => {
+			await softCloseFeatures[ testName ]( getWrapper );
+		} );
+	} );
+
+	describe( 'Set Cookie Image', () => {
+		test.each( [
+			[ 'expectSetsCookieImageOnSoftCloseClose' ],
+			[ 'expectSetsCookieImageOnSoftCloseTimeOut' ],
+			[ 'expectDoesNotSetCookieImageOnSoftCloseMaybeLater' ],
+			[ 'expectSetCookieImageOnAlreadyDonatedLink' ],
+			[ 'expectSetsMaybeLaterCookieOnSoftCloseMaybeLater' ]
+		] )( '%s', async ( testName: string ) => {
+			await setCookieImageFeatures[ testName ]( getWrapper );
+		} );
+	} );
+
+	describe( 'Use of Funds', () => {
+		test.each( [
+			[ 'expectShowsUseOfFunds' ],
+			[ 'expectHidesUseOfFunds' ]
+		] )( '%s', async ( testName: string ) => {
+			await desktopUseOfFundsFeatures[ testName ]( getWrapper() );
+		} );
+	} );
+
+	describe( 'Already Donated', () => {
+		test.each( [
+			[ 'expectFiresMaybeLaterEventOnLinkClick' ]
+		] )( '%s', async ( testName: string ) => {
+			await alreadyDonatedLinkFeatures[ testName ]( getWrapper() );
+		} );
+	} );
+
+	describe( 'Payment Icons', () => {
+		test.each( [
+			[ 'expectShowsPayPalLogo' ],
+			[ 'expectShowsCreditCardLogos' ],
+			[ 'expectShowsSepaLogo' ]
+		] )( '%s', async ( testName: string ) => {
+			await paymentIconFeatures[ testName ]( getWrapper() );
+		} );
+	} );
+
+} );

--- a/test/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerCtrl.spec.ts
+++ b/test/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerCtrl.spec.ts
@@ -14,7 +14,6 @@ import { useFormModel } from '@src/components/composables/useFormModel';
 import { resetFormModel } from '@test/resetFormModel';
 import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 import { bannerMainFeatures } from '@test/features/MainBanner';
-import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
 import { setCookieImageFeatures } from '@test/features/SetCookieImage';
 import { alreadyDonatedLinkFeatures } from '@test/features/AlreadyDonatedLink';
 import { TimerStub } from '@test/fixtures/TimerStub';
@@ -36,7 +35,10 @@ describe( 'BannerCtrl.vue', () => {
 			props: {
 				bannerState: BannerStates.Pending,
 				useOfFundsContent,
-				remainingImpressions: 10
+				localCloseTracker: {
+					getItem: () => '',
+					setItem: () => {}
+				}
 			},
 			global: {
 				mocks: {
@@ -59,7 +61,7 @@ describe( 'BannerCtrl.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEvent' ],
 			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
@@ -91,8 +93,7 @@ describe( 'BannerCtrl.vue', () => {
 		} );
 
 		test.each( [
-			[ 'expectShowsLiveDateAndTimeInMessage' ],
-			[ 'expectShowsLiveDateAndTimeInSlideshow' ]
+			[ 'expectShowsLiveDateAndTimeInTitle' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerContentDateAndTimeFeatures[ testName ]( getWrapper );
 		} );
@@ -110,37 +111,11 @@ describe( 'BannerCtrl.vue', () => {
 		} );
 	} );
 
-	describe( 'Soft Close', () => {
-		test.each( [
-			[ 'expectShowsSoftClose' ],
-			[ 'expectEmitsSoftCloseCloseEvent' ],
-			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
-			[ 'expectEmitsSoftCloseTimeOutEvent' ],
-			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
-			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ]
-		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper );
-		} );
-	} );
-
 	describe( 'Set Cookie Image', () => {
 		test.each( [
-			[ 'expectSetsCookieImageOnSoftCloseClose' ],
-			[ 'expectSetsCookieImageOnSoftCloseTimeOut' ],
-			[ 'expectDoesNotSetCookieImageOnSoftCloseMaybeLater' ],
 			[ 'expectSetCookieImageOnAlreadyDonatedLink' ],
-			[ 'expectSetsMaybeLaterCookieOnSoftCloseMaybeLater' ]
 		] )( '%s', async ( testName: string ) => {
 			await setCookieImageFeatures[ testName ]( getWrapper );
-		} );
-	} );
-
-	describe( 'Use of Funds', () => {
-		test.each( [
-			[ 'expectShowsUseOfFunds' ],
-			[ 'expectHidesUseOfFunds' ]
-		] )( '%s', async ( testName: string ) => {
-			await desktopUseOfFundsFeatures[ testName ]( getWrapper() );
 		} );
 	} );
 
@@ -159,6 +134,17 @@ describe( 'BannerCtrl.vue', () => {
 			[ 'expectShowsSepaLogo' ]
 		] )( '%s', async ( testName: string ) => {
 			await paymentIconFeatures[ testName ]( getWrapper() );
+		} );
+	} );
+
+	describe( 'Use of Funds', () => {
+		test.each( [
+			[ 'expectShowsUseOfFunds' ],
+			[ 'expectHidesUseOfFunds' ],
+			[ 'expectEmitsModalOpenedEvent' ],
+			[ 'expectEmitsModalClosedEvent' ]
+		] )( '%s', async ( testName: string ) => {
+			await desktopUseOfFundsFeatures[ testName ]( getWrapper() );
 		} );
 	} );
 

--- a/test/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerVar.spec.ts
+++ b/test/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerVar.spec.ts
@@ -14,7 +14,6 @@ import { useFormModel } from '@src/components/composables/useFormModel';
 import { resetFormModel } from '@test/resetFormModel';
 import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
 import { bannerMainFeatures } from '@test/features/MainBanner';
-import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
 import { setCookieImageFeatures } from '@test/features/SetCookieImage';
 import { alreadyDonatedLinkFeatures } from '@test/features/AlreadyDonatedLink';
 import { TimerStub } from '@test/fixtures/TimerStub';
@@ -36,7 +35,10 @@ describe( 'BannerVar.vue', () => {
 			props: {
 				bannerState: BannerStates.Pending,
 				useOfFundsContent,
-				remainingImpressions: 10
+				localCloseTracker: {
+					getItem: () => '',
+					setItem: () => {}
+				}
 			},
 			global: {
 				mocks: {
@@ -59,7 +61,7 @@ describe( 'BannerVar.vue', () => {
 
 	describe( 'Main Banner', () => {
 		test.each( [
-			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEvent' ],
 			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerMainFeatures[ testName ]( getWrapper() );
@@ -91,8 +93,7 @@ describe( 'BannerVar.vue', () => {
 		} );
 
 		test.each( [
-			[ 'expectShowsLiveDateAndTimeInMessage' ],
-			[ 'expectShowsLiveDateAndTimeInSlideshow' ]
+			[ 'expectShowsLiveDateAndTimeInTitle' ]
 		] )( '%s', async ( testName: string ) => {
 			await bannerContentDateAndTimeFeatures[ testName ]( getWrapper );
 		} );
@@ -110,37 +111,11 @@ describe( 'BannerVar.vue', () => {
 		} );
 	} );
 
-	describe( 'Soft Close', () => {
-		test.each( [
-			[ 'expectShowsSoftClose' ],
-			[ 'expectEmitsSoftCloseCloseEvent' ],
-			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
-			[ 'expectEmitsSoftCloseTimeOutEvent' ],
-			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
-			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ]
-		] )( '%s', async ( testName: string ) => {
-			await softCloseFeatures[ testName ]( getWrapper );
-		} );
-	} );
-
 	describe( 'Set Cookie Image', () => {
 		test.each( [
-			[ 'expectSetsCookieImageOnSoftCloseClose' ],
-			[ 'expectSetsCookieImageOnSoftCloseTimeOut' ],
-			[ 'expectDoesNotSetCookieImageOnSoftCloseMaybeLater' ],
 			[ 'expectSetCookieImageOnAlreadyDonatedLink' ],
-			[ 'expectSetsMaybeLaterCookieOnSoftCloseMaybeLater' ]
 		] )( '%s', async ( testName: string ) => {
 			await setCookieImageFeatures[ testName ]( getWrapper );
-		} );
-	} );
-
-	describe( 'Use of Funds', () => {
-		test.each( [
-			[ 'expectShowsUseOfFunds' ],
-			[ 'expectHidesUseOfFunds' ]
-		] )( '%s', async ( testName: string ) => {
-			await desktopUseOfFundsFeatures[ testName ]( getWrapper() );
 		} );
 	} );
 
@@ -159,6 +134,17 @@ describe( 'BannerVar.vue', () => {
 			[ 'expectShowsSepaLogo' ]
 		] )( '%s', async ( testName: string ) => {
 			await paymentIconFeatures[ testName ]( getWrapper() );
+		} );
+	} );
+
+	describe( 'Use of Funds', () => {
+		test.each( [
+			[ 'expectShowsUseOfFunds' ],
+			[ 'expectHidesUseOfFunds' ],
+			[ 'expectEmitsModalOpenedEvent' ],
+			[ 'expectEmitsModalClosedEvent' ]
+		] )( '%s', async ( testName: string ) => {
+			await desktopUseOfFundsFeatures[ testName ]( getWrapper() );
 		} );
 	} );
 

--- a/test/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerVar.spec.ts
+++ b/test/banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerVar.spec.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, test } from 'vitest';
+import { mount, VueWrapper } from '@vue/test-utils';
+import Banner from '@banners/wpde_desktop/C25_WPDE_Desktop_01/components/BannerVar.vue';
+import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+import { newDynamicContent } from '@test/banners/dynamicCampaignContent';
+import { useOfFundsContent } from '@test/banners/useOfFundsContent';
+import { formItems } from '@test/banners/formItems';
+import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
+import { desktopUseOfFundsFeatures } from '@test/features/UseOfFunds';
+import { bannerContentAnimatedTextFeatures, bannerContentDateAndTimeFeatures, bannerContentDisplaySwitchFeatures, bannerContentFeatures } from '@test/features/BannerContent';
+import { TrackerStub } from '@test/fixtures/TrackerStub';
+import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
+import { useFormModel } from '@src/components/composables/useFormModel';
+import { resetFormModel } from '@test/resetFormModel';
+import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import { bannerMainFeatures } from '@test/features/MainBanner';
+import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
+import { setCookieImageFeatures } from '@test/features/SetCookieImage';
+import { alreadyDonatedLinkFeatures } from '@test/features/AlreadyDonatedLink';
+import { TimerStub } from '@test/fixtures/TimerStub';
+import { Timer } from '@src/utils/Timer';
+import { fakeFormActions } from '@test/fixtures/FakeFormActions';
+import { paymentIconFeatures } from '@test/features/PaymentIcons';
+
+const formModel = useFormModel();
+const translator = ( key: string ): string => key;
+
+describe( 'BannerVar.vue', () => {
+
+	beforeEach( () => {
+		resetFormModel( formModel );
+	} );
+
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
+		return mount( Banner, {
+			props: {
+				bannerState: BannerStates.Pending,
+				useOfFundsContent,
+				remainingImpressions: 10
+			},
+			global: {
+				mocks: {
+					$translate: translator
+				},
+				provide: {
+					translator: { translate: translator },
+					dynamicCampaignText: dynamicContent ?? newDynamicContent(),
+					formActions: fakeFormActions,
+					currencyFormatter: new CurrencyEn(),
+					formItems,
+					tracker: new TrackerStub(),
+					timer: timer ?? new TimerStub()
+				}
+			},
+			// Needed for isVisible checks, see https://test-utils.vuejs.org/api/#isVisible
+			attachTo: document.body
+		} );
+	};
+
+	describe( 'Main Banner', () => {
+		test.each( [
+			[ 'expectDoesNotEmitCloseEvent' ],
+			[ 'expectEmitsCloseEventWhenRemainingImpressionsAreZero' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerMainFeatures[ testName ]( getWrapper() );
+		} );
+	} );
+
+	describe( 'Content', () => {
+		test.each( [
+			[ 'expectSlideShowPlaysWhenBecomesVisible' ],
+			[ 'expectSlideShowStopsOnFormInteraction' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerContentFeatures[ testName ]( getWrapper() );
+		} );
+
+		test.each( [
+			[ 'expectShowsSlideShowOnSmallSizes' ],
+			[ 'expectShowsMessageOnLargeSizes' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerContentDisplaySwitchFeatures[ testName ]( getWrapper, 1300 );
+		} );
+
+		test.each( [
+			[ 'expectHidesAnimatedVisitorsVsDonorsSentenceInMessage' ],
+			[ 'expectShowsAnimatedVisitorsVsDonorsSentenceInMessage' ],
+			[ 'expectHidesAnimatedVisitorsVsDonorsSentenceInSlideShow' ],
+			[ 'expectShowsAnimatedVisitorsVsDonorsSentenceInSlideShow' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerContentAnimatedTextFeatures[ testName ]( getWrapper );
+		} );
+
+		test.each( [
+			[ 'expectShowsLiveDateAndTimeInMessage' ],
+			[ 'expectShowsLiveDateAndTimeInSlideshow' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerContentDateAndTimeFeatures[ testName ]( getWrapper );
+		} );
+	} );
+
+	describe( 'Donation Form Happy Paths', () => {
+		test.each( [
+			[ 'expectMainDonationFormSubmitsWhenSofortIsSelected' ],
+			[ 'expectMainDonationFormSubmitsWhenYearlyIsSelected' ],
+			[ 'expectMainDonationFormGoesToUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsDontUpgrade' ]
+		] )( '%s', async ( testName: string ) => {
+			await donationFormFeatures[ testName ]( getWrapper() );
+		} );
+	} );
+
+	describe( 'Soft Close', () => {
+		test.each( [
+			[ 'expectShowsSoftClose' ],
+			[ 'expectEmitsSoftCloseCloseEvent' ],
+			[ 'expectEmitsSoftCloseMaybeLaterEvent' ],
+			[ 'expectEmitsSoftCloseTimeOutEvent' ],
+			[ 'expectEmitsBannerContentChangedOnSoftClose' ],
+			[ 'expectDoesNotShowSoftCloseOnFinalBannerImpression' ]
+		] )( '%s', async ( testName: string ) => {
+			await softCloseFeatures[ testName ]( getWrapper );
+		} );
+	} );
+
+	describe( 'Set Cookie Image', () => {
+		test.each( [
+			[ 'expectSetsCookieImageOnSoftCloseClose' ],
+			[ 'expectSetsCookieImageOnSoftCloseTimeOut' ],
+			[ 'expectDoesNotSetCookieImageOnSoftCloseMaybeLater' ],
+			[ 'expectSetCookieImageOnAlreadyDonatedLink' ],
+			[ 'expectSetsMaybeLaterCookieOnSoftCloseMaybeLater' ]
+		] )( '%s', async ( testName: string ) => {
+			await setCookieImageFeatures[ testName ]( getWrapper );
+		} );
+	} );
+
+	describe( 'Use of Funds', () => {
+		test.each( [
+			[ 'expectShowsUseOfFunds' ],
+			[ 'expectHidesUseOfFunds' ]
+		] )( '%s', async ( testName: string ) => {
+			await desktopUseOfFundsFeatures[ testName ]( getWrapper() );
+		} );
+	} );
+
+	describe( 'Already Donated', () => {
+		test.each( [
+			[ 'expectFiresMaybeLaterEventOnLinkClick' ]
+		] )( '%s', async ( testName: string ) => {
+			await alreadyDonatedLinkFeatures[ testName ]( getWrapper() );
+		} );
+	} );
+
+	describe( 'Payment Icons', () => {
+		test.each( [
+			[ 'expectShowsPayPalLogo' ],
+			[ 'expectShowsCreditCardLogos' ],
+			[ 'expectShowsSepaLogo' ]
+		] )( '%s', async ( testName: string ) => {
+			await paymentIconFeatures[ testName ]( getWrapper() );
+		} );
+	} );
+
+} );


### PR DESCRIPTION
**TLDR:**
- first banner of the main campaign 2025
- based on CTRL WPDE desktop 01 (2024) 
- VAR banner: highlights the recurring options in the form

- - -
**Both banners**

- [x] are based on the control banner of last year's desktop-wpde-01. https://www.wikipedia.de/?banner=B24_WPDE_Desktop_01_ctrl&devMode
- [x] do not have the softclose feature
- [x] have a progress bar
- [x] use the headline "Wikipedia ist unverkäuflich" in the center with the subheadline (like we have on DE desktop)
      -  in both, text and slides
- [x] use the new use of funds
- [x] use Bitte spenden Sie 5 € jährlich!" as the title in the upsell
- [x] use the same payment logo for Überweisung as DE desktop

**Variant banner**

- [x] highlights one or both recurrent options (see [Figma file](https://www.figma.com/design/fFQ2XINsjVHgwMaTjL6hIG/Fundraising-2025?node-id=2082-5951&t=d3C7VLIYzuylq51g-4))
<img width="327" height="254" alt="Bildschirmfoto vom 2025-10-15 13-55-05" src="https://github.com/user-attachments/assets/b00bdb62-4bc9-4ab5-8595-3090488468ef" />


 - - -
ticket: https://phabricator.wikimedia.org/T405918