### PR TITLE
Add dynamic content to mobile banners for wikipedia.de banners

### DIFF
--- a/banners/wpde_mobile/C25_WPDE_Mobile_00/content/BannerSlides.vue
+++ b/banners/wpde_mobile/C25_WPDE_Mobile_00/content/BannerSlides.vue
@@ -13,7 +13,7 @@
 	</KeenSliderSlide>
 	<KeenSliderSlide :is-current="currentSlide === 2">
 		<p>
-			Heute bitten wir Sie um Ihre Unterstützung. Insgesamt spenden 99% nichts – sie übergehen diesen
+			{{ campaignDaySentence }} Insgesamt spenden 99% nichts – sie übergehen diesen
 			Aufruf. Wikipedia wird durch Spenden von durchschnittlich {{ averageDonation }} finanziert.
 		</p>
 	</KeenSliderSlide>
@@ -53,7 +53,8 @@ const {
 	currentDate,
 	visitorsVsDonorsSentence,
 	goalDonationSum,
-	averageDonation
+	averageDonation,
+	campaignDaySentence
 }: DynamicContent = inject( 'dynamicCampaignText' );
 
 const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );

--- a/banners/wpde_mobile/C25_WPDE_Mobile_00/content/BannerSlidesVar.vue
+++ b/banners/wpde_mobile/C25_WPDE_Mobile_00/content/BannerSlidesVar.vue
@@ -13,7 +13,7 @@
 	</KeenSliderSlide>
 	<KeenSliderSlide :is-current="currentSlide === 2">
 		<p>
-			Heute bitten wir Sie um Ihre Unterstützung. Insgesamt spenden 99% nichts – sie übergehen diesen
+			{{ campaignDaySentence }} {Insgesamt spenden 99% nichts – sie übergehen diesen
 			Aufruf. Wikipedia wird durch Spenden von durchschnittlich {{ averageDonation }} finanziert.
 		</p>
 	</KeenSliderSlide>
@@ -53,7 +53,8 @@ const {
 	currentDate,
 	visitorsVsDonorsSentence,
 	goalDonationSum,
-	averageDonation
+	averageDonation,
+	campaignDaySentence
 }: DynamicContent = inject( 'dynamicCampaignText' );
 
 const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );

--- a/banners/wpde_mobile/C25_WPDE_Mobile_00/content/BannerText.vue
+++ b/banners/wpde_mobile/C25_WPDE_Mobile_00/content/BannerText.vue
@@ -7,7 +7,7 @@
 			<p>
 				Vielleicht kommen wir gerade ungelegen, aber dennoch: Klicken Sie jetzt bitte nicht weg! Am heutigen
 				{{ currentDayName }}, den {{ currentDate }} um {{ liveDateAndTime.currentTime }} Uhr, bitten wir Sie
-				bescheiden, die Unabhängigkeit von Wikipedia zu unterstützen. Heute bitten wir Sie um Ihre Unterstützung.
+				bescheiden, die Unabhängigkeit von Wikipedia zu unterstützen. {{ campaignDaySentence }}
 				Insgesamt spenden 99% nichts – sie übergehen diesen Aufruf. Wikipedia wird durch Spenden von
 				durchschnittlich {{ averageDonation }} finanziert. Doch schon mit einer Spende von 5&nbsp;€ kann Wikipedia sich auch
 				in Zukunft erfolgreich entwickeln. <AnimatedText :content="visitorsVsDonorsSentence"/> Die meisten
@@ -36,7 +36,8 @@ const {
 	currentDayName,
 	currentDate,
 	visitorsVsDonorsSentence,
-	averageDonation
+	averageDonation,
+	campaignDaySentence
 }: DynamicContent = inject( 'dynamicCampaignText' );
 
 const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );

--- a/banners/wpde_mobile/C25_WPDE_Mobile_00/content/BannerTextVar.vue
+++ b/banners/wpde_mobile/C25_WPDE_Mobile_00/content/BannerTextVar.vue
@@ -7,7 +7,7 @@
 			<p>
 				Vielleicht kommen wir gerade ungelegen, aber dennoch: Klicken Sie jetzt bitte nicht weg! Am heutigen
 				{{ currentDayName }}, den {{ currentDate }} um {{ liveDateAndTime.currentTime }} Uhr, bitten wir Sie
-				bescheiden, die Unabhängigkeit von Wikipedia zu unterstützen. Heute bitten wir Sie um Ihre Unterstützung.
+				bescheiden, die Unabhängigkeit von Wikipedia zu unterstützen. {{ campaignDaySentence }}
 				Insgesamt spenden 99% nichts – sie übergehen diesen Aufruf. Wikipedia wird durch Spenden von
 				durchschnittlich {{ averageDonation }} finanziert. Doch schon mit einer Spende von 15&nbsp;€ kann Wikipedia sich auch
 				in Zukunft erfolgreich entwickeln. <AnimatedText :content="visitorsVsDonorsSentence"/> Die meisten
@@ -36,7 +36,8 @@ const {
 	currentDayName,
 	currentDate,
 	visitorsVsDonorsSentence,
-	averageDonation
+	averageDonation,
+	campaignDaySentence
 }: DynamicContent = inject( 'dynamicCampaignText' );
 
 const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );

--- a/banners/wpde_mobile/C25_WPDE_Mobile_01/content/BannerSlides.vue
+++ b/banners/wpde_mobile/C25_WPDE_Mobile_01/content/BannerSlides.vue
@@ -13,7 +13,7 @@
 	</KeenSliderSlide>
 	<KeenSliderSlide :is-current="currentSlide === 2">
 		<p>
-			Heute bitten wir Sie um Ihre Unterstützung. Insgesamt spenden 99% nichts – sie übergehen diesen
+			{{ campaignDaySentence }} Insgesamt spenden 99% nichts – sie übergehen diesen
 			Aufruf. Wikipedia wird durch Spenden von durchschnittlich {{ averageDonation }} finanziert.
 		</p>
 	</KeenSliderSlide>
@@ -53,7 +53,8 @@ const {
 	currentDate,
 	visitorsVsDonorsSentence,
 	goalDonationSum,
-	averageDonation
+	averageDonation,
+	campaignDaySentence
 }: DynamicContent = inject( 'dynamicCampaignText' );
 
 const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );

--- a/banners/wpde_mobile/C25_WPDE_Mobile_01/content/BannerText.vue
+++ b/banners/wpde_mobile/C25_WPDE_Mobile_01/content/BannerText.vue
@@ -7,7 +7,7 @@
 			<p>
 				Vielleicht kommen wir gerade ungelegen, aber dennoch: Klicken Sie jetzt bitte nicht weg! Am heutigen
 				{{ currentDayName }}, den {{ currentDate }} um {{ liveDateAndTime.currentTime }} Uhr, bitten wir Sie
-				bescheiden, die Unabhängigkeit von Wikipedia zu unterstützen. Heute bitten wir Sie um Ihre Unterstützung.
+				bescheiden, die Unabhängigkeit von Wikipedia zu unterstützen. {{ campaignDaySentence }}
 				Insgesamt spenden 99% nichts – sie übergehen diesen Aufruf. Wikipedia wird durch Spenden von
 				durchschnittlich {{ averageDonation }} finanziert. Doch schon mit einer Spende von 5&nbsp;€ kann Wikipedia sich auch
 				in Zukunft erfolgreich entwickeln. <AnimatedText :content="visitorsVsDonorsSentence"/> Die meisten
@@ -36,7 +36,8 @@ const {
 	currentDayName,
 	currentDate,
 	visitorsVsDonorsSentence,
-	averageDonation
+	averageDonation,
+	campaignDaySentence
 }: DynamicContent = inject( 'dynamicCampaignText' );
 
 const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );

--- a/banners/wpde_mobile/C25_WPDE_Mobile_01/content/BannerTextVar.vue
+++ b/banners/wpde_mobile/C25_WPDE_Mobile_01/content/BannerTextVar.vue
@@ -7,7 +7,7 @@
 			<p>
 				Vielleicht kommen wir gerade ungelegen, aber dennoch: Klicken Sie jetzt bitte nicht weg! Am heutigen
 				{{ currentDayName }}, den {{ currentDate }} um {{ liveDateAndTime.currentTime }} Uhr, bitten wir Sie
-				bescheiden, die Unabhängigkeit von Wikipedia zu unterstützen. Heute bitten wir Sie um Ihre Unterstützung.
+				bescheiden, die Unabhängigkeit von Wikipedia zu unterstützen. {{ campaignDaySentence }}
 				Insgesamt spenden 99% nichts – sie übergehen diesen Aufruf. Wikipedia wird durch Spenden von
 				durchschnittlich {{ averageDonation }} finanziert. Doch schon mit einer Spende von 5&nbsp;€ kann Wikipedia sich auch
 				in Zukunft erfolgreich entwickeln. <AnimatedText :content="visitorsVsDonorsSentence"/> Die meisten
@@ -39,7 +39,8 @@ const {
 	currentDayName,
 	currentDate,
 	visitorsVsDonorsSentence,
-	averageDonation
+	averageDonation,
+	campaignDaySentence
 }: DynamicContent = inject( 'dynamicCampaignText' );
 
 const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );

--- a/package-lock.json
+++ b/package-lock.json
@@ -6114,7 +6114,7 @@
     },
     "node_modules/fundraising-frontend-content": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/wmde/fundraising-frontend-content.git#fbc410d180d176e95b51068c7e835df006690fa0",
+      "resolved": "git+ssh://git@github.com/wmde/fundraising-frontend-content.git#1762b2c2a08ccefcdbce7de354c16d71e0816636",
       "license": "CC0-1.0"
     },
     "node_modules/generator-function": {


### PR DESCRIPTION
- The sentence "Heute bitten wir Sie um Ihre Unterstützung." is replaced by {{ campaignDaySentence }}.
- The sentence "Insgesamt spenden 99% nichts – sie übergehen diesen Aufruf." is replaced by {{ visitorsVsDonorsSentence }}.
- The changes are made to the 3rd slide and the modal banner.

Ticket: https://phabricator.wikimedia.org/T408390