### PR TITLE
Remove the `campaign-day-before-campaign` item from CampaignDaySentence

### DIFF
--- a/src/utils/DynamicContent/generators/CampaignDaySentence.ts
+++ b/src/utils/DynamicContent/generators/CampaignDaySentence.ts
@@ -22,7 +22,7 @@ export class CampaignDaySentence implements TextGenerator {
 
 	public getText(): string {
 		if ( !this._campaignTimeRange.hasStarted() ) {
-			return this._translator.translate( 'campaign-day-before-campaign' );
+			return '';
 		}
 
 		if ( this._campaignTimeRange.hasEnded() ) {

--- a/src/utils/DynamicContent/messages/DynamicCampaignText.de.ts
+++ b/src/utils/DynamicContent/messages/DynamicCampaignText.de.ts
@@ -21,7 +21,6 @@ const Translations: TranslationMessages = {
 	'amount-missing': 'Noch fehlen {{amount}}',
 	'drama-text': 'Die Zeit wird knapp!',
 	'amount-total': 'Spendenziel:',
-	'campaign-day-before-campaign': 'Heute bitten wir Sie um Ihre Unterstützung.',
 	'campaign-day-first-day': 'Heute beginnt unsere Spendenkampagne.',
 	'campaign-day-nth-day': 'Heute ist der {{days}} Tag unserer Spendenkampagne.',
 	'campaign-day-only-n-days': 'In {{days}} Tagen endet unsere Spendenkampagne.',

--- a/src/utils/DynamicContent/messages/DynamicCampaignText.en.ts
+++ b/src/utils/DynamicContent/messages/DynamicCampaignText.en.ts
@@ -21,7 +21,6 @@ const Translations: TranslationMessages = {
 	'amount-missing': 'Still missing {{amount}}',
 	'drama-text': 'Time is running out!',
 	'amount-total': 'Donation target:',
-	'campaign-day-before-campaign': 'Today we ask for your support.',
 	'campaign-day-first-day': 'Today our fundraising campaign starts.',
 	'campaign-day-nth-day': 'This is the {{days}} day of our campaign.',
 	'campaign-day-only-n-days': 'Only {{days}} days left to donate for Wikipedia this year.',

--- a/test/unit/utils/DynamicContent/generators/CampaignDaySentence.spec.ts
+++ b/test/unit/utils/DynamicContent/generators/CampaignDaySentence.spec.ts
@@ -24,7 +24,7 @@ describe( 'CampaignDaySentence', function () {
 		const campaignDays = new TimeRange( startDate, endDate, beforeStartDate );
 		const campaignDaySentence = new CampaignDaySentence( campaignDays, new Translator( {} ), new OrdinalDe() );
 
-		expect( campaignDaySentence.getText() ).toEqual( 'campaign-day-before-campaign' );
+		expect( campaignDaySentence.getText() ).toEqual( '' );
 	} );
 
 	it( 'returns the correct sentence for the first day of the campaign', () => {


### PR DESCRIPTION
- The CampaignDaySentence class is modified to return an empty string if the date is before the campaign
- The tests are also be adapted
- The language item is also removed.

Ticket: https://phabricator.wikimedia.org/T404969