### PR TITLE
Update the close choice local storage key

### DIFF
--- a/src/utils/LocalCloseTracker.ts
+++ b/src/utils/LocalCloseTracker.ts
@@ -12,13 +12,13 @@ export class LocalStorageCloseTracker implements LocalCloseTracker {
 		if ( !hasLocalStorage() ) {
 			return;
 		}
-		window.localStorage.setItem( 'fundraising.closeChoice', `${feature}_${closeChoice}` );
+		window.localStorage.setItem( 'fundraising.closeChoice2025', `${feature}_${closeChoice}` );
 	}
 
 	public getItem(): string {
 		if ( !hasLocalStorage() ) {
 			return '';
 		}
-		return window.localStorage.getItem( 'fundraising.closeChoice' ) || '';
+		return window.localStorage.getItem( 'fundraising.closeChoice2025' ) || '';
 	}
 }


### PR DESCRIPTION
Pre-campaign banners have been accidentally
storing the close choice into local storage.

In order to make sure these choices don't
spoil our real test data we need to change the
key for the local storage item.

https://phabricator.wikimedia.org/T408078