### PR TITLE
Fix page jump on mobile banner close

### DIFF
--- a/banners/mobile/WMDE_FR_2026_Mobile_DE_01/components/BannerCtrl.vue
+++ b/banners/mobile/WMDE_FR_2026_Mobile_DE_01/components/BannerCtrl.vue
@@ -1,11 +1,11 @@
 <template>
 	<div class="wmde-banner-wrapper" :class="contentState">
 		<MiniBanner
-			@close="() => onClose( 'MiniBanner', CloseChoices.Close )"
+			@close="() => onMiniClose( 'MiniBanner', CloseChoices.Close )"
 			@show-full-page-banner="onshowFullPageBanner"
 			@show-full-page-banner-preselected="onshowFullPageBannerPreselected"
 			@showFundsModal="onShowFundsModal( 'MiniBanner' )"
-			@already-donated-clicked="onClose( 'MiniBanner', CloseChoices.AlreadyDonated )"
+			@already-donated-clicked="onMiniClose( 'MiniBanner', CloseChoices.AlreadyDonated )"
 		>
 			<template #banner-slides>
 				<KeenSlider :with-navigation="false" :play="slideshowShouldPlay" :interval="7000">
@@ -21,7 +21,7 @@
 
 		<FullPageBanner
 			@showFundsModal="onShowFundsModal( 'FullPageBanner' )"
-			@close="() => onClose( 'FullPageBanner', CloseChoices.Hide )"
+			@close="() => onFullPageClose( 'FullPageBanner', CloseChoices.Hide )"
 		>
 			<template #banner-text>
 				<BannerText :play-live-text="contentState === ContentStates.FullPage"/>
@@ -164,7 +164,11 @@ watch( contentState, async () => {
 	emit( 'bannerContentChanged' );
 } );
 
-function onClose( feature: TrackingFeatureName, userChoice: CloseChoices ): void {
+function onMiniClose( feature: TrackingFeatureName, userChoice: CloseChoices ): void {
+	emit( 'bannerClosed', new CloseEvent( feature, userChoice ) );
+}
+
+function onFullPageClose( feature: TrackingFeatureName, userChoice: CloseChoices ): void {
 	emit( 'bannerClosed', new CloseEvent( feature, userChoice ) );
 	emit( 'modalClosed' );
 }

--- a/banners/mobile/WMDE_FR_2026_Mobile_DE_01/components/BannerVar.vue
+++ b/banners/mobile/WMDE_FR_2026_Mobile_DE_01/components/BannerVar.vue
@@ -1,18 +1,17 @@
 <template>
 	<div class="wmde-banner-wrapper" :class="contentState">
 		<MiniBanner
-			@close="() => onClose( 'MiniBanner', CloseChoices.Close )"
+			@close="() => onMiniClose( 'MiniBanner', CloseChoices.Close )"
 			@show-full-page-banner="onshowFullPageBanner"
 			@show-full-page-banner-preselected="onshowFullPageBannerPreselected"
 			@showFundsModal="onShowFundsModal( 'MiniBanner' )"
-			@already-donated-clicked="onClose( 'MiniBanner', CloseChoices.AlreadyDonated )"
+			@already-donated-clicked="onMiniClose( 'MiniBanner', CloseChoices.AlreadyDonated )"
 		>
 			<template #banner-slides>
 				<KeenSlider :with-navigation="false" :play="slideshowShouldPlay" :interval="7000">
 
 					<template #slides="{ currentSlide }: any">
 						<BannerSlides :currentSlide="currentSlide" :play-live-text="contentState === ContentStates.Mini">
-							<template #progress><ProgressBar amount-to-show-on-right="MISSING"/></template>
 						</BannerSlides>
 					</template>
 
@@ -22,14 +21,10 @@
 
 		<FullPageBanner
 			@showFundsModal="onShowFundsModal( 'FullPageBanner' )"
-			@close="() => onClose( 'FullPageBanner', CloseChoices.Hide )"
+			@close="() => onFullPageClose( 'FullPageBanner', CloseChoices.Hide )"
 		>
 			<template #banner-text>
 				<BannerText :play-live-text="contentState === ContentStates.FullPage"/>
-			</template>
-
-			<template #progress>
-				<ProgressBar amount-to-show-on-right="MISSING"/>
 			</template>
 
 			<template #donation-form="{ formInteraction }: any">
@@ -124,7 +119,6 @@ import FormItemsBuilder from '@src/utils/FormItemsBuilder/FormItemsBuilder';
 import type { Translator } from '@src/Translator';
 import type { Currency } from '@src/utils/DynamicContent/formatters/Currency';
 import { UseOfFundsShownEvent } from '@src/tracking/events/UseOfFundsShownEvent';
-import ProgressBar from '@src/components/ProgressBar/ProgressBar.vue';
 
 enum ContentStates {
 	Mini = 'wmde-banner-wrapper--mini',
@@ -170,7 +164,11 @@ watch( contentState, async () => {
 	emit( 'bannerContentChanged' );
 } );
 
-function onClose( feature: TrackingFeatureName, userChoice: CloseChoices ): void {
+function onMiniClose( feature: TrackingFeatureName, userChoice: CloseChoices ): void {
+	emit( 'bannerClosed', new CloseEvent( feature, userChoice ) );
+}
+
+function onFullPageClose( feature: TrackingFeatureName, userChoice: CloseChoices ): void {
 	emit( 'bannerClosed', new CloseEvent( feature, userChoice ) );
 	emit( 'modalClosed' );
 }


### PR DESCRIPTION
We were firing the modal close event when the
mini banner was closed, and this caused the
page to jump to the top. This adds separate
close handlers for the mini and full page
banners.

Ticket: https://phabricator.wikimedia.org/T431694