### PR TITLE
Cap upper donation sum amount to display on the progress bar

### DIFF
--- a/src/utils/DynamicContent/generators/ProgressBarContent.ts
+++ b/src/utils/DynamicContent/generators/ProgressBarContent.ts
@@ -48,6 +48,10 @@ export class ProgressBarContent implements DynamicProgressBarContent {
 	}
 
 	public get amountDonated(): string {
+		const upperDisplayLimitDeltaInEuro = 100_000;
+		if ( this._remainingDonationSum < upperDisplayLimitDeltaInEuro ) {
+			return this._currencyFormatter.millions( this._donationSum - upperDisplayLimitDeltaInEuro );
+		}
 		return this._currencyFormatter.millions( this._donationSum );
 	}
 

--- a/test/unit/utils/DynamicContent/generators/ProgressBarContent.spec.ts
+++ b/test/unit/utils/DynamicContent/generators/ProgressBarContent.spec.ts
@@ -31,6 +31,20 @@ describe( 'ProgressBarContent', function () {
 		expect( progressBarContent.amountDonated ).toBe( '€3.0M' );
 	} );
 
+	it( 'should return formatted amount donated below upper display amount cap', function () {
+		const farProgressedProgressBarContent = new ProgressBarContent(
+			9_000_000,
+			100,
+			9_000_000,
+			0,
+			new Translator( {} ),
+			new CurrencyEn(),
+			true,
+			'alarm!'
+		);
+		expect( farProgressedProgressBarContent.amountDonated ).toBe( '€8.9M' );
+	} );
+
 	it( 'should return amount needed sentence', function () {
 		expect( progressBarContent.amountNeeded ).toBe( 'amount-missing' );
 	} );


### PR DESCRIPTION
Background:
- the progress bar should never display 100% (0€ remaining) on live banners
- the fundraising team is usually monitoring the real time data and would put the banners offline when reaching 100%

- This code prevents showing the donation target as the donations sum and instead displays a slightly smaller value