### PR TITLE
Wmde fr 2025 desktop de 15

### DIFF
--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/banner_ctrl.ts
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/banner_ctrl.ts
@@ -1,0 +1,76 @@
+import { createVueApp } from '@src/createVueApp';
+
+import './styles/styles.scss';
+
+import BannerConductor from '@src/components/BannerConductor/FallbackBannerConductor.vue';
+import Banner from './components/BannerCtrl.vue';
+import FallbackBanner from './components/FallbackBanner.vue';
+import { UrlRuntimeEnvironment } from '@src/utils/RuntimeEnvironment';
+import { WindowResizeHandler } from '@src/utils/ResizeHandler';
+import PageWPORG from '@src/page/PageWPORG';
+import { WindowMediaWiki } from '@src/page/MediaWiki/WindowMediaWiki';
+import { SkinFactory } from '@src/page/skin/SkinFactory';
+import { WindowSizeIssueChecker } from '@src/utils/SizeIssueChecker/WindowSizeIssueChecker';
+import TranslationPlugin from '@src/TranslationPlugin';
+import { Translator } from '@src/Translator';
+import DynamicTextPlugin from '@src/DynamicTextPlugin';
+import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
+import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
+import eventMappings from './event_map';
+import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
+import { LocalStorageCloseTracker } from '@src/utils/LocalCloseTracker';
+import messages from './messages';
+import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
+import { createFormItems } from './form_items';
+import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
+import { currentCampaignTimePercentage } from '@src/components/ProgressBar/currentCampaignTimePercentage';
+
+const date = new Date();
+const localeFactory = new LocaleFactoryDe();
+const translator = new Translator( messages );
+const mediaWiki = new WindowMediaWiki();
+const page = new PageWPORG( mediaWiki, ( new SkinFactory( mediaWiki ) ).getSkin(), new WindowSizeIssueChecker( 400 ) );
+const runtimeEnvironment = new UrlRuntimeEnvironment( window.location );
+const impressionCount = new LocalImpressionCount( page.getTracking().keyword, runtimeEnvironment );
+const tracker = new LegacyTrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings, runtimeEnvironment );
+
+const app = createVueApp( BannerConductor, {
+	page,
+	bannerConfig: {
+		delay: runtimeEnvironment.getBannerDelay( 7500 ),
+		transitionDuration: 1000
+	},
+	bannerCategory: 'fundraising',
+	bannerProps: {
+		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
+		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),
+		localCloseTracker: new LocalStorageCloseTracker(),
+		donationLink: createFallbackDonationURL( page.getTracking(), impressionCount )
+	},
+	resizeHandler: new WindowResizeHandler(),
+	banner: Banner,
+	fallbackBanner: FallbackBanner,
+	minWidthForMainBanner: 800,
+	impressionCount
+} );
+
+app.use( TranslationPlugin, translator );
+app.use( DynamicTextPlugin, {
+	campaignParameters: page.getCampaignParameters(),
+	date,
+	formatters: localeFactory.getFormatters(),
+	impressionCount,
+	translator
+} );
+
+const currencyFormatter = localeFactory.getCurrencyFormatter();
+
+app.provide( 'currencyFormatter', currencyFormatter );
+app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
+app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { ap: '0' } ) );
+app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
+app.provide( 'currentCampaignTimePercentage', currentCampaignTimePercentage( new Date(), page.getCampaignParameters() ) );
+
+app.mount( page.getBannerContainer() );

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/banner_var.ts
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/banner_var.ts
@@ -1,0 +1,76 @@
+import { createVueApp } from '@src/createVueApp';
+
+import './styles/styles.scss';
+
+import BannerConductor from '@src/components/BannerConductor/FallbackBannerConductor.vue';
+import Banner from './components/BannerVar.vue';
+import FallbackBanner from './components/FallbackBanner.vue';
+import { UrlRuntimeEnvironment } from '@src/utils/RuntimeEnvironment';
+import { WindowResizeHandler } from '@src/utils/ResizeHandler';
+import PageWPORG from '@src/page/PageWPORG';
+import { WindowMediaWiki } from '@src/page/MediaWiki/WindowMediaWiki';
+import { SkinFactory } from '@src/page/skin/SkinFactory';
+import { WindowSizeIssueChecker } from '@src/utils/SizeIssueChecker/WindowSizeIssueChecker';
+import TranslationPlugin from '@src/TranslationPlugin';
+import { Translator } from '@src/Translator';
+import DynamicTextPlugin from '@src/DynamicTextPlugin';
+import { LocalImpressionCount } from '@src/utils/LocalImpressionCount';
+import { LegacyTrackerWPORG } from '@src/tracking/LegacyTrackerWPORG';
+import eventMappings from './event_map';
+import { createFallbackDonationURL } from '@src/createFallbackDonationURL';
+import { LocalStorageCloseTracker } from '@src/utils/LocalCloseTracker';
+import messages from './messages';
+import { LocaleFactoryDe } from '@src/utils/LocaleFactory/LocaleFactoryDe';
+import { createFormItems } from './form_items';
+import { createFormActions } from '@src/createFormActions';
+import { WindowTimer } from '@src/utils/Timer';
+import { currentCampaignTimePercentage } from '@src/components/ProgressBar/currentCampaignTimePercentage';
+
+const date = new Date();
+const localeFactory = new LocaleFactoryDe();
+const translator = new Translator( messages );
+const mediaWiki = new WindowMediaWiki();
+const page = new PageWPORG( mediaWiki, ( new SkinFactory( mediaWiki ) ).getSkin(), new WindowSizeIssueChecker( 400 ) );
+const runtimeEnvironment = new UrlRuntimeEnvironment( window.location );
+const impressionCount = new LocalImpressionCount( page.getTracking().keyword, runtimeEnvironment );
+const tracker = new LegacyTrackerWPORG( mediaWiki, page.getTracking().keyword, eventMappings, runtimeEnvironment );
+
+const app = createVueApp( BannerConductor, {
+	page,
+	bannerConfig: {
+		delay: runtimeEnvironment.getBannerDelay( 7500 ),
+		transitionDuration: 1000
+	},
+	bannerCategory: 'fundraising',
+	bannerProps: {
+		useOfFundsContent: localeFactory.getUseOfFundsLoader().getContent(),
+		remainingImpressions: impressionCount.getRemainingImpressions( page.getMaxBannerImpressions( 'desktop' ) ),
+		localCloseTracker: new LocalStorageCloseTracker(),
+		donationLink: createFallbackDonationURL( page.getTracking(), impressionCount )
+	},
+	resizeHandler: new WindowResizeHandler(),
+	banner: Banner,
+	fallbackBanner: FallbackBanner,
+	minWidthForMainBanner: 800,
+	impressionCount
+} );
+
+app.use( TranslationPlugin, translator );
+app.use( DynamicTextPlugin, {
+	campaignParameters: page.getCampaignParameters(),
+	date,
+	formatters: localeFactory.getFormatters(),
+	impressionCount,
+	translator
+} );
+
+const currencyFormatter = localeFactory.getCurrencyFormatter();
+
+app.provide( 'currencyFormatter', currencyFormatter );
+app.provide( 'formItems', createFormItems( translator, currencyFormatter.euroAmount.bind( currencyFormatter ) ) );
+app.provide( 'formActions', createFormActions( page.getTracking(), impressionCount, { ap: '0' } ) );
+app.provide( 'tracker', tracker );
+app.provide( 'timer', new WindowTimer() );
+app.provide( 'currentCampaignTimePercentage', currentCampaignTimePercentage( new Date(), page.getCampaignParameters() ) );
+
+app.mount( page.getBannerContainer() );

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/banner_var.ts
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/banner_var.ts
@@ -1,6 +1,6 @@
 import { createVueApp } from '@src/createVueApp';
 
-import './styles/styles.scss';
+import './styles/styles_var.scss';
 
 import BannerConductor from '@src/components/BannerConductor/FallbackBannerConductor.vue';
 import Banner from './components/BannerVar.vue';

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/BannerCtrl.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/BannerCtrl.vue
@@ -1,0 +1,222 @@
+<template>
+	<div class="wmde-banner-wrapper" :class="contentState">
+		<MainBanner
+			@form-interaction="$emit( 'bannerContentChanged' )"
+			v-if="contentState === ContentStates.Main"
+			:bannerState="bannerState"
+		>
+			<template #close-button>
+				<ButtonClose @close="onCloseMain"/>
+			</template>
+
+			<template #banner-title>
+				<BannerTitle/>
+			</template>
+
+			<template #banner-text>
+				<BannerText/>
+			</template>
+
+			<template #banner-slides="{ play }: any">
+				<KeenSlider :with-navigation="true" :play="play" :interval="10000" :delay="2000" :navigation-color="'#ffffff'">
+
+					<template #slides="{ currentSlide }: any">
+						<BannerSlides :currentSlide="currentSlide"/>
+					</template>
+
+				</KeenSlider>
+			</template>
+
+			<template #progress>
+				<ProgressBar amount-to-show-on-right="TARGET"/>
+			</template>
+
+			<template #donation-form="{ formInteraction }: any">
+				<div class="wmde-banner-usage-link-wrapper">
+					<a
+						id="application-of-funds-link"
+						class="wmde-banner-usage-link t-use-of-funds-link"
+						:title="$translate( 'use-of-funds-link-description' )"
+						@click.prevent="onModalOpened"
+					>
+						{{ $translate( 'use-of-funds-link' ) }}
+					</a>
+				</div>
+
+				<MultiStepDonation
+					:step-controllers="stepControllers"
+					@form-interaction="formInteraction"
+					:submit-callback="onSubmit"
+				>
+
+					<template #[FormStepNames.MainDonationFormStep]="{ pageIndex, submit, isCurrent, previous }: any">
+						<MainDonationForm
+							:page-index="pageIndex"
+							@submit="submit"
+							:is-current="isCurrent"
+							@previous="previous"
+						>
+							<template #label-payment-ppl>
+								<span class="wmde-banner-select-group-label with-logos paypal">
+									<PayPalIcon/><span>Paypal</span>
+								</span>
+							</template>
+
+							<template #interval-select-group="{ fieldName, selectionItems, isValid, errorMessage, disabledOptions }: any">
+								<SelectGroup
+									:field-name="fieldName"
+									:selectionItems="selectionItems"
+									:isValid="isValid"
+									:errorMessage="errorMessage"
+									v-model:inputValue="interval"
+									:disabledOptions="disabledOptions"
+								/>
+							</template>
+
+							<template #label-payment-mcp>
+								<span class="wmde-banner-select-group-label with-logos credit-cards">
+									<MasterCardIcon/><span>Kreditkarte</span>
+								</span>
+							</template>
+
+							<template #label-payment-ueb>
+								<span class="wmde-banner-select-group-label with-logos bank-transfer">
+									<BankTransferIcon/><span>Überweisung</span>
+								</span>
+							</template>
+
+							<template #label-payment-bez>
+								<span class="wmde-banner-select-group-label with-logos bank-transfer">
+									<DirectDebitIcon/><span>Lastschrift</span>
+								</span>
+							</template>
+						</MainDonationForm>
+					</template>
+
+					<template #[FormStepNames.UpgradeToYearlyFormStep]="{ pageIndex, submit, isCurrent, previous }: any">
+						<UpgradeToYearlyButtonForm
+							:page-index="pageIndex"
+							@submit="submit"
+							:is-current="isCurrent"
+							@previous="previous"
+						/>
+					</template>
+
+				</MultiStepDonation>
+			</template>
+
+			<template #footer>
+				<FooterAlreadyDonatedWithoutFundsLink
+					@showFundsModal="onModalOpened"
+					@clickedAlreadyDonatedLink="onClose( 'MainBanner', CloseChoices.AlreadyDonated )"
+				/>
+			</template>
+
+		</MainBanner>
+
+		<FundsModal
+			:content="useOfFundsContent"
+			:visible="isFundsModalVisible"
+			@hide="onHideFundsModal"
+			@call-to-action="onHideFundsModal"
+		/>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+import { inject, ref, watch } from 'vue';
+import { UseOfFundsContent as useOfFundsContentInterface } from '@src/domain/UseOfFunds/UseOfFundsContent';
+import MainBanner from './MainBanner.vue';
+import FundsModal from '@src/components/UseOfFunds/UseOfFundsModal.vue';
+import BannerText from '../content/BannerText.vue';
+import BannerSlides from '../content/BannerSlides.vue';
+import MultiStepDonation from '@src/components/DonationForm/MultiStepDonation.vue';
+import MainDonationForm from '@src/components/DonationForm/Forms/MainDonationForm.vue';
+import UpgradeToYearlyButtonForm from '@src/components/DonationForm/Forms/UpgradeToYearlyButtonForm.vue';
+import KeenSlider from '@src/components/Slider/KeenSlider.vue';
+import { useFormModel } from '@src/components/composables/useFormModel';
+import {
+	createSubmittableMainDonationForm
+} from '@src/components/DonationForm/StepControllers/SubmittableMainDonationForm';
+import {
+	createSubmittableUpgradeToYearly
+} from '@src/components/DonationForm/StepControllers/SubmittableUpgradeToYearly';
+import { CloseChoices } from '@src/domain/CloseChoices';
+import { CloseEvent } from '@src/tracking/events/CloseEvent';
+import { TrackingFeatureName } from '@src/tracking/TrackingEvent';
+import ButtonClose from '@src/components/ButtonClose/ButtonClose.vue';
+import FooterAlreadyDonatedWithoutFundsLink from '@src/components/Footer/FooterAlreadyDonatedWithoutFundsLink.vue';
+import { LocalCloseTracker } from '@src/utils/LocalCloseTracker';
+import { BannerSubmitOnReturnEvent } from '@src/tracking/events/BannerSubmitOnReturnEvent';
+import { Tracker } from '@src/tracking/Tracker';
+import { useBannerHider } from '@src/components/composables/useBannerHider';
+import BannerTitle from '../content/BannerTitle.vue';
+import BankTransferIcon from '@src/components/PaymentLogos/BankTransferIcon.vue';
+import PayPalIcon from '@src/components/PaymentLogos/PayPalIcon.vue';
+import DirectDebitIcon from '@src/components/PaymentLogos/DirectDebitIcon.vue';
+import MasterCardIcon from '@src/components/PaymentLogos/MasterCardIcon.vue';
+import ProgressBar from '@src/components/ProgressBar/ProgressBar.vue';
+import SelectGroup from '@src/components/DonationForm/SubComponents/SelectGroupHighlightedInterval.vue';
+
+enum ContentStates {
+	Main = 'wmde-banner-wrapper--main',
+}
+
+enum FormStepNames {
+	MainDonationFormStep = 'MainDonationForm',
+	UpgradeToYearlyFormStep = 'UpgradeToYearlyForm'
+}
+
+interface Props {
+	bannerState: BannerStates;
+	useOfFundsContent: useOfFundsContentInterface;
+	localCloseTracker: LocalCloseTracker;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits( [ 'bannerClosed', 'bannerContentChanged', 'modalOpened', 'modalClosed' ] );
+useBannerHider( 800, emit );
+
+const tracker = inject<Tracker>( 'tracker' );
+
+const isFundsModalVisible = ref<boolean>( false );
+const contentState = ref<ContentStates>( ContentStates.Main );
+const formModel = useFormModel();
+const { interval } = formModel;
+const stepControllers = [
+	createSubmittableMainDonationForm( formModel, FormStepNames.UpgradeToYearlyFormStep ),
+	createSubmittableUpgradeToYearly( formModel, FormStepNames.MainDonationFormStep, FormStepNames.MainDonationFormStep )
+];
+
+watch( contentState, async () => {
+	emit( 'bannerContentChanged' );
+} );
+
+const onSubmit = (): void => {
+	// special callback function: asking for previous close choices
+	const closeChoice = props.localCloseTracker.getItem();
+	if ( closeChoice !== '' ) {
+		tracker.trackEvent( new BannerSubmitOnReturnEvent( closeChoice ) );
+	}
+};
+
+function onCloseMain(): void {
+	onClose( 'MainBanner', CloseChoices.Close );
+}
+
+function onClose( feature: TrackingFeatureName, userChoice: CloseChoices ): void {
+	emit( 'bannerClosed', new CloseEvent( feature, userChoice ) );
+}
+
+function onHideFundsModal(): void {
+	isFundsModalVisible.value = false;
+	emit( 'modalClosed' );
+}
+
+function onModalOpened(): void {
+	isFundsModalVisible.value = true;
+	emit( 'modalOpened' );
+}
+
+</script>

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/BannerCtrl.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/BannerCtrl.vue
@@ -157,7 +157,7 @@ import PayPalIcon from '@src/components/PaymentLogos/PayPalIcon.vue';
 import DirectDebitIcon from '@src/components/PaymentLogos/DirectDebitIcon.vue';
 import MasterCardIcon from '@src/components/PaymentLogos/MasterCardIcon.vue';
 import ProgressBar from '@src/components/ProgressBar/ProgressBar.vue';
-import SelectGroup from '@src/components/DonationForm/SubComponents/SelectGroupHighlightedInterval.vue';
+import SelectGroup from '@src/components/DonationForm/SubComponents/SelectGroup.vue';
 
 enum ContentStates {
 	Main = 'wmde-banner-wrapper--main',

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/BannerVar.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/BannerVar.vue
@@ -1,0 +1,222 @@
+<template>
+	<div class="wmde-banner-wrapper" :class="contentState">
+		<MainBanner
+			@form-interaction="$emit( 'bannerContentChanged' )"
+			v-if="contentState === ContentStates.Main"
+			:bannerState="bannerState"
+		>
+			<template #close-button>
+				<ButtonClose @close="onCloseMain"/>
+			</template>
+
+			<template #banner-title>
+				<BannerTitle/>
+			</template>
+
+			<template #banner-text>
+				<BannerText/>
+			</template>
+
+			<template #banner-slides="{ play }: any">
+				<KeenSlider :with-navigation="true" :play="play" :interval="10000" :delay="2000" :navigation-color="'#ffffff'">
+
+					<template #slides="{ currentSlide }: any">
+						<BannerSlides :currentSlide="currentSlide"/>
+					</template>
+
+				</KeenSlider>
+			</template>
+
+			<template #progress>
+				<ProgressBar amount-to-show-on-right="TARGET"/>
+			</template>
+
+			<template #donation-form="{ formInteraction }: any">
+				<div class="wmde-banner-usage-link-wrapper">
+					<a
+						id="application-of-funds-link"
+						class="wmde-banner-usage-link t-use-of-funds-link"
+						:title="$translate( 'use-of-funds-link-description' )"
+						@click.prevent="onModalOpened"
+					>
+						{{ $translate( 'use-of-funds-link' ) }}
+					</a>
+				</div>
+
+				<MultiStepDonation
+					:step-controllers="stepControllers"
+					@form-interaction="formInteraction"
+					:submit-callback="onSubmit"
+				>
+
+					<template #[FormStepNames.MainDonationFormStep]="{ pageIndex, submit, isCurrent, previous }: any">
+						<MainDonationForm
+							:page-index="pageIndex"
+							@submit="submit"
+							:is-current="isCurrent"
+							@previous="previous"
+						>
+							<template #label-payment-ppl>
+								<span class="wmde-banner-select-group-label with-logos paypal">
+									<PayPalIcon/><span>Paypal</span>
+								</span>
+							</template>
+
+							<template #interval-select-group="{ fieldName, selectionItems, isValid, errorMessage, disabledOptions }: any">
+								<SelectGroup
+									:field-name="fieldName"
+									:selectionItems="selectionItems"
+									:isValid="isValid"
+									:errorMessage="errorMessage"
+									v-model:inputValue="interval"
+									:disabledOptions="disabledOptions"
+								/>
+							</template>
+
+							<template #label-payment-mcp>
+								<span class="wmde-banner-select-group-label with-logos credit-cards">
+									<MasterCardIcon/><span>Kreditkarte</span>
+								</span>
+							</template>
+
+							<template #label-payment-ueb>
+								<span class="wmde-banner-select-group-label with-logos bank-transfer">
+									<BankTransferIcon/><span>Überweisung</span>
+								</span>
+							</template>
+
+							<template #label-payment-bez>
+								<span class="wmde-banner-select-group-label with-logos bank-transfer">
+									<DirectDebitIcon/><span>Lastschrift</span>
+								</span>
+							</template>
+						</MainDonationForm>
+					</template>
+
+					<template #[FormStepNames.UpgradeToYearlyFormStep]="{ pageIndex, submit, isCurrent, previous }: any">
+						<UpgradeToYearlyButtonForm
+							:page-index="pageIndex"
+							@submit="submit"
+							:is-current="isCurrent"
+							@previous="previous"
+						/>
+					</template>
+
+				</MultiStepDonation>
+			</template>
+
+			<template #footer>
+				<FooterAlreadyDonatedWithoutFundsLink
+					@showFundsModal="onModalOpened"
+					@clickedAlreadyDonatedLink="onClose( 'MainBanner', CloseChoices.AlreadyDonated )"
+				/>
+			</template>
+
+		</MainBanner>
+
+		<FundsModal
+			:content="useOfFundsContent"
+			:visible="isFundsModalVisible"
+			@hide="onHideFundsModal"
+			@call-to-action="onHideFundsModal"
+		/>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+import { inject, ref, watch } from 'vue';
+import { UseOfFundsContent as useOfFundsContentInterface } from '@src/domain/UseOfFunds/UseOfFundsContent';
+import MainBanner from './MainBanner.vue';
+import FundsModal from '@src/components/UseOfFunds/UseOfFundsModal.vue';
+import BannerText from '../content/BannerText.vue';
+import BannerSlides from '../content/BannerSlides.vue';
+import MultiStepDonation from '@src/components/DonationForm/MultiStepDonation.vue';
+import MainDonationForm from '@src/components/DonationForm/Forms/MainDonationForm.vue';
+import UpgradeToYearlyButtonForm from '@src/components/DonationForm/Forms/UpgradeToYearlyButtonForm.vue';
+import KeenSlider from '@src/components/Slider/KeenSlider.vue';
+import { useFormModel } from '@src/components/composables/useFormModel';
+import {
+	createSubmittableMainDonationForm
+} from '@src/components/DonationForm/StepControllers/SubmittableMainDonationForm';
+import {
+	createSubmittableUpgradeToYearly
+} from '@src/components/DonationForm/StepControllers/SubmittableUpgradeToYearly';
+import { CloseChoices } from '@src/domain/CloseChoices';
+import { CloseEvent } from '@src/tracking/events/CloseEvent';
+import { TrackingFeatureName } from '@src/tracking/TrackingEvent';
+import ButtonClose from '@src/components/ButtonClose/ButtonClose.vue';
+import FooterAlreadyDonatedWithoutFundsLink from '@src/components/Footer/FooterAlreadyDonatedWithoutFundsLink.vue';
+import { LocalCloseTracker } from '@src/utils/LocalCloseTracker';
+import { BannerSubmitOnReturnEvent } from '@src/tracking/events/BannerSubmitOnReturnEvent';
+import { Tracker } from '@src/tracking/Tracker';
+import { useBannerHider } from '@src/components/composables/useBannerHider';
+import BannerTitle from '../content/BannerTitle.vue';
+import BankTransferIcon from '@src/components/PaymentLogos/BankTransferIcon.vue';
+import PayPalIcon from '@src/components/PaymentLogos/PayPalIcon.vue';
+import DirectDebitIcon from '@src/components/PaymentLogos/DirectDebitIcon.vue';
+import MasterCardIcon from '@src/components/PaymentLogos/MasterCardIcon.vue';
+import ProgressBar from '@src/components/ProgressBar/ProgressBar.vue';
+import SelectGroup from '@src/components/DonationForm/SubComponents/SelectGroupHighlightedInterval.vue';
+
+enum ContentStates {
+	Main = 'wmde-banner-wrapper--main',
+}
+
+enum FormStepNames {
+	MainDonationFormStep = 'MainDonationForm',
+	UpgradeToYearlyFormStep = 'UpgradeToYearlyForm'
+}
+
+interface Props {
+	bannerState: BannerStates;
+	useOfFundsContent: useOfFundsContentInterface;
+	localCloseTracker: LocalCloseTracker;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits( [ 'bannerClosed', 'bannerContentChanged', 'modalOpened', 'modalClosed' ] );
+useBannerHider( 800, emit );
+
+const tracker = inject<Tracker>( 'tracker' );
+
+const isFundsModalVisible = ref<boolean>( false );
+const contentState = ref<ContentStates>( ContentStates.Main );
+const formModel = useFormModel();
+const { interval } = formModel;
+const stepControllers = [
+	createSubmittableMainDonationForm( formModel, FormStepNames.UpgradeToYearlyFormStep ),
+	createSubmittableUpgradeToYearly( formModel, FormStepNames.MainDonationFormStep, FormStepNames.MainDonationFormStep )
+];
+
+watch( contentState, async () => {
+	emit( 'bannerContentChanged' );
+} );
+
+const onSubmit = (): void => {
+	// special callback function: asking for previous close choices
+	const closeChoice = props.localCloseTracker.getItem();
+	if ( closeChoice !== '' ) {
+		tracker.trackEvent( new BannerSubmitOnReturnEvent( closeChoice ) );
+	}
+};
+
+function onCloseMain(): void {
+	onClose( 'MainBanner', CloseChoices.Close );
+}
+
+function onClose( feature: TrackingFeatureName, userChoice: CloseChoices ): void {
+	emit( 'bannerClosed', new CloseEvent( feature, userChoice ) );
+}
+
+function onHideFundsModal(): void {
+	isFundsModalVisible.value = false;
+	emit( 'modalClosed' );
+}
+
+function onModalOpened(): void {
+	isFundsModalVisible.value = true;
+	emit( 'modalOpened' );
+}
+
+</script>

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/BannerVar.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/BannerVar.vue
@@ -151,7 +151,7 @@ import { LocalCloseTracker } from '@src/utils/LocalCloseTracker';
 import { BannerSubmitOnReturnEvent } from '@src/tracking/events/BannerSubmitOnReturnEvent';
 import { Tracker } from '@src/tracking/Tracker';
 import { useBannerHider } from '@src/components/composables/useBannerHider';
-import BannerTitle from '../content/BannerTitle.vue';
+import BannerTitle from '../content/BannerTitleVar.vue';
 import BankTransferIcon from '@src/components/PaymentLogos/BankTransferIcon.vue';
 import PayPalIcon from '@src/components/PaymentLogos/PayPalIcon.vue';
 import DirectDebitIcon from '@src/components/PaymentLogos/DirectDebitIcon.vue';

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/BannerVar.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/BannerVar.vue
@@ -157,7 +157,7 @@ import PayPalIcon from '@src/components/PaymentLogos/PayPalIcon.vue';
 import DirectDebitIcon from '@src/components/PaymentLogos/DirectDebitIcon.vue';
 import MasterCardIcon from '@src/components/PaymentLogos/MasterCardIcon.vue';
 import ProgressBar from '@src/components/ProgressBar/ProgressBar.vue';
-import SelectGroup from '@src/components/DonationForm/SubComponents/SelectGroupHighlightedInterval.vue';
+import SelectGroup from '@src/components/DonationForm/SubComponents/SelectGroup.vue';
 
 enum ContentStates {
 	Main = 'wmde-banner-wrapper--main',

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/FallbackBanner.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/FallbackBanner.vue
@@ -1,0 +1,35 @@
+<template>
+	<FallbackBanner v-bind="props" @banner-closed="onClose">
+		<template #slides="{ currentSlide }: any">
+			<FallbackSlides :current-slide="currentSlide"/>
+		</template>
+		<template #message>
+			<FallbackText>
+			</FallbackText>
+		</template>
+	</FallbackBanner>
+</template>
+
+<script setup lang="ts">
+
+import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+import { UseOfFundsContent as useOfFundsContentInterface } from '@src/domain/UseOfFunds/UseOfFundsContent';
+import FallbackBanner from '@src/components/FallbackBanner/FallbackBanner.vue';
+import FallbackSlides from '../content/FallbackSlides.vue';
+import FallbackText from '../content/FallbackText.vue';
+import { CloseEvent } from '@src/tracking/events/CloseEvent';
+import { CloseChoices } from '@src/domain/CloseChoices';
+
+interface Props {
+	bannerState: BannerStates;
+	useOfFundsContent: useOfFundsContentInterface;
+	donationLink: string;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits( [ 'bannerClosed' ] );
+
+function onClose(): void {
+	emit( 'bannerClosed', new CloseEvent( 'FallbackBanner', CloseChoices.Close ) );
+}
+</script>

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/MainBanner.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/MainBanner.vue
@@ -1,0 +1,47 @@
+<template>
+	<div class="wmde-banner-main">
+		<slot name="close-button"/>
+		<div class="wmde-banner-content">
+			<div class="wmde-banner-column-left">
+				<div class="wmde-banner-message-container">
+					<slot name="banner-title"/>
+					<slot name="banner-text" v-if="onLargeScreen"/>
+					<slot name="banner-slides" v-else :play="slideshowShouldPlay"/>
+					<slot name="progress"/>
+				</div>
+				<slot name="footer"/>
+			</div>
+			<div class="wmde-banner-column-right">
+				<slot name="donation-form" :form-interaction="onFormInteraction"/>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+
+import { useDisplaySwitch } from '@src/components/composables/useDisplaySwitch';
+import { computed, nextTick, ref } from 'vue';
+import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+
+interface Props {
+	bannerState: BannerStates;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits( [ 'formInteraction' ] );
+
+const slideShowStopped = ref<boolean>( false );
+const slideshowShouldPlay = computed( () => props.bannerState === BannerStates.Visible && !slideShowStopped.value );
+
+const onLargeScreen = useDisplaySwitch( 1300 );
+
+const onFormInteraction = (): void => {
+	slideShowStopped.value = true;
+
+	nextTick( () => {
+		emit( 'formInteraction' );
+	} );
+};
+
+</script>

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/content/BannerSlides.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/content/BannerSlides.vue
@@ -1,0 +1,51 @@
+<template>
+	<KeenSliderSlide :is-current="currentSlide === 0">
+		<p>
+			Vielleicht kommen wir gerade ungelegen, aber dennoch: Klicken Sie jetzt bitte nicht weg!
+			Seit 25 Jahren steht Wikipedia für ein Internet, das von Menschen erschaffen wird – nicht von Maschinen.
+			Kein Konzern oder Milliardär finanziert das Projekt, sondern eine gemeinnützige Organisation.
+		</p>
+	</KeenSliderSlide>
+	<KeenSliderSlide :is-current="currentSlide === 1">
+		<p>
+			Am heutigen {{ currentDayName }}, den {{ currentDate }}, bitten wir Sie daher, diese Unabhängigkeit zu unterstützen.
+			{{ campaignDaySentence }}
+			<AnimatedText :content="visitorsVsDonorsSentence"/>
+		</p>
+	</KeenSliderSlide>
+	<KeenSliderSlide :is-current="currentSlide === 2">
+		<p>
+			Die meisten Menschen spenden, weil sie Wikipedia nützlich finden.
+			Die durchschnittliche Spende beträgt {{ averageDonation }}, doch bereits 5&nbsp;€ helfen uns weiter.
+		</p>
+	</KeenSliderSlide>
+	<KeenSliderSlide :is-current="currentSlide === 3">
+		<p>
+			Hat Wikipedia Ihnen in diesem Jahr Wissen im Wert einer Tasse Kaffee geschenkt?
+			Dann entscheiden Sie sich, eine der seltenen Ausnahmen zu sein, und geben Sie etwas zurück.
+			Vielen Dank!
+		</p>
+	</KeenSliderSlide>
+</template>
+
+<script setup lang="ts">
+import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import { inject } from 'vue';
+import KeenSliderSlide from '@src/components/Slider/KeenSliderSlide.vue';
+import AnimatedText from '@src/components/AnimatedText/AnimatedText.vue';
+
+interface Props {
+	currentSlide: number
+}
+
+defineProps<Props>();
+
+const {
+	currentDayName,
+	currentDate,
+	averageDonation,
+	campaignDaySentence,
+	visitorsVsDonorsSentence
+} = inject<DynamicContent>( 'dynamicCampaignText' );
+
+</script>

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/content/BannerText.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/content/BannerText.vue
@@ -1,0 +1,34 @@
+<template>
+	<div class="wmde-banner-message">
+		<div>
+			<p>
+				Vielleicht kommen wir gerade ungelegen, aber dennoch: Klicken Sie jetzt bitte nicht weg!
+				Seit 25 Jahren steht Wikipedia für ein Internet, das von Menschen erschaffen wird – nicht von Maschinen.
+				Kein Konzern oder Milliardär finanziert das Projekt, sondern eine gemeinnützige Organisation.
+				Am heutigen {{ currentDayName }}, den {{ currentDate }}, bitten wir Sie daher, die Unabhängigkeit von Wikipedia zu unterstützen.
+				{{ campaignDaySentence }}
+				<AnimatedText :content="visitorsVsDonorsSentence"/>
+				Die meisten Menschen spenden, weil sie Wikipedia nützlich finden.
+				Die durchschnittliche Spende beträgt {{ averageDonation }}, doch bereits 5&nbsp;€ helfen uns weiter.
+				Hat Wikipedia Ihnen in diesem Jahr Wissen im Wert einer Tasse Kaffee geschenkt?
+				Dann entscheiden Sie sich, eine der seltenen Ausnahmen zu sein, und geben Sie etwas zurück.
+				Vielen Dank!
+			</p>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { inject } from 'vue';
+import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import AnimatedText from '@src/components/AnimatedText/AnimatedText.vue';
+
+const {
+	currentDayName,
+	currentDate,
+	averageDonation,
+	campaignDaySentence,
+	visitorsVsDonorsSentence
+} = inject<DynamicContent>( 'dynamicCampaignText' );
+
+</script>

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/content/BannerTitle.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/content/BannerTitle.vue
@@ -1,0 +1,21 @@
+<template>
+	<div class="wmde-banner-message-header">
+		<InfoIconItalic/> <h2>Wikipedia ist unverkäuflich</h2>
+		<p class="headline">
+			{{ liveDateAndTime.currentDate }}, {{ liveDateAndTime.currentTime }} - An alle, die Wikipedia in Deutschland nutzen
+		</p>
+	</div>
+</template>
+
+<script setup lang="ts">
+import InfoIconItalic from '@src/components/Icons/InfoIconItalic.vue';
+import { useLiveDateAndTime } from '@src/components/composables/useLiveDateAndTime';
+import { inject, onMounted, onUnmounted } from 'vue';
+import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+
+const { getCurrentDateAndTime } = inject<DynamicContent>( 'dynamicCampaignText' );
+const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );
+onMounted( startTimer );
+onUnmounted( stopTimer );
+
+</script>

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/content/BannerTitleVar.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/content/BannerTitleVar.vue
@@ -1,0 +1,21 @@
+<template>
+	<div class="wmde-banner-message-header">
+		<InfoIconItalic/> <h2>Wikipedia ist unverkäuflich</h2>
+		<p class="headline">
+			{{ liveDateAndTime.currentDate }}, {{ liveDateAndTime.currentTime }} - An alle in Deutschland, die Wikipedia nutzen, aber noch nicht gespendet haben
+		</p>
+	</div>
+</template>
+
+<script setup lang="ts">
+import InfoIconItalic from '@src/components/Icons/InfoIconItalic.vue';
+import { useLiveDateAndTime } from '@src/components/composables/useLiveDateAndTime';
+import { inject, onMounted, onUnmounted } from 'vue';
+import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+
+const { getCurrentDateAndTime } = inject<DynamicContent>( 'dynamicCampaignText' );
+const { liveDateAndTime, startTimer, stopTimer } = useLiveDateAndTime( getCurrentDateAndTime );
+onMounted( startTimer );
+onUnmounted( stopTimer );
+
+</script>

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/content/FallbackSlides.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/content/FallbackSlides.vue
@@ -1,0 +1,27 @@
+<template>
+	<KeenSliderSlide :is-current="currentSlide === 0">
+		<p>
+			Hat Wikipedia Ihnen Wissen im Wert einer Tasse Kaffee geschenkt?
+		</p>
+	</KeenSliderSlide>
+	<KeenSliderSlide :is-current="currentSlide === 1">
+		<p>
+			Dann entscheiden Sie sich, etwas zurückzugeben. Danke!
+		</p>
+	</KeenSliderSlide>
+	<KeenSliderSlide :is-current="currentSlide === 2">
+		<FallbackBank/>
+	</KeenSliderSlide>
+</template>
+
+<script setup lang="ts">
+import KeenSliderSlide from '@src/components/Slider/KeenSliderSlide.vue';
+import FallbackBank from '@src/components/FallbackBanner/FallbackBank.vue';
+
+interface Props {
+	currentSlide: number
+}
+
+defineProps<Props>();
+
+</script>

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/content/FallbackText.vue
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/content/FallbackText.vue
@@ -1,0 +1,18 @@
+<template>
+	<div class="wmde-fbb-message">
+		<div class="wmde-fbb-message-content">
+			<p>
+				<InfoIconItalic/> <strong>An alle, die Wikipedia in Deutschland nutzen</strong>
+			</p>
+			<p>
+				Millionen Menschen nutzen Wikipedia, aber 99&nbsp;% spenden nicht – sie
+				übergehen diesen Aufruf. Wenn Wikipedia Ihnen in diesem Jahr Wissen im Wert einer Tasse Kaffee
+				geschenkt hat, dann geben Sie etwas zurück. Danke!
+			</p>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import InfoIconItalic from '@src/components/Icons/InfoIconItalic.vue';
+</script>

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/event_map.ts
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/event_map.ts
@@ -1,0 +1,38 @@
+import { TrackingEventConverterFactory } from '@src/tracking/LegacyTrackerWPORG';
+import { WMDELegacyBannerEvent } from '@src/tracking/WPORG/WMDELegacyBannerEvent';
+import { WMDESizeIssueEvent } from '@src/tracking/WPORG/WMDEBannerSizeIssue';
+import { BannerSubmitEvent } from '@src/tracking/events/BannerSubmitEvent';
+import { FormStepShownEvent } from '@src/tracking/events/FormStepShownEvent';
+import { mapFormStepShownEvent } from '@src/tracking/LegacyEventTracking/mapFormStepShownEvent';
+import { CloseEvent } from '@src/tracking/events/CloseEvent';
+import { mapCloseEvent } from '@src/tracking/LegacyEventTracking/mapCloseEvent';
+import { NotShownEvent } from '@src/tracking/events/NotShownEvent';
+import { mapNotShownEvent } from '@src/tracking/LegacyEventTracking/mapNotShownEvent';
+import { createViewportInfo } from '@src/tracking/LegacyEventTracking/createViewportInfo';
+import { FallbackBannerSubmitEvent } from '@src/tracking/events/FallbackBannerSubmitEvent';
+import { ShownEvent } from '@src/tracking/events/ShownEvent';
+import { mapShownEvent } from '@src/tracking/LegacyEventTracking/mapShownEvent';
+import { BannerSubmitOnReturnEvent } from '@src/tracking/events/BannerSubmitOnReturnEvent';
+
+export default new Map<string, TrackingEventConverterFactory>( [
+	[ ShownEvent.EVENT_NAME, mapShownEvent ],
+	[ CloseEvent.EVENT_NAME, mapCloseEvent ],
+	[ FormStepShownEvent.EVENT_NAME, mapFormStepShownEvent ],
+	[ NotShownEvent.EVENT_NAME, mapNotShownEvent ],
+	[ BannerSubmitEvent.EVENT_NAME, ( e: BannerSubmitEvent ): WMDESizeIssueEvent => {
+		switch ( e.feature ) {
+			case 'UpgradeToYearlyForm':
+				return new WMDESizeIssueEvent( `submit-${e.userChoice}`, createViewportInfo(), 1 );
+			default:
+				return new WMDESizeIssueEvent( `submit`, createViewportInfo(), 1 );
+		}
+	} ],
+	[ FallbackBannerSubmitEvent.EVENT_NAME,
+		( e: FallbackBannerSubmitEvent ): WMDESizeIssueEvent =>
+			new WMDESizeIssueEvent( e.eventName, createViewportInfo(), 1 )
+	],
+	[ BannerSubmitOnReturnEvent.EVENT_NAME,
+		( e: BannerSubmitOnReturnEvent ): WMDELegacyBannerEvent =>
+			new WMDELegacyBannerEvent( e.eventName + ( e.userChoice !== '' ? `-${e.userChoice}` : '' ), 1 )
+	]
+] );

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/form_items.ts
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/form_items.ts
@@ -10,6 +10,7 @@ export function createFormItems( translations: Translator, amountFormatter: Numb
 		.setIntervals(
 			Intervals.ONCE,
 			Intervals.MONTHLY,
+			Intervals.QUARTERLY,
 			Intervals.YEARLY
 		)
 		.setAmounts( 5, 10, 20, 25, 50, 100 )

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/form_items.ts
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/form_items.ts
@@ -10,7 +10,6 @@ export function createFormItems( translations: Translator, amountFormatter: Numb
 		.setIntervals(
 			Intervals.ONCE,
 			Intervals.MONTHLY,
-			Intervals.QUARTERLY,
 			Intervals.YEARLY
 		)
 		.setAmounts( 5, 10, 20, 25, 50, 100 )

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/form_items.ts
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/form_items.ts
@@ -1,0 +1,23 @@
+import FormItemsBuilder from '@src/utils/FormItemsBuilder/FormItemsBuilder';
+import { Translator } from '@src/Translator';
+import { DonationFormItems } from '@src/utils/FormItemsBuilder/DonationFormItems';
+import { Intervals } from '@src/utils/FormItemsBuilder/fields/Intervals';
+import { PaymentMethods } from '@src/utils/FormItemsBuilder/fields/PaymentMethods';
+import { NumberFormatter } from '@src/utils/DynamicContent/formatters/NumberFormatter';
+
+export function createFormItems( translations: Translator, amountFormatter: NumberFormatter ): DonationFormItems {
+	return new FormItemsBuilder( translations, amountFormatter )
+		.setIntervals(
+			Intervals.ONCE,
+			Intervals.MONTHLY,
+			Intervals.QUARTERLY,
+			Intervals.YEARLY
+		)
+		.setAmounts( 5, 10, 20, 25, 50, 100 )
+		.setPaymentMethods(
+			PaymentMethods.PAYPAL,
+			PaymentMethods.CREDIT_CARD,
+			PaymentMethods.DIRECT_DEBIT,
+			PaymentMethods.BANK_TRANSFER
+		).getItems();
+}

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/messages.ts
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/messages.ts
@@ -1,0 +1,40 @@
+import DynamicCampaignTextDe from '@src/utils/DynamicContent/messages/DynamicCampaignText.de';
+import CloseButtonTextDe from '@src/components/ButtonClose/messages/ButtonClose.de';
+import { TranslationMessages } from '@src/Translator';
+import UpgradeToYearlyDe from '@src/components/DonationForm/Forms/messages/UpgradeToYearly.de';
+import FooterDe from '@src/components/Footer/messages/Footer.de';
+import MainDonationFormDe from '@src/components/DonationForm/Forms/messages/MainDonationForm.de';
+import FallbackBanner from '@src/components/FallbackBanner/messages/FallbackBanner.de';
+import SoftCloseDe from '@src/components/SoftClose/messages/SoftClose.de';
+import DoubleProgressBarDe from '@src/components/ProgressBar/messages/DoubleProgressBar.de';
+
+const messages: TranslationMessages = {
+	...DynamicCampaignTextDe,
+	...CloseButtonTextDe,
+	...UpgradeToYearlyDe,
+	...FooterDe,
+	...MainDonationFormDe,
+	...FallbackBanner,
+	...SoftCloseDe,
+	...DoubleProgressBarDe,
+	'already-donated-link': 'Habe schon gespendet',
+	'soft-close-prompt': 'Dürfen wir später nochmal fragen?',
+	'upgrade-to-yearly-copy': `<p>Jedes Jahr sind wir auf Menschen wie Sie angewiesen. Jährliche Spenden helfen uns besonders und ermöglichen langfristige Weiterentwicklungen.</p>
+		<p>Sie gehen kein Risiko ein: Jederzeit formlos zu sofort kündbar.</p>`,
+	'upgrade-to-yearly-no': 'Nein, ich spende einmalig {{amount}}',
+	'upgrade-to-yearly-yes': 'Ja, ich spende {{amount}} jährlich',
+	'campaign-day-only-n-days': 'Heute sind es nur noch {{days}} Tage bis zum Ende unserer Spendenkampagne.',
+	'custom-amount-placeholder': 'Wahlbetrag',
+	'upgrade-to-yearly-header': 'Bitte spenden Sie {{amount}} jährlich!',
+
+	'cheering-500': 'Kleiner Betrag, große Wirkung. Danke!',
+	'cheering-1000': 'Gute Wahl. Eine der häufigsten Spenden.',
+	'cheering-2000': 'Ein starker Beitrag, der viel bewirkt. Toll',
+	'cheering-2500': 'Mehr als durchschnittlich gespendet wird!',
+	'cheering-5000': 'Wenige Menschen spenden so viel. Danke!',
+	'cheering-10000': 'Wow. So viel wird selten gespendet. Danke!',
+	'cheering-custom': 'Ihr Betrag, Ihre Wirkung! Herzlichen Dank.',
+	'interval-highlight': 'Dauerhaft etwas bewegen.',
+};
+
+export default messages;

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/messages.ts
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/messages.ts
@@ -35,6 +35,8 @@ const messages: TranslationMessages = {
 	'cheering-10000': 'Wow. So viel wird selten gespendet. Danke!',
 	'cheering-custom': 'Ihr Betrag, Ihre Wirkung! Herzlichen Dank.',
 	'interval-highlight': 'Dauerhaft etwas bewegen.',
+
+	'prefix-days-left': 'Noch',
 };
 
 export default messages;

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/styles/Banner.scss
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/styles/Banner.scss
@@ -1,0 +1,22 @@
+@use 'src/themes/Treedip/variables/fonts';
+
+.wmde-banner {
+	&-wrapper {
+		font-size: 14px;
+		font-family: fonts.$ui;
+		box-shadow: 0 3px 0.6em rgb( 60 60 60 / 40% );
+		background-color: var( --main-background );
+	}
+
+	&--pending {
+		.wmde-banner-wrapper {
+			box-shadow: none;
+		}
+	}
+
+	&--closed {
+		.wmde-banner-wrapper {
+			display: none;
+		}
+	}
+}

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/styles/MainBanner.scss
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/styles/MainBanner.scss
@@ -1,0 +1,65 @@
+$banner-height: 357px !default;
+$form-width: 344px !default;
+
+.wmde-banner {
+
+	.previous {
+		--slider-chevron: var( --previous-button-fill );
+	}
+
+	&-main {
+		min-height: $banner-height;
+		display: flex;
+		flex-direction: column;
+		padding: 0 14px 0 24px;
+	}
+
+	&-content {
+		display: flex;
+		flex-direction: row;
+		flex-grow: 1;
+	}
+
+	&-message {
+		height: auto;
+	}
+
+	&-message-container {
+		display: flex;
+		flex: 1 1 auto;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		padding: 40px 50px 11px 40px;
+
+		background-color: var( --message-background );
+	}
+
+	&-slider-container {
+		margin-bottom: 10px;
+	}
+	&-progress-bar {
+		width: 100%;
+	}
+
+	&-column-left {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		flex: 1 1 auto;
+		overflow-y: hidden;
+		margin-left: -24px;
+		margin-top: -12px;
+	}
+
+	&-column-right {
+		order: 2;
+		flex: 0 0 $form-width;
+		display: flex;
+		flex-direction: column;
+		width: $form-width;
+		padding: 0;
+		margin-bottom: 30px;
+		background: linear-gradient( 90deg, var( --message-background ) 0, var( --message-background ) 10%, var( --form-background ) 10%, var( --form-background ) 100% );
+	}
+}

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/styles/styles.scss
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/styles/styles.scss
@@ -1,0 +1,47 @@
+// This is the file where we import the theme-specific component styles
+@use 'src/themes/Mustard/swatches/skin_vector-2022' with (
+	$slider: true,
+	$select-group: true,
+	$select-group-bubble: true,
+	$select-group-button: true,
+	$select-group-image-label: true,
+	$upgrade-to-yearly: true,
+	$fallback-banner: true,
+	$progress-bar: true,
+	$select-group-highlighted-interval: true,
+);
+@use 'src/components/BannerConductor/banner-transition';
+@use '../../../../src/components/UseOfFunds/styles/swatches/skin_vector-2022' as uof-default;
+@use 'Banner';
+@use '../../../../src/components/UseOfFunds/styles/styles';
+@use 'MainBanner' with (
+	$banner-height: 357px
+);
+@use 'src/themes/Mustard/defaults';
+@use 'src/themes/Mustard/ButtonClose/ButtonClose';
+@use 'src/themes/Mustard/ProgressBar/ProgressBar';
+@use 'src/themes/Mustard/DonationForm/DonationForm';
+@use 'src/themes/Mustard/DonationForm/MultiStepDonation';
+@use 'src/themes/Mustard/DonationForm/SubComponents/SelectGroupHighlightedInterval' with (
+	$payment-option-width: 25%
+);
+@use 'src/themes/Mustard/DonationForm/SubComponents/SelectGroupRadios';
+@use 'src/themes/Mustard/DonationForm/SubComponents/SelectGroupPortraitImageLabel';
+@use 'src/themes/Mustard/DonationForm/SubComponents/SelectCustomAmountRadio';
+@use 'src/themes/Mustard/DonationForm/Forms/MainDonationForm';
+@use 'src/themes/Mustard/DonationForm/Forms/UpgradeToYearlyButtonForm' with (
+	$font-size: 14px
+);
+@use 'src/themes/Mustard/Footer/FooterAlreadyDonatedWithoutFundsLink';
+@use 'src/themes/Mustard/Footer/SelectionInput';
+@use 'src/themes/Mustard/Message/Message'  with (
+	$slider-main-headline-font-size: 25px,
+	$message-header-padding-bottom: 8px,
+	$message-header-small-up-padding-bottom: 8px
+);
+@use 'src/themes/Mustard/Slider/KeenSlider' with (
+	$slider-padding: 0
+);
+@use 'src/themes/Mustard/UseOfFundsLink/UseOfFundsLink';
+@use 'src/components/FallbackBanner/styles/swatches/skin_vector-2022' as fbb-default;
+@use 'src/components/FallbackBanner/styles/styles' as fbb-styles;

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/styles/styles.scss
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/styles/styles.scss
@@ -8,7 +8,6 @@
 	$upgrade-to-yearly: true,
 	$fallback-banner: true,
 	$progress-bar: true,
-	$select-group-highlighted-interval: true,
 );
 @use 'src/components/BannerConductor/banner-transition';
 @use '../../../../src/components/UseOfFunds/styles/swatches/skin_vector-2022' as uof-default;
@@ -22,7 +21,7 @@
 @use 'src/themes/Mustard/ProgressBar/ProgressBar';
 @use 'src/themes/Mustard/DonationForm/DonationForm';
 @use 'src/themes/Mustard/DonationForm/MultiStepDonation';
-@use 'src/themes/Mustard/DonationForm/SubComponents/SelectGroupHighlightedInterval' with (
+@use 'src/themes/Mustard/DonationForm/SubComponents/SelectGroup' with (
 	$payment-option-width: 25%
 );
 @use 'src/themes/Mustard/DonationForm/SubComponents/SelectGroupRadios';

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/styles/styles_var.scss
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/styles/styles_var.scss
@@ -8,7 +8,6 @@
 	$upgrade-to-yearly: true,
 	$fallback-banner: true,
 	$progress-bar: true,
-	$select-group-highlighted-interval: true,
 );
 @use 'src/components/BannerConductor/banner-transition';
 @use '../../../../src/components/UseOfFunds/styles/swatches/skin_vector-2022' as uof-default;
@@ -22,7 +21,7 @@
 @use 'src/themes/Mustard/ProgressBar/ProgressBar';
 @use 'src/themes/Mustard/DonationForm/DonationForm';
 @use 'src/themes/Mustard/DonationForm/MultiStepDonation';
-@use 'src/themes/Mustard/DonationForm/SubComponents/SelectGroupHighlightedInterval' with (
+@use 'src/themes/Mustard/DonationForm/SubComponents/SelectGroup' with (
 	$payment-option-width: 25%
 );
 @use 'src/themes/Mustard/DonationForm/SubComponents/SelectGroupRadios';

--- a/banners/desktop/WMDE_FR_2025_Desktop_DE_15/styles/styles_var.scss
+++ b/banners/desktop/WMDE_FR_2025_Desktop_DE_15/styles/styles_var.scss
@@ -1,0 +1,48 @@
+// This is the file where we import the theme-specific component styles
+@use 'src/themes/Mustard/swatches/skin_vector-2022' with (
+	$slider: true,
+	$select-group: true,
+	$select-group-bubble: true,
+	$select-group-button: true,
+	$select-group-image-label: true,
+	$upgrade-to-yearly: true,
+	$fallback-banner: true,
+	$progress-bar: true,
+	$select-group-highlighted-interval: true,
+);
+@use 'src/components/BannerConductor/banner-transition';
+@use '../../../../src/components/UseOfFunds/styles/swatches/skin_vector-2022' as uof-default;
+@use 'Banner';
+@use '../../../../src/components/UseOfFunds/styles/styles';
+@use 'MainBanner' with (
+	$banner-height: 357px
+);
+@use 'src/themes/Mustard/defaults';
+@use 'src/themes/Mustard/ButtonClose/ButtonClose';
+@use 'src/themes/Mustard/ProgressBar/ProgressBar';
+@use 'src/themes/Mustard/DonationForm/DonationForm';
+@use 'src/themes/Mustard/DonationForm/MultiStepDonation';
+@use 'src/themes/Mustard/DonationForm/SubComponents/SelectGroupHighlightedInterval' with (
+	$payment-option-width: 25%
+);
+@use 'src/themes/Mustard/DonationForm/SubComponents/SelectGroupRadios';
+@use 'src/themes/Mustard/DonationForm/SubComponents/SelectGroupPortraitImageLabel';
+@use 'src/themes/Mustard/DonationForm/SubComponents/SelectCustomAmountRadio';
+@use 'src/themes/Mustard/DonationForm/Forms/MainDonationForm';
+@use 'src/themes/Mustard/DonationForm/Forms/UpgradeToYearlyButtonForm' with (
+	$font-size: 14px
+);
+@use 'src/themes/Mustard/Footer/FooterAlreadyDonatedWithoutFundsLink';
+@use 'src/themes/Mustard/Footer/SelectionInput';
+@use 'src/themes/Mustard/Message/Message'  with (
+	$slider-main-headline-font-size: 25px,
+	$slider-sub-headline-font-size: 16px,
+	$message-header-padding-bottom: 8px,
+	$message-header-small-up-padding-bottom: 8px
+);
+@use 'src/themes/Mustard/Slider/KeenSlider' with (
+	$slider-padding: 0
+);
+@use 'src/themes/Mustard/UseOfFundsLink/UseOfFundsLink';
+@use 'src/components/FallbackBanner/styles/swatches/skin_vector-2022' as fbb-default;
+@use 'src/components/FallbackBanner/styles/styles' as fbb-styles;

--- a/campaign_info.toml
+++ b/campaign_info.toml
@@ -6,9 +6,9 @@
 [desktop]
 name = "Desktop"
 icon = "desktop"
-campaign = "WMDE_FR_2025_Desktop_DE_14"
-description = "Based on VAR of desktop-de-13, VAR - Submitting the banner form redirects users to the variant donation form (ap=2)."
-campaign_tracking = "14-ba-251201"
+campaign = "WMDE_FR_2025_Desktop_DE_15"
+description = "Based on VAR of desktop-de-12, VAR contains a text change"
+campaign_tracking = "15-ba-251208"
 preview_link = "/wiki/Wikipedia:Hauptseite?devbanner={{banner}}&banner=B25_WMDE_local_prototype"
 preview_link_darkmode = "/wiki/Wikipedia:Hauptseite?devbanner={{banner}}&banner=B25_WMDE_local_prototype&vectornightmode=1"
 preview_link_offline = ""
@@ -18,14 +18,14 @@ use_of_funds_source = "MediaWiki:WMDE_Fundraising/UseOfFunds_2025_DE"
 
 # Banners of the campaign, key after "banners" can be anything
 [desktop.banners.ctrl]
-filename = "./banners/desktop/WMDE_FR_2025_Desktop_DE_14/banner_ctrl.ts"
-pagename = "WMDE_FR_2025_Desktop_DE_14_ctrl"
-tracking = "org-14-251201-ctrl"
+filename = "./banners/desktop/WMDE_FR_2025_Desktop_DE_15/banner_ctrl.ts"
+pagename = "WMDE_FR_2025_Desktop_DE_15_ctrl"
+tracking = "org-15-251208-ctrl"
 
 [desktop.banners.var]
-filename = "./banners/desktop/WMDE_FR_2025_Desktop_DE_14/banner_var.ts"
-pagename = "WMDE_FR_2025_Desktop_DE_14_var"
-tracking = "org-14-251201-var"
+filename = "./banners/desktop/WMDE_FR_2025_Desktop_DE_15/banner_var.ts"
+pagename = "WMDE_FR_2025_Desktop_DE_15_var"
+tracking = "org-15-251208-var"
 
 [desktop.test_matrix]
 platform = ["edge", "firefox_windows", "chrome_windows", "firefox_linux", "chrome_linux", "chrome_macos", "firefox_macos", "safari" ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -6117,7 +6117,7 @@
     },
     "node_modules/fundraising-frontend-content": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/wmde/fundraising-frontend-content.git#e5b695e0acf1770dc120fa0742e7b3de96ba3235",
+      "resolved": "git+ssh://git@github.com/wmde/fundraising-frontend-content.git#90bea9bbea14bd820a2cb1c2a43719d7bca6a8aa",
       "license": "CC0-1.0"
     },
     "node_modules/generator-function": {

--- a/src/themes/Mustard/Message/Message.scss
+++ b/src/themes/Mustard/Message/Message.scss
@@ -4,6 +4,7 @@
 $font: fonts.$content !default;
 $font-sizes: ( breakpoints.$extra-small: 18px ) !default;
 $slider-main-headline-font-size: 18px !default;
+$slider-sub-headline-font-size: 18px !default;
 $message-header-padding-bottom: 10px !default;
 $message-header-small-up-padding-bottom: 15px !default;
 $message-header-padding-top: 0 !default;
@@ -68,7 +69,7 @@ $message-header-small-up-padding-top: 0 !default;
 		}
 
 		p {
-			font-size: 18px;
+			font-size: $slider-sub-headline-font-size;
 			margin: 0;
 			padding: 0;
 		}

--- a/src/themes/Mustard/ProgressBar/ProgressBar.scss
+++ b/src/themes/Mustard/ProgressBar/ProgressBar.scss
@@ -63,10 +63,6 @@ $progress-bar-margin: 0 !default;
 			height: 60px;
 			margin-top: 0;
 
-			@include breakpoints.large-up {
-				margin-top: -30px;
-			}
-
 			.wmde-banner-progress-bar-text {
 				position: static;
 			}

--- a/src/themes/Mustard/Slider/KeenSlider.scss
+++ b/src/themes/Mustard/Slider/KeenSlider.scss
@@ -33,7 +33,7 @@ $slider-padding: 16px 0 !default;
 
 		&-content {
 			text-align: center;
-			padding: 0 30px;
+			padding: 0 30px 4px;
 
 			p {
 				margin: 0 0 1em;

--- a/test/banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/BannerCtrl.spec.ts
+++ b/test/banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/BannerCtrl.spec.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, test, vi } from 'vitest';
+import { mount, VueWrapper } from '@vue/test-utils';
+import Banner from '@banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/BannerCtrl.vue';
+import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+import { newDynamicContent } from '@test/banners/dynamicCampaignContent';
+import { useOfFundsContent } from '@test/banners/useOfFundsContent';
+import { formItems } from '@test/banners/formItems';
+import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
+import { desktopUseOfFundsFeatures } from '@test/features/UseOfFunds';
+import {
+	bannerContentAnimatedTextFeatures,
+	bannerContentDateAndTimeFeatures,
+	bannerContentDisplaySwitchFeatures,
+	bannerContentFeatures
+} from '@test/features/BannerContent';
+import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
+import { useFormModel } from '@src/components/composables/useFormModel';
+import { resetFormModel } from '@test/resetFormModel';
+import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import { bannerAutoHideFeatures } from '@test/features/MainBanner';
+import { formActionSwitchFeatures } from '@test/features/form_action_switch/MainDonation_UpgradeToYearlyButton';
+import { alreadyDonatedLinkFeatures } from '@test/features/AlreadyDonatedLink';
+import { Tracker } from '@src/tracking/Tracker';
+import { TimerStub } from '@test/fixtures/TimerStub';
+import { Timer } from '@src/utils/Timer';
+import { fakeFormActions } from '@test/fixtures/FakeFormActions';
+import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
+import { softCloseSubmitTrackingFeaturesDesktop } from '@test/features/SoftCloseSubmitTrackingDesktop';
+
+const formModel = useFormModel();
+const translator = ( key: string ): string => key;
+let tracker: Tracker;
+
+describe( 'BannerCtrl.vue', () => {
+
+	beforeEach( () => {
+		resetFormModel( formModel );
+		tracker = {
+			trackEvent: vi.fn()
+		};
+	} );
+
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
+		return mount( Banner, {
+			attachTo: document.body,
+			props: {
+				bannerState: BannerStates.Pending,
+				useOfFundsContent,
+				localCloseTracker: {
+					getItem: () => '',
+					setItem: () => {}
+				}
+			},
+			global: {
+				mocks: {
+					$translate: translator
+				},
+				provide: {
+					translator: { translate: translator },
+					dynamicCampaignText: dynamicContent ?? newDynamicContent(),
+					currentCampaignTimePercentage: 42,
+					formActions: fakeFormActions,
+					currencyFormatter: new CurrencyEn(),
+					formItems,
+					tracker,
+					timer: timer ?? new TimerStub()
+				}
+			}
+		} );
+	};
+
+	describe( 'Main Banner', () => {
+		test.each( [
+			[ 'expectClosesBannerWhenWindowBecomesSmall' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerAutoHideFeatures[ testName ]( getWrapper );
+		} );
+	} );
+
+	describe( 'Content', () => {
+		test.each( [
+			[ 'expectSlideShowPlaysWhenBecomesVisible' ],
+			[ 'expectSlideShowStopsOnFormInteraction' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerContentFeatures[ testName ]( getWrapper() );
+		} );
+
+		test.each( [
+			[ 'expectShowsSlideShowOnSmallSizes' ],
+			[ 'expectShowsMessageOnLargeSizes' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerContentDisplaySwitchFeatures[ testName ]( getWrapper, 1300 );
+		} );
+
+		test.each( [
+			[ 'expectShowsAnimatedVisitorsVsDonorsSentenceInMessage' ],
+			[ 'expectShowsAnimatedVisitorsVsDonorsSentenceInSlideShow' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerContentAnimatedTextFeatures[ testName ]( getWrapper );
+		} );
+
+		test.each( [
+			[ 'expectShowsLiveDateAndTimeInTitle' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerContentDateAndTimeFeatures[ testName ]( getWrapper );
+		} );
+	} );
+
+	describe( 'Donation Form Happy Paths', () => {
+		test.each( [
+			[ 'expectMainDonationFormSubmitsWhenSofortIsSelected' ],
+			[ 'expectMainDonationFormSubmitsWhenYearlyIsSelected' ],
+			[ 'expectMainDonationFormGoesToUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsDontUpgrade' ]
+		] )( '%s', async ( testName: string ) => {
+			await donationFormFeatures[ testName ]( getWrapper() );
+		} );
+
+		test.each( [
+			[ 'expectMainDonationFormSubmitsWithAddressForDirectDebit' ],
+			[ 'expectMainDonationFormSubmitsWithAddressForPayPal' ],
+			[ 'expectUpgradeToYearlyFormSubmitsWithAddressForDirectDebit' ],
+			[ 'expectUpgradeToYearlyFormSubmitsWithAddressForPayPal' ]
+		] )( '%s', async ( testName: string ) => {
+			await formActionSwitchFeatures[ testName ]( getWrapper() );
+		} );
+	} );
+
+	describe( 'Soft Close', () => {
+		test.each( [
+			[ 'expectDoesNotShowSoftClose' ]
+		] )( '%s', async ( testName: string ) => {
+			await softCloseFeatures[ testName ]( getWrapper );
+		} );
+	} );
+
+	describe( 'Track user choice on the previous soft-close banner', () => {
+		test.each( [
+			[ 'expectEmitsBannerSubmitOnReturnEvent' ],
+			[ 'expectDoesNotEmitsBannerSubmitOnReturnEventWhenLocalStorageItemIsMissing' ]
+		] )( '%s', async ( testName: string ) => {
+			await softCloseSubmitTrackingFeaturesDesktop[ testName ]( getWrapper(), tracker );
+		} );
+	} );
+
+	describe( 'Already Donated', () => {
+		test.each( [
+			[ 'expectFiresMaybeLaterEventOnLinkClick' ]
+		] )( '%s', async ( testName: string ) => {
+			await alreadyDonatedLinkFeatures[ testName ]( getWrapper() );
+		} );
+	} );
+
+	describe( 'Use of Funds', () => {
+		test.each( [
+			[ 'expectShowsUseOfFunds' ],
+			[ 'expectHidesUseOfFunds' ],
+			[ 'expectEmitsModalOpenedEvent' ],
+			[ 'expectEmitsModalClosedEvent' ]
+		] )( '%s', async ( testName: string ) => {
+			await desktopUseOfFundsFeatures[ testName ]( getWrapper() );
+		} );
+	} );
+} );

--- a/test/banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/BannerVar.spec.ts
+++ b/test/banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/BannerVar.spec.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, test, vi } from 'vitest';
+import { mount, VueWrapper } from '@vue/test-utils';
+import Banner from '@banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/BannerVar.vue';
+import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+import { newDynamicContent } from '@test/banners/dynamicCampaignContent';
+import { useOfFundsContent } from '@test/banners/useOfFundsContent';
+import { formItems } from '@test/banners/formItems';
+import { CurrencyEn } from '@src/utils/DynamicContent/formatters/CurrencyEn';
+import { desktopUseOfFundsFeatures } from '@test/features/UseOfFunds';
+import {
+	bannerContentAnimatedTextFeatures,
+	bannerContentDateAndTimeFeatures,
+	bannerContentDisplaySwitchFeatures,
+	bannerContentFeatures
+} from '@test/features/BannerContent';
+import { donationFormFeatures } from '@test/features/forms/MainDonation_UpgradeToYearlyButton';
+import { useFormModel } from '@src/components/composables/useFormModel';
+import { resetFormModel } from '@test/resetFormModel';
+import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import { bannerAutoHideFeatures } from '@test/features/MainBanner';
+import { formActionSwitchFeatures } from '@test/features/form_action_switch/MainDonation_UpgradeToYearlyButton';
+import { alreadyDonatedLinkFeatures } from '@test/features/AlreadyDonatedLink';
+import { Tracker } from '@src/tracking/Tracker';
+import { TimerStub } from '@test/fixtures/TimerStub';
+import { Timer } from '@src/utils/Timer';
+import { fakeFormActions } from '@test/fixtures/FakeFormActions';
+import { softCloseFeatures } from '@test/features/SoftCloseDesktop';
+import { softCloseSubmitTrackingFeaturesDesktop } from '@test/features/SoftCloseSubmitTrackingDesktop';
+
+const formModel = useFormModel();
+const translator = ( key: string ): string => key;
+let tracker: Tracker;
+
+describe( 'BannerCtrl.vue', () => {
+
+	beforeEach( () => {
+		resetFormModel( formModel );
+		tracker = {
+			trackEvent: vi.fn()
+		};
+	} );
+
+	const getWrapper = ( dynamicContent: DynamicContent = null, timer: Timer = null ): VueWrapper<any> => {
+		return mount( Banner, {
+			attachTo: document.body,
+			props: {
+				bannerState: BannerStates.Pending,
+				useOfFundsContent,
+				localCloseTracker: {
+					getItem: () => '',
+					setItem: () => {}
+				}
+			},
+			global: {
+				mocks: {
+					$translate: translator
+				},
+				provide: {
+					translator: { translate: translator },
+					dynamicCampaignText: dynamicContent ?? newDynamicContent(),
+					currentCampaignTimePercentage: 42,
+					formActions: fakeFormActions,
+					currencyFormatter: new CurrencyEn(),
+					formItems,
+					tracker,
+					timer: timer ?? new TimerStub()
+				}
+			}
+		} );
+	};
+
+	describe( 'Main Banner', () => {
+		test.each( [
+			[ 'expectClosesBannerWhenWindowBecomesSmall' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerAutoHideFeatures[ testName ]( getWrapper );
+		} );
+	} );
+
+	describe( 'Content', () => {
+		test.each( [
+			[ 'expectSlideShowPlaysWhenBecomesVisible' ],
+			[ 'expectSlideShowStopsOnFormInteraction' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerContentFeatures[ testName ]( getWrapper() );
+		} );
+
+		test.each( [
+			[ 'expectShowsSlideShowOnSmallSizes' ],
+			[ 'expectShowsMessageOnLargeSizes' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerContentDisplaySwitchFeatures[ testName ]( getWrapper, 1300 );
+		} );
+
+		test.each( [
+			[ 'expectShowsAnimatedVisitorsVsDonorsSentenceInMessage' ],
+			[ 'expectShowsAnimatedVisitorsVsDonorsSentenceInSlideShow' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerContentAnimatedTextFeatures[ testName ]( getWrapper );
+		} );
+
+		test.each( [
+			[ 'expectShowsLiveDateAndTimeInTitle' ]
+		] )( '%s', async ( testName: string ) => {
+			await bannerContentDateAndTimeFeatures[ testName ]( getWrapper );
+		} );
+	} );
+
+	describe( 'Donation Form Happy Paths', () => {
+		test.each( [
+			[ 'expectMainDonationFormSubmitsWhenSofortIsSelected' ],
+			[ 'expectMainDonationFormSubmitsWhenYearlyIsSelected' ],
+			[ 'expectMainDonationFormGoesToUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsUpgrade' ],
+			[ 'expectUpgradeToYearlyFormSubmitsDontUpgrade' ]
+		] )( '%s', async ( testName: string ) => {
+			await donationFormFeatures[ testName ]( getWrapper() );
+		} );
+
+		test.each( [
+			[ 'expectMainDonationFormSubmitsWithAddressForDirectDebit' ],
+			[ 'expectMainDonationFormSubmitsWithAddressForPayPal' ],
+			[ 'expectUpgradeToYearlyFormSubmitsWithAddressForDirectDebit' ],
+			[ 'expectUpgradeToYearlyFormSubmitsWithAddressForPayPal' ]
+		] )( '%s', async ( testName: string ) => {
+			await formActionSwitchFeatures[ testName ]( getWrapper() );
+		} );
+	} );
+
+	describe( 'Soft Close', () => {
+		test.each( [
+			[ 'expectDoesNotShowSoftClose' ]
+		] )( '%s', async ( testName: string ) => {
+			await softCloseFeatures[ testName ]( getWrapper );
+		} );
+	} );
+
+	describe( 'Track user choice on the previous soft-close banner', () => {
+		test.each( [
+			[ 'expectEmitsBannerSubmitOnReturnEvent' ],
+			[ 'expectDoesNotEmitsBannerSubmitOnReturnEventWhenLocalStorageItemIsMissing' ]
+		] )( '%s', async ( testName: string ) => {
+			await softCloseSubmitTrackingFeaturesDesktop[ testName ]( getWrapper(), tracker );
+		} );
+	} );
+
+	describe( 'Already Donated', () => {
+		test.each( [
+			[ 'expectFiresMaybeLaterEventOnLinkClick' ]
+		] )( '%s', async ( testName: string ) => {
+			await alreadyDonatedLinkFeatures[ testName ]( getWrapper() );
+		} );
+	} );
+
+	describe( 'Use of Funds', () => {
+		test.each( [
+			[ 'expectShowsUseOfFunds' ],
+			[ 'expectHidesUseOfFunds' ],
+			[ 'expectEmitsModalOpenedEvent' ],
+			[ 'expectEmitsModalClosedEvent' ]
+		] )( '%s', async ( testName: string ) => {
+			await desktopUseOfFundsFeatures[ testName ]( getWrapper() );
+		} );
+	} );
+} );

--- a/test/banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/FallbackBanner.spec.ts
+++ b/test/banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/FallbackBanner.spec.ts
@@ -1,0 +1,59 @@
+import { describe, test } from 'vitest';
+import { mount, VueWrapper } from '@vue/test-utils';
+import FallbackBanner from '@banners/desktop/WMDE_FR_2025_Desktop_DE_15/components/FallbackBanner.vue';
+import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+import { useOfFundsContent } from '@test/banners/useOfFundsContent';
+import { newDynamicContent } from '@test/banners/dynamicCampaignContent';
+import { DynamicContent } from '@src/utils/DynamicContent/DynamicContent';
+import { Tracker } from '@src/tracking/Tracker';
+import { TrackerStub } from '@test/fixtures/TrackerStub';
+import { fallbackBannerFeatures, submitFeatures } from '@test/features/FallbackBanner';
+import { Timer } from '@src/utils/Timer';
+import { TimerStub } from '@test/fixtures/TimerStub';
+
+const translator = ( key: string ): string => key;
+
+describe( 'FallbackBanner.vue', () => {
+	const getWrapperAtWidth = ( width: number, dynamicContent: DynamicContent = null, tracker: Tracker = null, timer: Timer = null ): VueWrapper<any> => {
+		Object.defineProperty( window, 'innerWidth', { writable: true, configurable: true, value: width } );
+		return mount( FallbackBanner, {
+			props: {
+				bannerState: BannerStates.Pending,
+				useOfFundsContent,
+				donationLink: 'https://spenden.wikimedia.de'
+			},
+			global: {
+				mocks: {
+					$translate: translator
+				},
+				provide: {
+					translator: { translate: translator },
+					dynamicCampaignText: dynamicContent ?? newDynamicContent(),
+					currentCampaignTimePercentage: 42,
+					tracker: tracker ?? new TrackerStub(),
+					timer: timer ?? new TimerStub()
+				}
+			}
+		} );
+	};
+
+	test.each( [
+		[ 'showsTheSmallBanner' ],
+		[ 'showsTheLargeBanner' ],
+		[ 'emitsTheBannerCloseEvent' ],
+		[ 'playsTheSlideshowWhenBecomesVisible' ],
+		[ 'showsUseOfFundsFromSmallBanner' ],
+		[ 'hidesUseOfFundsFromSmallBanner' ],
+		[ 'showsUseOfFundsFromLargeBanner' ],
+		[ 'hidesUseOfFundsFromLargeBanner' ]
+	] )( '%s', async ( testName: string ) => {
+		await fallbackBannerFeatures[ testName ]( getWrapperAtWidth );
+	} );
+
+	test.each( [
+		[ 'submitsFromLargeBanner' ],
+		[ 'submitsFromSmallBanner' ]
+	] )( '%s', async ( testName: string ) => {
+		await submitFeatures[ testName ]( getWrapperAtWidth );
+	} );
+} );


### PR DESCRIPTION
Both banners

    The banners are based on the [control banner of desktop-de-12](https://de.wikipedia.org/?banner=WMDE_FR_2025_Desktop_DE_12_ctrl&devMode).

Variant banner

    The subheadline is changed to "An alle in Deutschland, die Wikipedia nutzen, aber noch nicht gespendet haben".

Notes

    The font size of the headline and subheadline may be reduced.

https://phabricator.wikimedia.org/T412002