### PR TITLE
Hide banner when user is temporary

### DIFF
--- a/src/page/MediaWiki/MediaWiki.ts
+++ b/src/page/MediaWiki/MediaWiki.ts
@@ -8,6 +8,7 @@ export interface MediaWiki {
 	isShowingContentPage: () => boolean;
 	isContentHiddenByLightbox: () => boolean;
 	isInArticleNamespace: () => boolean;
+	isShowingTemporaryAccountBar: () => boolean;
 	track: ( name: string, trackingData: BannerEvent|LegacyBannerEvent|SizeIssue ) => void;
 	preventBannerDisplayForPeriod: ( bannerCategory: BannerCategory ) => void;
 	preventBannerDisplayUntilEndOfCampaign: ( bannerCategory: BannerCategory ) => void;

--- a/src/page/MediaWiki/WindowMediaWiki.ts
+++ b/src/page/MediaWiki/WindowMediaWiki.ts
@@ -6,10 +6,14 @@ import { setCookie } from '@src/page/MediaWiki/setCookie';
 import { createImageCookieSetter } from '@src/page/MediaWiki/createImageCookieSetter';
 import { BannerCategory } from '@src/components/BannerConductor/BannerCategory';
 
+/**
+ * An interface that defines the parts of the huge Mediawiki object that are interesting for us
+ */
 interface MediaWikiTools {
 	config: { get: ( item: string ) => any };
 	track: ( name: string, trackingData: BannerEvent|LegacyBannerEvent|SizeIssue ) => void;
 	centralNotice: { setBannerLoadedButHidden: () => void };
+	user: { isTemp: () => boolean };
 }
 
 interface MwWindow extends Window {
@@ -48,6 +52,12 @@ export class WindowMediaWiki implements MediaWiki {
 
 	public isShowingContentPage(): boolean {
 		return this.getConfigItem( 'wgAction' ) === 'view';
+	}
+
+	public isShowingTemporaryAccountBar(): boolean {
+		// We assume that the temporary account bar will be visible when the user is a temporary user.
+		// The (brittle) alternative would be to look for an element with `mw-temp-user-banner` class
+		return window.mw.user.isTemp();
 	}
 
 	public track( name: string, trackingData: LegacyBannerEvent | SizeIssue ): void {

--- a/src/page/PageWPORG.ts
+++ b/src/page/PageWPORG.ts
@@ -64,6 +64,10 @@ class PageWPORG implements Page {
 			return BannerNotShownReasons.DisallowedNamespace;
 		}
 
+		if ( this._mediaWiki.isShowingTemporaryAccountBar() ) {
+			return BannerNotShownReasons.UserInteraction;
+		}
+
 		if ( this.hasSizeIssues( bannerDimensions ) ) {
 			return BannerNotShownReasons.SizeIssue;
 		}

--- a/test/fixtures/MediaWikiStub.ts
+++ b/test/fixtures/MediaWikiStub.ts
@@ -13,6 +13,10 @@ export class MediaWikiStub implements MediaWiki {
 		return false;
 	}
 
+	public isShowingTemporaryAccountBar(): boolean {
+		return false;
+	}
+
 	public preventBannerDisplayForPeriod(): void {
 	}
 

--- a/test/integration/page/PageWPORG.spec.ts
+++ b/test/integration/page/PageWPORG.spec.ts
@@ -15,14 +15,19 @@ describe( 'PageWPORG', function () {
 	const bannerTestCategory = 'fundraising';
 
 	beforeEach( () => {
+		// the default booleans in the checking functions would all allow showing the banner.
+		// Individual tests can override them to test the functionality.
 		mediaWiki = {
 			isInArticleNamespace(): boolean {
 				return true;
 			},
 			isShowingContentPage(): boolean {
-				return false;
+				return true;
 			},
 			isContentHiddenByLightbox(): boolean {
+				return false;
+			},
+			isShowingTemporaryAccountBar(): boolean {
 				return false;
 			},
 			getConfigItem: vitest.fn(),
@@ -34,37 +39,34 @@ describe( 'PageWPORG', function () {
 		};
 	} );
 
-	it( 'shows when appropriate', function () {
-		mediaWiki.isInArticleNamespace = vitest.fn().mockReturnValue( true );
-		mediaWiki.isShowingContentPage = vitest.fn().mockReturnValue( true );
-		mediaWiki.isContentHiddenByLightbox = vitest.fn().mockReturnValue( false );
-
+	it( 'shows when mediawiki object returns appropriate values', function () {
 		expect( ( new PageWPORG( mediaWiki, new SkinStub(), new SizeIssueCheckerStub() ) ).getReasonToNotShowBanner( Vector2.ZERO ) )
 			.toBe( null );
 	} );
 
 	it( 'hides when not in article namespace', function () {
 		mediaWiki.isInArticleNamespace = vitest.fn().mockReturnValue( false );
-		mediaWiki.isShowingContentPage = vitest.fn().mockReturnValue( true );
-		mediaWiki.isContentHiddenByLightbox = vitest.fn().mockReturnValue( false );
 
 		expect( ( new PageWPORG( mediaWiki, new SkinStub(), new SizeIssueCheckerStub() ) ).getReasonToNotShowBanner( Vector2.ZERO ) )
 			.toBe( BannerNotShownReasons.DisallowedNamespace );
 	} );
 
 	it( 'hides when not on content page', function () {
-		mediaWiki.isInArticleNamespace = vitest.fn().mockReturnValue( true );
 		mediaWiki.isShowingContentPage = vitest.fn().mockReturnValue( false );
-		mediaWiki.isContentHiddenByLightbox = vitest.fn().mockReturnValue( false );
 
 		expect( ( new PageWPORG( mediaWiki, new SkinStub(), new SizeIssueCheckerStub() ) ).getReasonToNotShowBanner( Vector2.ZERO ) )
 			.toBe( BannerNotShownReasons.UserInteraction );
 	} );
 
 	it( 'hides when content is hidden by lightbox', function () {
-		mediaWiki.isInArticleNamespace = vitest.fn().mockReturnValue( true );
-		mediaWiki.isShowingContentPage = vitest.fn().mockReturnValue( true );
 		mediaWiki.isContentHiddenByLightbox = vitest.fn().mockReturnValue( true );
+
+		expect( ( new PageWPORG( mediaWiki, new SkinStub(), new SizeIssueCheckerStub() ) ).getReasonToNotShowBanner( Vector2.ZERO ) )
+			.toBe( BannerNotShownReasons.UserInteraction );
+	} );
+
+	it( 'hides when showing a temporary account bar', function () {
+		mediaWiki.isShowingTemporaryAccountBar = vitest.fn().mockReturnValue( true );
 
 		expect( ( new PageWPORG( mediaWiki, new SkinStub(), new SizeIssueCheckerStub() ) ).getReasonToNotShowBanner( Vector2.ZERO ) )
 			.toBe( BannerNotShownReasons.UserInteraction );


### PR DESCRIPTION
When a user makes an edit, they get a temporary user ID, but do not count as a "logged in" user for CentralNotice.

The banner for notifying the user about their temporary ID obscures the fundraising banner, so we hide it in these cases.

Ticket: https://phabricator.wikimedia.org/T408908