### PR TITLE
Hide banner when language button is clicked

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6117,7 +6117,7 @@
     },
     "node_modules/fundraising-frontend-content": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/wmde/fundraising-frontend-content.git#fbc410d180d176e95b51068c7e835df006690fa0",
+      "resolved": "git+ssh://git@github.com/wmde/fundraising-frontend-content.git#1762b2c2a08ccefcdbce7de354c16d71e0816636",
       "license": "CC0-1.0"
     },
     "node_modules/generator-function": {

--- a/src/page/skin/Minerva.ts
+++ b/src/page/skin/Minerva.ts
@@ -3,6 +3,7 @@ import { Skin } from '@src/page/skin/Skin';
 class Minerva implements Skin {
 	private _searchField: HTMLInputElement;
 	private _searchButton: HTMLButtonElement;
+	private _langButton: HTMLAnchorElement;
 	private _hideBannerCallback: () => void;
 	private readonly _referencedHideBannerCallback: () => void;
 
@@ -11,8 +12,10 @@ class Minerva implements Skin {
 
 		this._searchField = document.getElementById( 'searchInput' ) as HTMLInputElement;
 		this._searchButton = document.getElementById( 'searchIcon' ) as HTMLButtonElement;
+		this._langButton = document.querySelector( 'a[href="#p-lang"]' );
 		this._searchField.addEventListener( 'focus', this._referencedHideBannerCallback );
 		this._searchButton.addEventListener( 'click', this._referencedHideBannerCallback );
+		this._langButton.addEventListener( 'click', this._referencedHideBannerCallback );
 	}
 
 	public addHideBannerListener( hideBannerListener: () => void ): void {
@@ -22,6 +25,7 @@ class Minerva implements Skin {
 	public removeEventListeners(): void {
 		this._searchField.removeEventListener( 'focus', this._referencedHideBannerCallback );
 		this._searchButton.removeEventListener( 'click', this._referencedHideBannerCallback );
+		this._langButton.removeEventListener( 'click', this._referencedHideBannerCallback );
 	}
 
 	public minimumVisiblePageBeneathBanner(): number {


### PR DESCRIPTION
This adds the language selection button to the
hide banner callbacks in order to hide the banner
to stop it obscuring the language modal.

Ticket: https://phabricator.wikimedia.org/T409465