### PR TITLE
Deactivate late progress in dev environment

### DIFF
--- a/src/environment/dev/CampaignParameterOverride.ts
+++ b/src/environment/dev/CampaignParameterOverride.ts
@@ -17,7 +17,7 @@ export function getCampaignParameterOverride( campaignParameters: CampaignParame
 		...campaignParameters,
 		startDate: '2025-10-28',
 		endDate: '2025-12-31',
-		isLateProgress: true,
+		isLateProgress: false,
 		dramaTextIsVisible: true
 	};
 }


### PR DESCRIPTION
To help the banners look like they will when
deployed at this point in the campaign we
need to turn off the late progress override