### PR TITLE
Add option to submit to new tab

### DIFF
--- a/src/components/BannerConductor/BannerConductor.vue
+++ b/src/components/BannerConductor/BannerConductor.vue
@@ -13,6 +13,7 @@
 			:bannerState="bannerState.stateName"
 			:bannerHeight="bannerRef?.offsetHeight"
 			@banner-closed="closeHandler"
+			@banner-submitted="submitedHandler"
 			@banner-content-changed="onContentChanged"
 			@modal-opened="page.setModalOpened"
 			@modal-closed="page.setModalClosed"
@@ -85,6 +86,10 @@ async function closeHandler( closeEvent: TrackingEvent<void> ): Promise<any> {
 	await stateMachine.changeState( stateFactory.newClosedState( closeEvent ) );
 }
 
+async function submitedHandler(): Promise<any> {
+	await stateMachine.changeState( stateFactory.newSubmittedState() );
+}
+
 </script>
 
 <style lang="scss">
@@ -96,7 +101,8 @@ async function closeHandler( closeEvent: TrackingEvent<void> ): Promise<any> {
 	z-index: 1000;
 }
 .wmde-banner--not-shown,
-.wmde-banner--closed {
+.wmde-banner--closed,
+.wmde-banner--submitted {
 	display: none;
 }
 </style>

--- a/src/components/BannerConductor/FallbackBannerConductor.vue
+++ b/src/components/BannerConductor/FallbackBannerConductor.vue
@@ -9,6 +9,7 @@
 			:bannerState="bannerState.stateName"
 			:bannerHeight="bannerRef?.offsetHeight"
 			@banner-closed="closeHandler"
+			@banner-submitted="submitHandler"
 			@banner-content-changed="onContentChanged"
 			@modal-opened="page.setModalOpened"
 			@modal-closed="page.setModalClosed"
@@ -94,6 +95,10 @@ async function closeHandler( closeEvent: TrackingEvent<void> ): Promise<any> {
 	await stateMachine.changeState( stateFactory.newClosedState( closeEvent ) );
 }
 
+async function submitHandler(): Promise<any> {
+	await stateMachine.changeState( stateFactory.newSubmittedState() );
+}
+
 </script>
 
 <style lang="scss">
@@ -105,7 +110,8 @@ async function closeHandler( closeEvent: TrackingEvent<void> ): Promise<any> {
 	z-index: 1000;
 }
 .wmde-banner--not-shown,
-.wmde-banner--closed {
+.wmde-banner--closed,
+.wmde-banner--submitted {
 	display: none;
 }
 </style>

--- a/src/components/BannerConductor/StateMachine/BannerStates.ts
+++ b/src/components/BannerConductor/StateMachine/BannerStates.ts
@@ -4,5 +4,6 @@ export enum BannerStates {
 	NotShown = 'wmde-banner--not-shown',
 	Showing = 'wmde-banner--showing',
 	Visible = 'wmde-banner--visible',
-	Closed = 'wmde-banner--closed'
+	Closed = 'wmde-banner--closed',
+	Submitted = 'wmde-banner--submitted'
 }

--- a/src/components/BannerConductor/StateMachine/states/StateFactory.ts
+++ b/src/components/BannerConductor/StateMachine/states/StateFactory.ts
@@ -14,6 +14,7 @@ import { InitialState } from '@src/components/BannerConductor/StateMachine/state
 import type { TrackingEvent, TrackingFeatureName } from '@src/tracking/TrackingEvent';
 import type { Timer } from '@src/utils/Timer';
 import type { BannerCategory } from '@src/components/BannerConductor/BannerCategory';
+import { SubmittedState } from '@src/components/BannerConductor/StateMachine/states/SubmittedState';
 
 export class StateFactory {
 	private readonly _bannerConfig: BannerConfig;
@@ -62,6 +63,10 @@ export class StateFactory {
 
 	public newClosedState( closeEvent: TrackingEvent<void> ): BannerState {
 		return new ClosedState( closeEvent, this._bannerCategory, this._page, this._tracker, this._resizeHandler, this._timer );
+	}
+
+	public newSubmittedState(): BannerState {
+		return new SubmittedState( this._page, this._resizeHandler, this._timer );
 	}
 }
 

--- a/src/components/BannerConductor/StateMachine/states/SubmittedState.ts
+++ b/src/components/BannerConductor/StateMachine/states/SubmittedState.ts
@@ -1,0 +1,43 @@
+import { BannerState } from '@src/components/BannerConductor/StateMachine/states/BannerState';
+import { BannerStates } from '@src/components/BannerConductor/StateMachine/BannerStates';
+import type { Page } from '@src/page/Page';
+import type { ResizeHandler } from '@src/utils/ResizeHandler';
+import type { Timer } from '@src/utils/Timer';
+
+export class SubmittedState extends BannerState {
+	public readonly stateName: BannerStates = BannerStates.Submitted;
+	private _page: Page;
+	private _resizeHandler: ResizeHandler;
+	private _timer: Timer;
+
+	public constructor(
+		page: Page,
+		resizeHandler: ResizeHandler,
+		timer: Timer
+	) {
+		super();
+		this._page = page;
+		this._resizeHandler = resizeHandler;
+		this._timer = timer;
+	}
+
+	public enter(): Promise<any> {
+		this._page
+			.unsetAnimated()
+			.setSpace( 0 )
+			.removePageEventListeners();
+		this._resizeHandler.onClose();
+		this._timer.clearAll();
+		return Promise.resolve();
+	}
+
+	public exit(): Promise<any> {
+		throw new Error( 'This state will never be exited' );
+	}
+
+	public onContentChanged(): void {
+		// Content changed will fire on the submit button press so it
+		// needs to be caught here else it will throw an exception
+	}
+
+}

--- a/src/components/BannerConductor/StateMachine/states/VisibleState.ts
+++ b/src/components/BannerConductor/StateMachine/states/VisibleState.ts
@@ -21,6 +21,7 @@ export class VisibleState extends BannerState {
 		this._tracker = tracker;
 
 		this.canMoveToStates.push( BannerStates.Closed );
+		this.canMoveToStates.push( BannerStates.Submitted );
 	}
 
 	public enter(): Promise<any> {

--- a/src/components/DonationForm/MultiStepDonation.vue
+++ b/src/components/DonationForm/MultiStepDonation.vue
@@ -14,7 +14,7 @@
 			/>
 		</div>
 	</div>
-	<form ref="submitFormRef" :action="formAction" class="wmde-banner-submit-form" method="post">
+	<form ref="submitFormRef" :action="formAction" class="wmde-banner-submit-form" method="post" :target="submitOpensInNewTab ? '_blank' : null">
 		<SubmitValues />
 	</form>
 </template>
@@ -39,14 +39,16 @@ interface Props {
 	formActionOverride?: string;
 	// This is to allow the banner to trigger side effects when the form is submitted
 	submitCallback?: () => void;
+	submitOpensInNewTab?: boolean;
 }
 
 const props = withDefaults( defineProps<Props>(), {
 	showErrorScrollLink: false,
 	formActionOverride: '',
-	submitCallback: () => {} // eslint-disable-line @typescript-eslint/no-empty-function
+	submitCallback: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
+	submitOpensInNewTab: false
 } );
-const emit = defineEmits( [ 'formInteraction' ] );
+const emit = defineEmits( [ 'formInteraction', 'hide' ] );
 
 const slots: object = useSlots();
 const usedSlotNames: string[] = Object.keys( slots );
@@ -91,6 +93,7 @@ const multistepCallbacks = {
 		props.submitCallback();
 		await nextTick();
 		submitFormRef.value.submit();
+		emit( 'hide' );
 	}
 };
 

--- a/test/components/BannerConductor/BannerConductor.spec.ts
+++ b/test/components/BannerConductor/BannerConductor.spec.ts
@@ -37,6 +37,7 @@ describe( 'BannerConductor.vue', () => {
 			},
 			emits: [
 				'bannerClosed',
+				'bannerSubmitted',
 				'bannerContentChanged',
 				'modalOpened',
 				'modalClosed'
@@ -44,11 +45,15 @@ describe( 'BannerConductor.vue', () => {
 			methods: {
 				onClose() {
 					this.$emit( 'bannerClosed', new CloseEvent( 'MainBanner', 'closed' ) );
+				},
+				onSubmit() {
+					this.$emit( 'bannerSubmitted' );
 				}
 			},
 			template: `<div class="test-banner" style="height: 100px">
 				Hello, world!
 				<button class="emit-banner-closed" @click="onClose"></button>
+				<button class="emit-banner-submitted" @click="onSubmit"></button>
 				<button class="emit-banner-content-changed" @click="$emit( 'bannerContentChanged' )"></button>
 				<button class="emit-banner-modal-open" @click="$emit( 'modalOpened' )"></button>
 				<button class="emit-banner-modal-closed" @click="$emit( 'modalClosed' )"></button>
@@ -214,6 +219,20 @@ describe( 'BannerConductor.vue', () => {
 		] );
 
 		expect( wrapper.classes() ).toContain( BannerStates.Closed );
+	} );
+
+	it( 'moves to submitted state when donor submits banner', async () => {
+		const wrapper = await getShownBannerWrapper();
+		await wrapper.find( '.emit-banner-submitted' ).trigger( 'click' );
+
+		expect( stateMachineSpy.statesCalled ).toEqual( [
+			BannerStates.Pending,
+			BannerStates.Showing,
+			BannerStates.Visible,
+			BannerStates.Submitted
+		] );
+
+		expect( wrapper.classes() ).toContain( BannerStates.Submitted );
 	} );
 
 	it( 'tells the page that a modal was opened', async () => {

--- a/test/components/BannerConductor/FallbackBannerConductor.spec.ts
+++ b/test/components/BannerConductor/FallbackBannerConductor.spec.ts
@@ -37,6 +37,7 @@ describe( 'FallbackBannerConductor.vue', () => {
 			},
 			emits: [
 				'bannerClosed',
+				'bannerSubmitted',
 				'bannerContentChanged',
 				'modalOpened',
 				'modalClosed'
@@ -44,11 +45,15 @@ describe( 'FallbackBannerConductor.vue', () => {
 			methods: {
 				onClose(): void {
 					this.$emit( 'bannerClosed', new CloseEvent( 'MainBanner', 'closed' ) );
+				},
+				onSubmit() {
+					this.$emit( 'bannerSubmitted' );
 				}
 			},
 			template: `<div class="${containerClass}" style="height: 100px;">
 				Hello, world!
 				<button class="emit-banner-closed" @click="onClose"></button>
+				<button class="emit-banner-submitted" @click="onSubmit"></button>
 				<button class="emit-banner-content-changed" @click="$emit( 'bannerContentChanged' )"></button>
 				<button class="emit-banner-modal-open" @click="$emit( 'modalOpened' )"></button>
 				<button class="emit-banner-modal-closed" @click="$emit( 'modalClosed' )"></button>
@@ -282,6 +287,20 @@ describe( 'FallbackBannerConductor.vue', () => {
 		] );
 
 		expect( wrapper.classes() ).toContain( BannerStates.Closed );
+	} );
+
+	it( 'moves to submitted state when donor submits banner', async () => {
+		const wrapper = await getShownBannerWrapper();
+		await wrapper.find( '.emit-banner-submitted' ).trigger( 'click' );
+
+		expect( stateMachineSpy.statesCalled ).toEqual( [
+			BannerStates.Pending,
+			BannerStates.Showing,
+			BannerStates.Visible,
+			BannerStates.Submitted
+		] );
+
+		expect( wrapper.classes() ).toContain( BannerStates.Submitted );
 	} );
 
 	it( 'tells the page that a modal was opened', async () => {

--- a/test/components/BannerConductor/StateMachine/states/SubmittedState.spec.ts
+++ b/test/components/BannerConductor/StateMachine/states/SubmittedState.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vitest } from 'vitest';
+import { PageStub } from '@test/fixtures/PageStub';
+import { ResizeHandlerStub } from '@test/fixtures/ResizeHandlerStub';
+import { TimerStub } from '@test/fixtures/TimerStub';
+import { TimerSpy } from '@test/fixtures/TimerSpy';
+import { SubmittedState } from '@src/components/BannerConductor/StateMachine/states/SubmittedState';
+
+describe( 'SubmittedState', function () {
+	it( 'frees the space on the page without animation', function () {
+		const page = new PageStub();
+		page.setSpace = vitest.fn( () => page );
+		page.unsetAnimated = vitest.fn( () => page );
+		const state = new SubmittedState(
+			page,
+			new ResizeHandlerStub(),
+			new TimerStub()
+		);
+
+		state.enter();
+
+		expect( page.setSpace ).toHaveBeenCalledWith( 0 );
+		expect( page.unsetAnimated ).toHaveBeenCalledOnce();
+	} );
+
+	it( 'removes the event listeners', function () {
+		const page = new PageStub();
+		const resizeHandler = new ResizeHandlerStub();
+		page.removePageEventListeners = vitest.fn( () => page );
+		resizeHandler.onClose = vitest.fn();
+		const state = new SubmittedState(
+			page,
+			resizeHandler,
+			new TimerStub()
+		);
+
+		state.enter();
+
+		expect( page.removePageEventListeners ).toHaveBeenCalledOnce();
+		expect( resizeHandler.onClose ).toHaveBeenCalledOnce();
+	} );
+
+	it( 'stops the timers', function () {
+		const timer = new TimerSpy();
+		const state = new SubmittedState(
+			new PageStub(),
+			new ResizeHandlerStub(),
+			timer
+		);
+
+		state.enter();
+
+		expect( timer.clearAllCalls ).toStrictEqual( 1 );
+	} );
+
+	it( 'throws error on exit', function () {
+		const state = new SubmittedState(
+			new PageStub(),
+			new ResizeHandlerStub(),
+			new TimerStub()
+		);
+
+		expect( () => state.exit() ).toThrowError( 'This state will never be exited' );
+	} );
+} );

--- a/test/components/DonationForm/MultiStepDonation.spec.ts
+++ b/test/components/DonationForm/MultiStepDonation.spec.ts
@@ -189,4 +189,30 @@ describe( 'MultistepDonation.vue', () => {
 		expect( wrapper.find( '.wmde-banner-submit-form' ).attributes( 'action' ) )
 			.toBe( 'https://example.com/withBellsAndWhistles' );
 	} );
+
+	it( 'sets submit form to open in new tab when required', async () => {
+		const stepController = new StepControllerSpy();
+		const wrapper = getWrapper( { form: subFormEmitterTemplate }, [ stepController ] );
+		const submitForm = wrapper.find<HTMLFormElement>( '.wmde-banner-submit-form' );
+
+		expect( submitForm.attributes( 'target' ) ).toBeUndefined();
+
+		await wrapper.setProps( { submitOpensInNewTab: true } );
+
+		expect( submitForm.attributes( 'target' ) ).toStrictEqual( '_blank' );
+	} );
+
+	it( 'emits submit event on submit when set to open in new tab', async () => {
+		const stepController = new StepControllerSpy();
+		const wrapper = getWrapper( { form: subFormEmitterTemplate }, [ stepController ] );
+		await wrapper.setProps( { submitOpensInNewTab: true } );
+		const submitForm = wrapper.find<HTMLFormElement>( '.wmde-banner-submit-form' );
+		submitForm.element.submit = vi.fn();
+
+		// We submit a sub form once to cache the navigation callbacks in the StepControllerSpy
+		await wrapper.find( '.emitting-sub-form' ).trigger( 'submit' );
+		await stepController.callSubmit( { customData: undefined, eventName: 'mushroom', feature: 'MainDonationForm', userChoice: 'badchoice' } );
+
+		expect( wrapper.emitted( 'hide' ).length ).toStrictEqual( 1 );
+	} );
 } );


### PR DESCRIPTION
We want to allow banners to open the donation form
in a new tab when submitted. This adds the following
to allow that:

- Add submit opens in new tab option to the donation form
- Add new submitted state to banner conductors that will
  make sure the banner is hidden when the donor returns
  to the tab

Ticket: https://phabricator.wikimedia.org/T432196